### PR TITLE
fix can't add when value is REG_BINARY

### DIFF
--- a/examples/reg.py
+++ b/examples/reg.py
@@ -285,7 +285,9 @@ class RegHandler:
             ):
                 valueData = int(self.__options.vd)
             elif dwType == rrp.REG_BINARY:
-                valueData = binascii.a2b_hex(self.__options.vd)
+                bin_value_len = len(self.__options.vd)
+                bin_value_len += (bin_value_len & 1)
+                valueData = binascii.a2b_hex(self.__options.vd.ljust(bin_value_len, '0'))
             else:
                 valueData = self.__options.vd
 

--- a/examples/reg.py
+++ b/examples/reg.py
@@ -33,6 +33,7 @@ import codecs
 import logging
 import sys
 import time
+import binascii
 from struct import unpack
 
 from impacket import version
@@ -283,6 +284,8 @@ class RegHandler:
                 rrp.REG_QWORD, rrp.REG_QWORD_LITTLE_ENDIAN
             ):
                 valueData = int(self.__options.vd)
+            elif dwType == rrp.REG_BINARY:
+                valueData = binascii.a2b_hex(self.__options.vd)
             else:
                 valueData = self.__options.vd
 


### PR DESCRIPTION
it only can accept bytes object when -vt is REG_BINARY
fix the issue that can't add key when value type is REG_BINARY