### PR TITLE
Added user filter on findDelegation

### DIFF
--- a/examples/findDelegation.py
+++ b/examples/findDelegation.py
@@ -64,6 +64,7 @@ class FindDelegation:
         self.__aesKey = cmdLineOptions.aesKey
         self.__doKerberos = cmdLineOptions.k
         self.__kdcHost = cmdLineOptions.dc_ip
+        self.__disabled = cmdLineOptions.disabled
         if cmdLineOptions.hashes is not None:
             self.__lmhash, self.__nthash = cmdLineOptions.hashes.split(':')
 
@@ -132,8 +133,13 @@ class FindDelegation:
                 raise
 
         searchFilter = "(&(|(UserAccountControl:1.2.840.113556.1.4.803:=16777216)(UserAccountControl:1.2.840.113556.1.4.803:=" \
-                       "524288)(msDS-AllowedToDelegateTo=*)(msDS-AllowedToActOnBehalfOfOtherIdentity=*))" \
-                       "(!(UserAccountControl:1.2.840.113556.1.4.803:=2))(!(UserAccountControl:1.2.840.113556.1.4.803:=8192))"
+                       "524288)(msDS-AllowedToDelegateTo=*)(msDS-AllowedToActOnBehalfOfOtherIdentity=*)"
+                       
+        if self.__disabled:
+            searchFilter = searchFilter + ")(UserAccountControl:1.2.840.113556.1.4.803:=2)"
+        else:
+            searchFilter = searchFilter + ")(!(UserAccountControl:1.2.840.113556.1.4.803:=2))"
+            
 
         if self.__requestUser is not None:
             searchFilter += '(sAMAccountName:=%s))' % self.__requestUser
@@ -158,7 +164,7 @@ class FindDelegation:
 
         answers = []
         logging.debug('Total of records returned %d' % len(resp))
-        
+
         for item in resp:
             if isinstance(item, ldapasn1.SearchResultEntry) is not True:
                 continue
@@ -196,12 +202,16 @@ class FindDelegation:
                     if str(attribute['type']) == 'msDS-AllowedToActOnBehalfOfOtherIdentity':
                         rbcdRights = []
                         rbcdObjType = []
-                        searchFilter = '(&(|'
+                        searchFilter = "(&(|"
                         sd = ldaptypes.SR_SECURITY_DESCRIPTOR(data=bytes(attribute['vals'][0]))
                         for ace in sd['Dacl'].aces:
                             searchFilter = searchFilter + "(objectSid="+ace['Ace']['Sid'].formatCanonical()+")"
-                        searchFilter = searchFilter + ")(!(UserAccountControl:1.2.840.113556.1.4.803:=2)))"
+                        if self.__disabled:
+                       	    searchFilter = searchFilter + ")(UserAccountControl:1.2.840.113556.1.4.803:=2))"
+                        else:
+                            searchFilter = searchFilter + ")(!(UserAccountControl:1.2.840.113556.1.4.803:=2)))"
                         delegUserResp = ldapConnection.search(searchFilter=searchFilter,attributes=['sAMAccountName', 'objectCategory'],sizeLimit=999)
+                       
                         for item2 in delegUserResp:
                             if isinstance(item2, ldapasn1.SearchResultEntry) is not True:
                                 continue
@@ -209,7 +219,7 @@ class FindDelegation:
                             rbcdObjType.append(str(item2['attributes'][1]['vals'][0]).split('=')[1].split(',')[0])
 							
                         if mustCommit is True:
-                            if int(userAccountControl) & UF_ACCOUNTDISABLE:
+                            if int(userAccountControl) & UF_ACCOUNTDISABLE and self.__disabled is not True:
                                 logging.debug('Bypassing disabled account %s ' % sAMAccountName)
                             else:
                                 for rights, objType in zip(rbcdRights,rbcdObjType):
@@ -218,7 +228,7 @@ class FindDelegation:
                 #print unconstrained + constrained delegation relationships
                 if delegation in ['Unconstrained', 'Constrained w/o Protocol Transition', 'Constrained w/ Protocol Transition']:
                     if mustCommit is True:
-                            if int(userAccountControl) & UF_ACCOUNTDISABLE:
+                            if int(userAccountControl) & UF_ACCOUNTDISABLE and self.__disabled is not True:
                                 logging.debug('Bypassing disabled account %s ' % sAMAccountName)
                             else:
                                 for rights in rightsTo:
@@ -246,9 +256,9 @@ if __name__ == '__main__':
     parser.add_argument('-target-domain', action='store', help='Domain to query/request if different than the domain of the user. '
                                                                'Allows for retrieving delegation info across trusts.')
     parser.add_argument('-user', action='store', help='Requests data for specific user')
-
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
 
+    parser.add_argument('-disabled', action='store_true', help='Query only disabled users')
     group = parser.add_argument_group('authentication')
 
     group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')


### PR DESCRIPTION
I added a user filter, just like GetADUsers. This allows for lighter results in huge environments.
I also changed the "Constrained" strings to "Constrained w/o Protocol Transition" because of the "Constrained w/ Protocol Transition" that was already there. Before this, users of the findDelegation script that would not read the code and would only find "Constrained" accounts could wrongly assume that the "Protocol Transition" thing is not checked. 