### PR TITLE
RBCD 2nd Try fails due to non-existent SID lookup

### DIFF
--- a/examples/rbcd.py
+++ b/examples/rbcd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Impacket - Collection of Python classes for working with network protocols.
 #
 # SECUREAUTH LABS. Copyright (C) 2021 SecureAuth Corporation. All rights reserved.

--- a/examples/rbcd.py
+++ b/examples/rbcd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # Impacket - Collection of Python classes for working with network protocols.
 #
 # SECUREAUTH LABS. Copyright (C) 2021 SecureAuth Corporation. All rights reserved.
@@ -406,8 +406,12 @@ class RBCD(object):
                 logging.info('Accounts allowed to act on behalf of other identity:')
                 for ace in sd['Dacl'].aces:
                     SID = ace['Ace']['Sid'].formatCanonical()
-                    SamAccountName = self.get_sid_info(ace['Ace']['Sid'].formatCanonical())[1]
-                    logging.info('    %-10s   (%s)' % (SamAccountName, SID))
+                    logging.info("Trying with SID: {0}".format(SID))
+                    try: 
+                        SamAccountName = self.get_sid_info(ace['Ace']['Sid'].formatCanonical())[1]
+                        logging.info('    %-10s   (%s)' % (SamAccountName, SID))
+                    except TypeError: 
+                        pass
             else:
                 logging.info('Attribute msDS-AllowedToActOnBehalfOfOtherIdentity is empty')
         except IndexError:


### PR DESCRIPTION
* 2nd try of rbcd.py against same target (delegate-to) fails due to non-existent SID lookup.
* This pull request try to catch TypeError then try next SID, which believed to fix this bug.
```
$ rbcd.py -delegate-from 'new-machine$' -delegate-to 'ad$' -action write -ts -debug -dc-ip 10.x.y.z "contoso.com/user:password"
Impacket v0.9.25.dev1+20220119.101925.12de27dc - Copyright 2021 SecureAuth Corporation

[2022-01-28 18:14:34] [+] Impacket Library Installation Path: /usr/local/lib/python3.9/dist-packages/impacket-0.9.25.dev1+20220119.101925.12de27dc-py3.9.egg/impacket
[2022-01-28 18:14:35] [+] Initializing domainDumper()
[2022-01-28 18:14:35] [*] Accounts allowed to act on behalf of other identity:
[2022-01-28 18:14:35] [-] SID not found in LDAP: S-1-5-21-111111111-2222222-33333-16146
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/impacket-0.9.25.dev1+20220119.101925.12de27dc-py3.9.egg/EGG-INFO/scripts/rbcd.py", line 576, in main
    rbcd.write(args.delegate_from)
  File "/usr/local/lib/python3.9/dist-packages/impacket-0.9.25.dev1+20220119.101925.12de27dc-py3.9.egg/EGG-INFO/scripts/rbcd.py", line 295, in write
    sd, targetuser = self.get_allowed_to_act()
  File "/usr/local/lib/python3.9/dist-packages/impacket-0.9.25.dev1+20220119.101925.12de27dc-py3.9.egg/EGG-INFO/scripts/rbcd.py", line 409, in get_allowed_to_act
    SamAccountName = self.get_sid_info(ace['Ace']['Sid'].formatCanonical())[1]
TypeError: 'bool' object is not subscriptable
[2022-01-28 18:14:35] [-] 'bool' object is not subscriptable
```

