### PR TITLE
add TimeOut parameter in EvtRpcQuerySeek

### DIFF
--- a/impacket/dcerpc/v5/even6.py
+++ b/impacket/dcerpc/v5/even6.py
@@ -234,6 +234,7 @@ class EvtRpcQuerySeek(NDRCALL):
         ('LogQuery', CONTEXT_HANDLE_LOG_QUERY),
         ('Pos', LARGE_INTEGER),
         ('BookmarkXML', LPWSTR),
+        ('TimeOut', DWORD),
         ('Flags', DWORD),
     )
 

--- a/tests/SMB_RPC/test_even6.py
+++ b/tests/SMB_RPC/test_even6.py
@@ -83,6 +83,42 @@ class EVEN6Tests(unittest.TestCase):
             buff = b''.join(event)
             print(hexdump(buff))
 
+    def test_EvtRpcRegisterLogQuery_EvtRpcQuerySeek(self):
+        dce, rpctransport = self.connect(2)
+
+        request = even6.EvtRpcRegisterLogQuery()
+        request['Path'] = 'Security\x00'
+        request['Query'] = '*\x00'
+        request['Flags'] = even6.EvtQueryChannelName | even6.EvtReadNewestToOldest
+
+        request.dump()
+        try:
+            resp = dce.request(request)
+            resp.dump()
+        except Exception as e:
+            return
+
+        log_handle = resp['Handle']
+
+        request = even6.EvtRpcQuerySeek()
+        request['LogQuery'] = log_handle
+        request['Pos'] = 0
+        request['BookmarkXML'] = f"""
+                    <?xml version="1.0" encoding="UTF-8"?>
+                     <BookmarkList>
+                        <Bookmark Channel="Security\x00" RecordId="{1}" IsCurrent="true"/>
+                     </BookmarkList>
+                \x00"""
+        request['TimeOut'] = 60
+        request['Flags'] = 0x00000001
+
+        request.dump()
+        try:
+            resp = dce.request(request)
+            resp.dump()
+        except Exception as e:
+            return
+
     def test_hEvtRpcRegisterLogQuery_hEvtRpcQueryNext(self):
         dce, rpctransport = self.connect(2)
 


### PR DESCRIPTION
In [docs](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-even6/940e1f4c-89cc-49f4-9cee-f73e2001e000) EvtRpcQuerySeek has TimeOut parameter