### PR TITLE
Add HKEY_USERS to reg.py and correct HKU hive mapping

### DIFF
--- a/examples/reg.py
+++ b/examples/reg.py
@@ -397,8 +397,10 @@ class RegHandler:
             raise Exception('Error parsing keyName %s' % keyName)
         if rootKey.upper() == 'HKLM':
             ans = rrp.hOpenLocalMachine(dce)
-        elif rootKey.upper() == 'HKU':
+        elif rootKey.upper() == 'HKCU':
             ans = rrp.hOpenCurrentUser(dce)
+        elif rootKey.upper() == 'HKU':
+            ans = rrp.hOpenUsers(dce)
         elif rootKey.upper() == 'HKCR':
             ans = rrp.hOpenClassesRoot(dce)
         else:
@@ -504,7 +506,7 @@ if __name__ == '__main__':
     query_parser.add_argument('-keyName', action='store', required=True,
                               help='Specifies the full path of the subkey. The '
                                    'keyName must include a valid root key. Valid root keys for the local computer are: HKLM,'
-                                   ' HKU, HKCR.')
+                                   ' HKU, HKCU, HKCR.')
     query_parser.add_argument('-v', action='store', metavar="VALUENAME", required=False, help='Specifies the registry '
                            'value name that is to be queried. If omitted, all value names for keyName are returned. ')
     query_parser.add_argument('-ve', action='store_true', default=False, required=False, help='Queries for the default '
@@ -517,7 +519,7 @@ if __name__ == '__main__':
     add_parser.add_argument('-keyName', action='store', required=True,
                               help='Specifies the full path of the subkey. The '
                                    'keyName must include a valid root key. Valid root keys for the local computer are: HKLM,'
-                                   ' HKU, HKCR.')
+                                   ' HKU, HKCU, HKCR.')
     add_parser.add_argument('-v', action='store', metavar="VALUENAME", required=False, help='Specifies the registry '
                            'value name that is to be set.')
     add_parser.add_argument('-vt', action='store', metavar="VALUETYPE", required=False, help='Specifies the registry '
@@ -532,7 +534,7 @@ if __name__ == '__main__':
     delete_parser.add_argument('-keyName', action='store', required=True,
                               help='Specifies the full path of the subkey. The '
                                    'keyName must include a valid root key. Valid root keys for the local computer are: HKLM,'
-                                   ' HKU, HKCR.')
+                                   ' HKU, HKCU, HKCR.')
     delete_parser.add_argument('-v', action='store', metavar="VALUENAME", required=False, help='Specifies the registry '
                            'value name that is to be deleted.')
     delete_parser.add_argument('-va', action='store_true', required=False, help='Delete all values under this key.')


### PR DESCRIPTION
Adds HKEY_USERS hive support to reg.py as "HKU", and renames access to HKEY_CURRENT_USER from "HKU" to "HKCU" to more closely match convention.

While the renaming of the prior HKU to HKCU is technically correct, if the preference is to not change existing behaviour I'm happy to revert that change and map HKEY_USERS to something else ("HKUSERS"?)