### PR TITLE
Added support for a custom additional ticket for S4U2Proxy

### DIFF
--- a/examples/getST.py
+++ b/examples/getST.py
@@ -660,10 +660,10 @@ class GETST:
                 logging.info('Impersonating %s' % self.__options.impersonate)
                 # Editing below to pass hashes for decryption
                 if self.__additional_ticket is not None:
-                    tgs, copher, oldSessionKey, sessionKey = self.doS4U2ProxyWithAdditionalTicket(tgt, cipher, oldSessionKey, sessionKey, unhexlify(self.__nthash), self.__aesKey,
+                    tgs, cipher, oldSessionKey, sessionKey = self.doS4U2ProxyWithAdditionalTicket(tgt, cipher, oldSessionKey, sessionKey, unhexlify(self.__nthash), self.__aesKey,
                                                                                                   self.__kdcHost, self.__additional_ticket)
                 else:
-                    tgs, copher, oldSessionKey, sessionKey = self.doS4U(tgt, cipher, oldSessionKey, sessionKey, unhexlify(self.__nthash), self.__aesKey, self.__kdcHost)
+                    tgs, cipher, oldSessionKey, sessionKey = self.doS4U(tgt, cipher, oldSessionKey, sessionKey, unhexlify(self.__nthash), self.__aesKey, self.__kdcHost)
             except Exception as e:
                 logging.debug("Exception", exc_info=True)
                 logging.error(str(e))
@@ -713,7 +713,7 @@ if __name__ == '__main__':
     if len(sys.argv) == 1:
         parser.print_help()
         print("\nExamples: ")
-        print("\t./getTGT.py -hashes lm:nt contoso.com/user\n")
+        print("\t./getST.py -spn cifs/contoso-dc -hashes lm:nt contoso.com/user\n")
         print("\tit will use the lm:nt hashes for authentication. If you don't specify them, a password will be asked")
         sys.exit(1)
 


### PR DESCRIPTION
In [this blogpost](https://shenaniganslabs.io/2019/01/28/Wagging-the-Dog.html#when-accounts-collude---trustedtoauthfordelegation-who) Elad Shamir explains that Kerberos Constrained Delegations configured without Protocol Transition (a.k.a. with "Kerberos only" set) prevents a service from obtaining a forwardable TGS when conducting an S4U2Self. He demonstrates a technique using RBCD to bypass that. The steps are as follows

1. **serviceA** is configured for KCD Kerberos only
2. **serviceA**'s `msDs-AllowedToActOnBehalfOfOtherIdentity` attribute is set to **serviceB**
3. **serviceB**'s credentials are used to ask for admin's forwardable ticket for one of **serviceA**'s SPNs (common rbcd abuse): `getST.py -spn cifs/serviceA -impersonate admin domain/serviceB:password`
4. **serviceA**'s credentials are then used to operate an S4U2Proxy to obtain a forwardable TGS for admin to one of the services **serviceA** can delegate to. For this to work, the TGS obtained in step 3 has to be included as an additional ticket. This PR allows this step to work: `getST.py -spn cifs/target -impersonate admin -additional-ticket admin.ccache domain/serviceA:password`
