### PR TITLE
Only display enabled users

### DIFF
--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -85,6 +85,7 @@ class DumpSecrets:
         self.__justUser = options.just_dc_user
         self.__pwdLastSet = options.pwd_last_set
         self.__printUserStatus= options.user_status
+        self.__printEnabledUsers = options.only_enabled
         self.__resumeFileName = options.resumefile
         self.__canProcessSAMLSA = True
         self.__kdcHost = options.dc_ip
@@ -193,7 +194,7 @@ class DumpSecrets:
                                            useVSSMethod=self.__useVSSMethod, justNTLM=self.__justDCNTLM,
                                            pwdLastSet=self.__pwdLastSet, resumeSession=self.__resumeFileName,
                                            outputFileName=self.__outputFileName, justUser=self.__justUser,
-                                           printUserStatus= self.__printUserStatus)
+                                           printUserStatus= self.__printUserStatus, printEnabledUsers= self.__printEnabledUsers)
             try:
                 self.__NTDSHashes.dump()
             except Exception, e:
@@ -295,6 +296,8 @@ if __name__ == '__main__':
                        help='Shows pwdLastSet attribute for each NTDS.DIT account. Doesn\'t apply to -outputfile data')
     group.add_argument('-user-status', action='store_true', default=False,
                         help='Display whether or not the user is disabled')
+    group.add_argument('-only-enabled', action='store_true', default=False,
+                        help='Display enabled users only')
     group.add_argument('-history', action='store_true', help='Dump password history, and LSA secrets OldVal')
     group = parser.add_argument_group('authentication')
 

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -1696,7 +1696,7 @@ class NTDSHashes:
 
     def __init__(self, ntdsFile, bootKey, isRemote=False, history=False, noLMHash=True, remoteOps=None,
                  useVSSMethod=False, justNTLM=False, pwdLastSet=False, resumeSession=None, outputFileName=None,
-                 justUser=None, printUserStatus=False,
+                 justUser=None, printUserStatus=False, printEnabledUsers=True,
                  perSecretCallback = lambda secretType, secret : _print_helper(secret),
                  resumeSessionMgr=ResumeSessionMgrInFile):
         self.__bootKey = bootKey
@@ -1707,6 +1707,7 @@ class NTDSHashes:
         self.__remoteOps = remoteOps
         self.__pwdLastSet = pwdLastSet
         self.__printUserStatus = printUserStatus
+        self.__printEnabledUsers = printEnabledUsers
         if self.__NTDS is not None:
             self.__ESEDB = ESENT_DB(ntdsFile, isRemote = isRemote)
             self.__cursor = self.__ESEDB.openTable('datatable')
@@ -1926,6 +1927,13 @@ class NTDSHashes:
 
     def __decryptHash(self, record, prefixTable=None, outputFile=None):
         LOG.debug('Entering NTDSHashes.__decryptHash')
+
+        # Skip disabled users when requested
+        if self.__printEnabledUsers is True:
+            if record[self.NAME_TO_INTERNAL['userAccountControl']] is not None:
+                if '{0:08b}'.format(record[self.NAME_TO_INTERNAL['userAccountControl']])[-2:-1] != '0':
+                    return
+
         if self.__useVSSMethod is True:
             LOG.debug('Decrypting hash for user: %s' % record[self.NAME_TO_INTERNAL['name']])
 


### PR DESCRIPTION
Hi!

There was already an option for displaying user status in the output, but sometimes I need to only export the currently enabled users. This PR adds a switch "-only-enabled" to do just that!