### PR TITLE
dpapi.py bugfix

### DIFF
--- a/impacket/dpapi.py
+++ b/impacket/dpapi.py
@@ -1032,7 +1032,10 @@ def privatekeyblob_to_pkcs1(key):
     if PY3:
         pubExp = int(key['rsapubkey']['pubexp']) # e
     else:
-        pubExp = long(key['rsapubkey']['pubexp']) # e
+        try:
+            pubExp = long(key['rsapubkey']['pubexp']) # e
+        except:
+            pubExp=0
     # RSA.Integer(prime2).inverse(prime1) # u
 
     r = RSA.construct((modulus, pubExp, privateExp, prime1, prime2))

--- a/impacket/dpapi.py
+++ b/impacket/dpapi.py
@@ -1030,8 +1030,9 @@ def privatekeyblob_to_pkcs1(key):
     coefficient = bytes_to_long(key['coefficient'][::-1])
     privateExp = bytes_to_long(key['privateExponent'][::-1]) # d
     if PY3:
-        long = int
-    pubExp = long(key['rsapubkey']['pubexp']) # e
+        pubExp = int(key['rsapubkey']['pubexp']) # e
+    else:
+        pubExp = long(key['rsapubkey']['pubexp']) # e
     # RSA.Integer(prime2).inverse(prime1) # u
 
     r = RSA.construct((modulus, pubExp, privateExp, prime1, prime2))


### PR DESCRIPTION
Before the fix, in python 2 (I know I know, it's almost deprecated) we get the following error when trying to decrypt a masterkey using the domain backup key:
```
$ dpapi.py masterkey -file c1bb00eb-99a9-469e-bda8-2204fc87ada6 -pvk backup_key.pvk
Impacket v0.9.21-dev - Copyright 2019 SecureAuth Corporation

[MASTERKEYFILE]
Version     :        2 (2)
Guid        : c1bb00eb-99a9-469e-bda8-2204fc87ada6
Flags       :        0 (0)
Policy      :        0 (0)
MasterKeyLen: 00000088 (136)
BackupKeyLen: 00000068 (104)
CredHistLen : 00000000 (0)
DomainKeyLen: 00000174 (372)

local variable 'long' referenced before assignment
```
After the patch, everything works as intended