### PR TITLE
Set SMB default challenge for SimpleSMBServer

### DIFF
--- a/examples/smbserver.py
+++ b/examples/smbserver.py
@@ -92,7 +92,7 @@ if __name__ == '__main__':
         server.addCredential(options.username, 0, lmhash, nthash)
 
     # Here you can set a custom SMB challenge in hex format
-    # If empty defaults to '4141414141414141'
+    # If empty defaults to '1122334455667788'
     # (remember: must be 16 hex bytes long)
     # e.g. server.setSMBChallenge('12345678abcdef00')
     server.setSMBChallenge('')

--- a/impacket/examples/serviceinstall.py
+++ b/impacket/examples/serviceinstall.py
@@ -46,6 +46,14 @@ class ServiceInstall:
 
         self.share = ''
 
+    @property
+    def get_service_name(self):
+        return self.__service_name
+
+    @property
+    def get_binary_service_name(self):
+        return self.__binary_service_name
+
     def getShare(self):
         return self.share
 

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -4827,7 +4827,7 @@ class SimpleSMBServer:
             self.__smbConfig.set('global', 'log_file', 'None')
             self.__smbConfig.set('global', 'rpc_apis', 'yes')
             self.__smbConfig.set('global', 'credentials_file', '')
-            self.__smbConfig.set('global', 'challenge', "A" * 16)
+            self.__smbConfig.set('global', 'challenge', "1122334455667788")
 
             # IPC always needed
             self.__smbConfig.add_section('IPC$')


### PR DESCRIPTION
The SMB Challenge for `smbserver.py` changed from `b"A" * 16`  to `\x11\x22\x33\x44\x55\x66\x77\x88` in a previous commit. However, its basic implementation in `SimpleSMBServer` kept using a default challenge of `b"A" * 16`. This results in Kali linux using a default challenge of `AAAAAAAA` as it uses impacket examples by default when invoking anything impacket-related from the command-line.
This commit changes it to set it to `1122334455667788` once and for all by default.