### PR TITLE
Added Kerberos support for SMBPasswd.py, fixes #1156

### DIFF
--- a/examples/smbpasswd.py
+++ b/examples/smbpasswd.py
@@ -221,3 +221,4 @@ if __name__ == '__main__':
 	else:
 		# If using NTLM hashes for the new password
 		smbpasswd.hSamrChangePasswordUser()
+


### PR DESCRIPTION
We checked with @ShutdownRepo, and it is not possible to perform a password change with [SamrUnicodeChangePasswordUser2](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/acb3204a-da8b-478e-9139-1ea589edb880) using Kerberos when the current password is expired (`STATUS_PASSWORD_EXPIRED`), since the bypass relies on a null session, which cannot be obtained through Kerberos.

However we submitted a pull request to [smbpasswd.py](https://github.com/SecureAuthCorp/impacket/blob/master/examples/smbpasswd.py) and it is now possible to authenticate using Kerberos (only when password is not expired). 

Here is a demo:

![image](https://user-images.githubusercontent.com/79218792/136186958-af8884c4-65db-4661-9543-cf552a4d1573.png)