### PR TITLE
Fix hash extraction bug in AES128-CTS-HMAC-SHA1-96 code path

### DIFF
--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -198,7 +198,7 @@ class GetUserSPNs:
         # In short, we're interested in splitting the checksum and the rest of the encrypted data
         #
         # Regarding AES encryption type (AES128 CTS HMAC-SHA1 96 and AES256 CTS HMAC-SHA1 96)
-        # last 12 bytes of the encrypted ticket represent the checksum of the decrypted 
+        # last 12 bytes of the encrypted ticket represent the checksum of the decrypted
         # ticket
         if decodedTGS['ticket']['enc-part']['etype'] == constants.EncryptionTypes.rc4_hmac.value:
             entry = '$krb5tgs$%d$*%s$%s$%s*$%s$%s' % (
@@ -213,7 +213,7 @@ class GetUserSPNs:
             entry = '$krb5tgs$%d$%s$%s$*%s*$%s$%s' % (
                 constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value, username, decodedTGS['ticket']['realm'], spn.replace(':', '~'),
                 hexlify(decodedTGS['ticket']['enc-part']['cipher'][-12:].asOctets()).decode(),
-                hexlify(decodedTGS['ticket']['enc-part']['cipher'][:-12:].asOctets()).decode)
+                hexlify(decodedTGS['ticket']['enc-part']['cipher'][:-12:].asOctets()).decode())
             if fd is None:
                 print(entry)
             else:


### PR DESCRIPTION
Before this PR,

Running `python GetUserSPNs.py... -outputfile hashes.txt` generated a file with content like,

```
$krb5tgs$17$...<built-in method decode of bytes object at 0x55fad9d939c0>
```

After this PR, hash extraction works properly, and the extracted hashes crack just fine with WIP JtR module.

Related: https://github.com/openwall/john/issues/2809#issuecomment-952846956.