### PR TITLE
[ntlmrelayx] Dump ADCS: bug fixes

### DIFF
--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -678,10 +678,12 @@ class LDAPAttack(ProtocolAttack):
 
             for ace in (a for a in sd["Dacl"]["Data"] if a["AceType"] == ldaptypes.ACCESS_ALLOWED_OBJECT_ACE.ACE_TYPE):
                 sid = format_sid(ace["Ace"]["Sid"].getData())
-                if ace["Ace"]["ObjectTypeLen"] == 0:
+                if ace["Ace"]["Flags"] == 2:
                     uuid = bin_to_string(ace["Ace"]["InheritedObjectType"]).lower()
-                else:
+                elif ace["Ace"]["Flags"] == 1:
                     uuid = bin_to_string(ace["Ace"]["ObjectType"]).lower()
+                else:
+                    continue
 
                 if not uuid in enrollment_uuids:
                     continue

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -714,7 +714,7 @@ class LDAPAttack(ProtocolAttack):
                     sid_map[sid] = sid
                     continue
 
-                if not len(self.client.response):
+                if not len(self.client.entries):
                     sid_map[sid] = sid
                 else:
                     sid_map[sid] = domain_fqdn + "\\" + self.client.response[0]["attributes"]["name"]


### PR DESCRIPTION
Hi !

This commit fixes 2 issues with the LDAP attack dumping ADCS info.

1) For some reason unknown to me, some ACEs can have neither a valid `ObjectType` nor `InheritedObjectType`. The current check will try to parse `InheritedObjectType` if `ObjectType` is empty, resulting in an error as `InheritedObjectType` will also be empty. The [right way to check this](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/c79a383c-2b3f-4655-abe7-dcbb7ce0cfbe) seems to be checking the `Flags` field: a value of `0` indicates neither of these fields are valid, and the ACE can be ignored.
2) If a SID cannot be translated, the `self.client.response` object will still contain some information (but not the expected result object), and as such the `len(self.client.response)` will not be empty, resulting in an error when trying to access `self.client.response[0]["attributes"]`. I am replacing this check with `self.client.entries` object which will behave as wanted.

Thanks !
