### PR TITLE
Added JSON output to for ntlm, lsa secrets (plaintext only), and cached credentials

### DIFF
--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -174,9 +174,10 @@ class DumpSecrets:
 
                     self.__SAMHashes    = SAMHashes(SAMFileName, bootKey, isRemote = self.__isRemote)
                     self.__SAMHashes.dump()
-                    if self.__jsonOutput:
-                        self.__SAMHashes.exportJson(self.__outputFileName,self.__remoteName)
                     if self.__outputFileName is not None:
+                        if self.__jsonOutput:
+                            self.__SAMHashes.exportJson(self.__outputFileName,self.__remoteName)
+                        # you may wish to place an else here and in the two other similar locations
                         self.__SAMHashes.export(self.__outputFileName)
                 except Exception as e:
                     logging.error('SAM hashes extraction failed: %s' % str(e))
@@ -191,9 +192,13 @@ class DumpSecrets:
                                                    isRemote=self.__isRemote, history=self.__history)
                     self.__LSASecrets.dumpCachedHashes()
                     if self.__outputFileName is not None:
+                        if self.__jsonOutput:
+                            self.__LSASecrets.exportCachedJson(self.__outputFileName,self.__remoteName)
                         self.__LSASecrets.exportCached(self.__outputFileName)
                     self.__LSASecrets.dumpSecrets()
                     if self.__outputFileName is not None:
+                        if self.__jsonOutput:
+                            self.__LSASecrets.exportSecretsJson(self.__outputFileName,self.__remoteName)
                         self.__LSASecrets.exportSecrets(self.__outputFileName)
                 except Exception as e:
                     if logging.getLogger().level == logging.DEBUG:

--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -103,6 +103,7 @@ class DumpSecrets:
         self.__canProcessSAMLSA = True
         self.__kdcHost = options.dc_ip
         self.__options = options
+        self.__jsonOutput = options.json_output
 
         if options.hashes is not None:
             self.__lmhash, self.__nthash = options.hashes.split(':')
@@ -173,6 +174,8 @@ class DumpSecrets:
 
                     self.__SAMHashes    = SAMHashes(SAMFileName, bootKey, isRemote = self.__isRemote)
                     self.__SAMHashes.dump()
+                    if self.__jsonOutput:
+                        self.__SAMHashes.exportJson(self.__outputFileName,self.__remoteName)
                     if self.__outputFileName is not None:
                         self.__SAMHashes.export(self.__outputFileName)
                 except Exception as e:
@@ -315,6 +318,8 @@ if __name__ == '__main__':
     group.add_argument('-user-status', action='store_true', default=False,
                         help='Display whether or not the user is disabled')
     group.add_argument('-history', action='store_true', help='Dump password history, and LSA secrets OldVal')
+    group.add_argument('-json-output', action='store_true', help='Dump the secretsdump information in json format. '
+                        'Note: this output only includes ntlm, dcc2, and plaintext lsa secrets output')
     group = parser.add_argument_group('authentication')
 
     group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')


### PR DESCRIPTION
I Added an additional option and corresponding function to allow for JSON output to be generated.
Something I have wanted for awhile and given how ubiquitous easy-to-use JSON is, this change 
should allow for quick and easy parsing into other tools for automation, logging, etc. 
All outputs also include their original 'answer' formats.

An example of it running:  
![impacket-json-output-running](https://user-images.githubusercontent.com/30613497/139357675-517040d1-905d-4477-8a43-94fad8edddfb.png)
 
Also: I was unsure if the json-output flag should be exclusive of the traditional format or not, for the time being, and to err to the safe side, the option currently generates the JSON format in addition to the original format.