### PR TITLE
Add ServerName argument to srvs.hNetrShareEnum

### DIFF
--- a/impacket/dcerpc/v5/srvs.py
+++ b/impacket/dcerpc/v5/srvs.py
@@ -3092,9 +3092,12 @@ def hNetrShareDel(dce, netName):
     request['NetName'] = netName
     return dce.request(request)
 
-def hNetrShareEnum(dce, level, resumeHandle = 0, preferedMaximumLength = 0xffffffff):
+def hNetrShareEnum(dce, level, resumeHandle = 0, preferedMaximumLength = 0xffffffff, serverName = '\x00'):
+    # serverName example: "\\\\1.2.3.4\x00"
+    if serverName[-1] != '\x00':
+        serverName += '\x00'  # final NULL byte is mandatory
     request = NetrShareEnum()
-    request['ServerName'] = '\x00'
+    request['ServerName'] = serverName
     request['PreferedMaximumLength'] = preferedMaximumLength
     request['ResumeHandle'] = resumeHandle
     request['InfoStruct']['Level'] = level

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -409,7 +409,7 @@ class SMBConnection:
         dce = rpctransport.get_dce_rpc()
         dce.connect()
         dce.bind(srvs.MSRPC_UUID_SRVS)
-        resp = srvs.hNetrShareEnum(dce, 1)
+        resp = srvs.hNetrShareEnum(dce, 1, serverName="\\\\" + self.getRemoteHost())
         return resp['InfoStruct']['ShareInfo']['Level1']['Buffer']
 
     def listPath(self, shareName, path, password = None):


### PR DESCRIPTION
I have an SMB server for which impacket `smbconnection.listShares()` doesn't return as many shares as Windows explorer shows me.
Impacket only returns "C$", "F$" and a few others, and "IPC$", "print$" and "prnproc$", while Windows sees many more shares which are not only technical/admin shares but also business ones.

Through a packet capture analysis I found the difference being that Windows fills the "ServerName" field in the NetShareEnumAll request which impacket doesn't (or actually fills it with a NULL byte only coming from b4cacea6afc6dc5c7e03aa4d55cf6520e21837b1):
https://github.com/SecureAuthCorp/impacket/blob/d84fca225175729bdf215adca10f3b3bd5a84733/impacket/dcerpc/v5/srvs.py#L3095-L3097

We can observe that Windows fills it with "\\\\\<ip\>\<NULL\>"
Even though [the specification](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-srvs/c4a98e7b-d416-439c-97bd-4d9f52f8ba52) mentions that this field can be NULL and that the server MUST remove any preceding "\\\\"

This code fixes it for `smbconnection.listShares()` only (which is what I need at the moment...). Would you like me to add something similar to all other structures in srvs.py that have a "ServerName" field?

I tested it on the problematic server and a few others, but I can run a larger scale test :)
EDIT: I did a larger scale test and I did not notice any regression