### PR TITLE
fix: can only concatenate str error

### DIFF
--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -588,7 +588,7 @@ class MSSQL:
     def socketRecv(self, packetSize):
         data = self.socket.recv(packetSize)
         if self.tlsSocket is not None:
-            dd = ''
+            dd = b''
             self.tlsSocket.bio_write(data)
             while True:
                 try:


### PR DESCRIPTION
Fixes the below error for python3 when using mssqlclient.py:
[-] can only concatenate str (not "bytes") to str