### PR TITLE
[secretsdump] Added OpenGPG public/private key parsing in secretsdump.py

### DIFF
--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -1588,6 +1588,24 @@ class LSASecrets(OfflineRegistry):
                     LOG.warning("Unknown SQSA version (%s), please open an issue with the following data so we can add a parser for it." % str(strDecoded['version']))
                     LOG.warning("Don't forget to remove sensitive content before sending the data in a Github issue.")
                     secret = json.dumps(strDecoded, indent=4)
+        elif re.match('^L\$([0-9A-Z]{3})-PRV-([0-9A-F]{32})$', upperName) is not None:
+            # Decode stored OpenGPG private key
+            keyid = re.search('^L\$([0-9A-Z]{3})-PRV-([0-9A-F]{32})$', upperName).group(2)
+            try:
+                b64key = secretItem.decode('utf-16le')
+            except:
+                pass
+            else:
+                secret = 'OpenGPG private key %s: \n%s' % (keyid, b64key)
+        elif re.match('^L\$([0-9A-Z]{3})-PUB-([0-9A-F]{32})$', upperName) is not None:
+            # Decode stored OpenGPG public key
+            keyid = re.search('^L\$([0-9A-Z]{3})-PUB-([0-9A-F]{32})$', upperName).group(2)
+            try:
+                b64key = secretItem.decode('utf-16le')
+            except:
+                pass
+            else:
+                secret = 'OpenGPG public key %s: \n%s' % (keyid, b64key)
 
         if secret != '':
             printableSecret = secret


### PR DESCRIPTION
I have added parsing for the OpenGPG keys extracted from the LSA by secretsdump. It now prints:

After my patch, secretsdump prints:

```
[*] L$GLB-PUB-6EEB8090F4CB218E406224CAF1C587F5
OpenGPG public key 6EEB8090F4CB218E406224CAF1C587F5: m4OY24OW0WSAx4Fjtu7PiEsDp8WcTeLO5brWnJb42ahf9ZykEJ14mpUTCTnv7wX/0TBteUPBqI9YW62hGhXZhennx4c98WLGHwslmqBN5A2jLlspn2LnEF8pACvs9YbkzcxaEXKLz/qUG718kKrGEvBT1tLRQ+6Lc9+bIKbuAzR38/Wbq2JX2CG0040
[*] L$LOC-PRV-6EEB8090F4CB218E406224CAF1C587F5
OpenGPG private key 6EEB8090F4CB218E406224CAF1C587F5: m8e0R9G008GW12Ge64lFL5iJLmSnyjenR8bMZ2i3gfNXU3MNq11lqhF9hASp6LvxFwDc5whIisFWgPm4M1lxqu2XEOV6NpnXVG4UH+zXkzs+xnt5jeGzWe9dmAHzBP6OwQG4/gDBx90eYKJ0KXQp9U5Mbc1j0fz5Z2EnH6fdEQdapPd33Qg6KfTfZAm010G0248WqWV2dsaesCSQ6KvVCs/CBdU3c23Lv1tkM8KjsAjXkNKAXZ4bDRwxy2XKM6LxPvgXjcXxBrm4u4nYMZTCaZYtcpPhs+PLowd0qwmcIBJfQCCifbAsv7IDEe0KpP21/wSZpjZrKQS2jT0IhEgxDo8RVTbfKm+qsFV/uo+VQ4FnO4h0110rTEzT3/jukvqBwnTgdckoU7/xa/NtywoOMJbzbaZyeGH0icsQGW3SgKBFo5BNhGi7yUwr2Dl/gq3Il7BGFFTV24401BkJPtGQ3/nsawcLWDGauL4iI7jj/EFxdKedSSY7oFa6YfzNz+wHtYTjoOmRNbqiQpD/0Gq+KwlXv0eFTjvPVA0Gku7Ck2+q5LrRToMLoT7+aTTQwQbahycg9GavXa4DfAwNrdPkNCQNa5XmzokAYYu836y96XgAefQtfJE6puf/LA0G9Ok54e7xLl6Wvh4CQBy4XBK7VMWs0uRubjhAn6MHnJpVQ3sBNtIP9lF9rDYOt/TwmbzAy1P2GWZL+L04gCnJT80G1TZWEAUVPKQvLlmgjkvviy4AGzeoUEJVGdyRMLAr09xIn/2bCmFiyimmN9tSovxbWpn73zzwhIhOqq6AahJDG0
[*] Cleaning up...
[*] Stopping service RemoteRegistry
```

## References
 - https://podalirius.net/en/articles/extracting-opengpg-keys-stored-in-the-windows-lsa/