### PR TITLE
Fix incorrect padding in SMBSessionSetupAndX_Extended_ResponseData

### DIFF
--- a/impacket/smb.py
+++ b/impacket/smb.py
@@ -1493,7 +1493,7 @@ class SMBSessionSetupAndX_Extended_Response_Data(AsciiOrUnicodeStructure):
     )
     def getData(self):
         if self.structure == self.UnicodeStructure:
-            if len(str(self['SecurityBlob'])) % 2 == 0:
+            if len(self['SecurityBlob']) % 2 == 0:
                 self['Pad'] = '\x00'
         return AsciiOrUnicodeStructure.getData(self)
 


### PR DESCRIPTION
This PR fixes #1309 by adding a padding byte depending on the size of the `SecurityBlob` instead of depending on the size of the string representation of the `SecurityBlob` bytes.