### PR TITLE
Fix `NTLM_HTTP.get_instance()`

### DIFF
--- a/impacket/ntlm.py
+++ b/impacket/ntlm.py
@@ -941,12 +941,12 @@ class NTLM_HTTP(object):
     MSG_TYPE = None
 
     @classmethod
-    def get_instace(cls,msg_64):
+    def get_instance(cls,msg_64):
         msg = None
         msg_type = 0
         if msg_64 != '':
             msg = base64.b64decode(msg_64[5:]) # Remove the 'NTLM '
-            msg_type = ord(msg[8])
+            msg_type = msg[8]
     
         for _cls in NTLM_HTTP.__subclasses__():
             if msg_type == _cls.MSG_TYPE:


### PR DESCRIPTION
The `ord()` function is failing because it requires a length-1 string (a single char) whereas `data[8]` is a byte, so it is already a number, and we can already compare it with `_cls.MSG_TYPE` without converting it to anything.

This PR also fixes a typo in the function name.