### PR TITLE
Fixing Error:  '>' not supported between instances of 'str' and 'int'

### DIFF
--- a/examples/psexec.py
+++ b/examples/psexec.py
@@ -278,7 +278,7 @@ class RemoteStdOutPipe(Pipes):
                         LastDataSent = ''
                     # Just in case this got out of sync, i'm cleaning it up if there are more than 10 chars,
                     # it will give false positives tho.. we should find a better way to handle this.
-                    if LastDataSent > 10:
+                    if len(LastDataSent) > 10:
                         LastDataSent = ''
                 except:
                     pass


### PR DESCRIPTION
the err: '>' not supported between instances of 'str' and 'int' is encountered here