### PR TITLE
SMBClient and going back to the original user's HASH...

### DIFF
--- a/impacket/dcerpc/v5/samr.py
+++ b/impacket/dcerpc/v5/samr.py
@@ -2725,15 +2725,38 @@ def hSamrGetAliasMembership(dce, domainHandle, sidArray):
     request['SidArray']['Count'] = len(sidArray['Sids'])
     return dce.request(request)
 
-def hSamrChangePasswordUser(dce, userHandle, oldPassword, newPassword):
+def hSamrChangePasswordUser(dce, userHandle, oldPassword, newPassword, oldPwdHashNT='', newPwdHashLM='', newPwdHashNT=''):
     request = SamrChangePasswordUser()
     request['UserHandle'] = userHandle
 
     from impacket import crypto, ntlm
 
-    oldPwdHashNT = ntlm.NTOWFv1(oldPassword)
-    newPwdHashNT = ntlm.NTOWFv1(newPassword)
-    newPwdHashLM = ntlm.LMOWFv1(newPassword)
+    if oldPwdHashNT == '':
+        oldPwdHashNT = ntlm.NTOWFv1(oldPassword)
+    else:
+        # Let's convert the hashes to binary form, if not yet
+        try:
+            oldPwdHashNT = unhexlify(oldPwdHashNT)
+        except:
+            pass
+
+    if newPwdHashLM == '':
+        newPwdHashLM = ntlm.LMOWFv1(newPassword)
+    else:
+        # Let's convert the hashes to binary form, if not yet
+        try:
+            newPwdHashLM = unhexlify(newPwdHashLM)
+        except:
+            pass
+
+    if newPwdHashNT == '':
+        newPwdHashNT = ntlm.NTOWFv1(newPassword)
+    else:
+        # Let's convert the hashes to binary form, if not yet
+        try:
+            newPwdHashNT = unhexlify(newPwdHashNT)
+        except:
+            pass
 
     request['LmPresent'] = 0
     request['OldLmEncryptedWithNewLm'] = NULL


### PR DESCRIPTION
Hey @asolino,

This is just a minor feature suggestion that might be useful during a pentest.
Suppose we managed to get the hashes for a domain user “lab.bransh.com\user1”: 

lab.bransh.com\user1:1108:AAD3B435B51404EEAAD3B435B51404EE:21474DA8CBE3D3A1753727D6483756AB:::

Its password is VERY complex, we cannot crack it in a reasonable amount of time, and we need to know the plain text value to use certain Active Directory attached services (e.g. a WebApp using AD, RDP or whastever).

In order to accomplish this, an option may be to change the user’s password for a value that we control, do whatever we need to do with this account and then take it back to its original state. The first part of this is already implemented in smbclient.py, as we can change the currently known hash to a password value that we want, thanks to "SamrUnicodeChangePasswordUser2". However, the second one was not yet offered...

_Note 1: of course it has to be carefully planned to consider a time-frame during which the victim is not going to use it. Also, the Domain password policies should be considered (i.e. Minimum Password Age and Password History)._

_Note 2: when setting the original hash for the target account, the Domain Controller will flag the account with the attribute “User must change password at next logon” (looks like this is how the method “SamrChangePasswordUser” works). However, it will be less noisy than getting an incorrect password message for the legitimate user._

Let’s use the obtained hash to change the account password:

![image](https://user-images.githubusercontent.com/24248983/35492194-2cbc832a-048a-11e8-9d24-4b9e2a2ac137.png)

After that, do whatever you need to do with the plaintext password:

![image](https://user-images.githubusercontent.com/24248983/35492201-315506e6-048a-11e8-984a-efb8eeba5bfe.png)

Then change the password again to the original hashes:

![image](https://user-images.githubusercontent.com/24248983/35492203-34a828a0-048a-11e8-9931-59514ab391d6.png)

Once the legitimate user authenticates again, s/he will receive a message like:

![image](https://user-images.githubusercontent.com/24248983/35492205-37c7ebce-048a-11e8-9e6f-a4a2319c5ab1.png)

But most likely from a GUI ;)

This is far from being as stealthy as we would like it to be, but during a pentest it could be useful and much less noisy than leaving the account with a different password.

Cheers!

P.S.: I had to slightly modify the impacket/dcerpc/v5/samr.py source code. Even though I tried to be careful with default values for new parameters to avoid breaking existent code, please take a special look at it.  