### PR TITLE
Fixed putting multiple locks on one packet

### DIFF
--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -1495,7 +1495,7 @@ class SMB3:
         smbLock['FileID']       = fileId
         smbLock['LockCount']    = len(locks)
         smbLock['LockSequence'] = lockSequence
-        smbLock['Locks']        = ''.join(str(x) for x in locks)
+        smbLock['Locks']        = locks
 
         packet['Data'] = smbLock
 

--- a/impacket/smb3structs.py
+++ b/impacket/smb3structs.py
@@ -1093,7 +1093,7 @@ class SMB2Lock(Structure):
         ('LockSequence','<L=0'),
         ('FileID',':',SMB2_FILEID),
         ('_Locks','_-Locks','self["LockCount"]*24'),
-        ('Locks',':'),
+        ('Locks','*:'),
     )
 
 class SMB2Lock_Response(Structure):


### PR DESCRIPTION
The current code has a bug where passing multiple locks won't work since when you try to join the __str__ representation of all the locks you actually get byte string which can't be joined.
Instead I have changed the format of the lock to allow passing a list.