### PR TITLE
Handle unknown NTSTATUS in SessionError

### DIFF
--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -699,7 +699,7 @@ class KerberosError(SessionError):
         return self.packet
 
     def getErrorString( self ):
-        return constants.ERROR_MESSAGES[self.error]
+        return str(self)
 
     def __str__( self ):
         retString = 'Kerberos SessionError: %s(%s)' % (constants.ERROR_MESSAGES[self.error])
@@ -708,7 +708,13 @@ class KerberosError(SessionError):
             if self.error == constants.ErrorCodes.KRB_ERR_GENERIC.value:
                 eData = decoder.decode(self.packet['e-data'], asn1Spec = KERB_ERROR_DATA())[0]
                 nt_error = struct.unpack('<L', eData['data-value'].asOctets()[:4])[0]
-                retString += '\nNT ERROR: %s(%s)' % (nt_errors.ERROR_MESSAGES[nt_error])
+
+                if nt_error in nt_errors.ERROR_MESSAGES:
+                    error_msg_short = nt_errors.ERROR_MESSAGES[nt_error][0] 
+                    error_msg_verbose = nt_errors.ERROR_MESSAGES[nt_error][1] 
+                    retString += '\nNT ERROR: code: 0x%x - %s - %s' % (nt_error, error_msg_short, error_msg_verbose)
+                else:
+                    retString += '\nNT ERROR: unknown error code: 0x%x' % nt_error
         except:
             pass
 

--- a/impacket/smb.py
+++ b/impacket/smb.py
@@ -578,7 +578,13 @@ class SessionError(Exception):
                 error_code_str = '%s(%s)' % error_code
 
         if self.nt_status:
-            return 'SMB SessionError: %s(%s)' % nt_errors.ERROR_MESSAGES.get(self.error_code, ("UNKNOWN_NTSTATUS", self.error_code))
+            key = self.error_code
+            if key in nt_errors.ERROR_MESSAGES:
+                error_msg_short = nt_errors.ERROR_MESSAGES[key][0] 
+                error_msg_verbose = nt_errors.ERROR_MESSAGES[key][1] 
+                return 'SMB SessionError: code: 0x%x - %s - %s' % (self.error_code, error_msg_short, error_msg_verbose)
+            else:
+                return 'SMB SessionError: unknown error code: 0x%x' % self.error_code
         else:
             # Fall back to the old format
             return 'SMB SessionError: class: %s, code: %s' % (error_class_str, error_code_str)

--- a/impacket/smb.py
+++ b/impacket/smb.py
@@ -578,7 +578,7 @@ class SessionError(Exception):
                 error_code_str = '%s(%s)' % error_code
 
         if self.nt_status:
-            return 'SMB SessionError: %s(%s)' % nt_errors.ERROR_MESSAGES[self.error_code]
+            return 'SMB SessionError: %s(%s)' % nt_errors.ERROR_MESSAGES.get(self.error_code, ("UNKNOWN_NTSTATUS", self.error_code))
         else:
             # Fall back to the old format
             return 'SMB SessionError: class: %s, code: %s' % (error_class_str, error_code_str)

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -986,10 +986,13 @@ class SessionError(Exception):
         return self.packet
 
     def getErrorString( self ):
-        return nt_errors.ERROR_MESSAGES[self.error]
+        return str(self)
 
     def __str__( self ):
-        if self.error in nt_errors.ERROR_MESSAGES:
-            return 'SMB SessionError: %s(%s)' % (nt_errors.ERROR_MESSAGES[self.error])
+        key = self.error
+        if key in nt_errors.ERROR_MESSAGES:
+            error_msg_short = nt_errors.ERROR_MESSAGES[key][0] 
+            error_msg_verbose = nt_errors.ERROR_MESSAGES[key][1] 
+            return 'SMB SessionError: code: 0x%x - %s - %s' % (self.error, error_msg_short, error_msg_verbose)
         else:
-            return 'SMB SessionError: 0x%x' % self.error
+            return 'SMB SessionError: unknown error code: 0x%x' % self.error


### PR DESCRIPTION
When a [`SessionError`](https://github.com/SecureAuthCorp/impacket/blob/d509775976ba37f4eaea630cc511e2fc3b65aba3/impacket/smb.py#L310) is raised during SMB session negotiation, currently unexpected NTSTATUS error codes are not handled properly. If the `SessionError` exception is catched and logged, a KeyError is thrown when retrieving the string representation of the exception in: 

https://github.com/SecureAuthCorp/impacket/blob/d509775976ba37f4eaea630cc511e2fc3b65aba3/impacket/smb.py#L581

The error occurred when receiving an unexpected error code during an SMB login scan using [`CrackMapExec`](https://github.com/byt3bl33d3r/CrackMapExec/blob/e9bcd09bd2c862200a40ecdc431fcf56f0ae5b67/cme/protocols/smb.py#L477).

This pull request adds a generic error message when the error code is not contained in the `ERROR_MESSAGES` dictionary.