### PR TITLE
SMB3 improvements

### DIFF
--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -184,7 +184,11 @@ class SMB3:
             'ClientName'               : '',    #
             #GSSoptions (MutualAuth and Delegate)
             'GSSoptions'               : {},
-            'PreauthIntegrityHashValue': a2b_hex(b'0'*128)
+            # If the client implements the SMB 3.1.1 dialect,
+            # it MUST also implement the following
+            'PreauthIntegrityHashId': 0,
+            'PreauthIntegrityHashValue': a2b_hex(b'0'*128),
+            'CipherId' : 0
         }
 
         self._Session = {
@@ -353,6 +357,28 @@ class SMB3:
 
     def getDialect(self):
         return self._Connection['Dialect']
+
+    def processContextList(self, contextCount, contextList):
+        offset = 0
+        while contextCount > 0:
+            context = SMB2NegotiateContext(contextList[offset:])
+            if context['ContextType'] == SMB2_PREAUTH_INTEGRITY_CAPABILITIES:
+                contextPreAuth = SMB2PreAuthIntegrityCapabilities(context['Data'])
+                self._Connection['PreauthIntegrityHashId'] = struct.unpack('<H', contextPreAuth['HashAlgorithms'])[0]
+            elif context['ContextType'] == SMB2_ENCRYPTION_CAPABILITIES:
+                contextEncryption = SMB2EncryptionCapabilities(context['Data'])
+                cipherId = struct.unpack('<H', contextEncryption['Ciphers'])[0]
+                self._Connection['CipherId'] = cipherId
+                if cipherId != 0:
+                    self._Connection['SupportsEncryption'] = True
+            elif context['ContextType'] == SMB2_COMPRESSION_CAPABILITIES:
+                pass
+            elif context['ContextType'] == SMB2_NETNAME_NEGOTIATE_CONTEXT_ID:
+                pass
+
+            padding = ((8 - (context['DataLength'] % 8)) % 8)
+            offset = 8 + context['DataLength'] + padding
+            contextCount -= 1
 
     def signSMB(self, packet):
         packet['Signature'] = '\x00'*16
@@ -532,12 +558,12 @@ class SMB3:
                     # to the negotiate request as specified in section 2.2.3.1 and initialize
                     # the Ciphers field with the ciphers supported by the client in the order of preference.
 
-                    negotiateContext2 = SMB2NegotiateContext ()
+                    negotiateContext2 = SMB2NegotiateContext()
                     negotiateContext2['ContextType'] = SMB2_ENCRYPTION_CAPABILITIES
 
                     encryptionCapabilities = SMB2EncryptionCapabilities()
                     encryptionCapabilities['CipherCount'] = 1
-                    encryptionCapabilities['Ciphers'] = 1
+                    encryptionCapabilities['Ciphers'] = b'\x01\x00'
 
                     negotiateContext2['Data'] = encryptionCapabilities.getData()
                     negotiateContext2['DataLength'] = len(negotiateContext2['Data'])
@@ -570,12 +596,17 @@ class SMB3:
         self._Connection['ServerGuid']        = negResp['ServerGuid']
         self._Connection['GSSNegotiateToken'] = negResp['Buffer']
         self._Connection['Dialect']           = negResp['DialectRevision']
+
         if (negResp['SecurityMode'] & SMB2_NEGOTIATE_SIGNING_REQUIRED) == SMB2_NEGOTIATE_SIGNING_REQUIRED or \
                 self._Connection['Dialect'] == SMB2_DIALECT_311:
             self._Connection['RequireSigning'] = True
         if self._Connection['Dialect'] == SMB2_DIALECT_311:
             # Always Sign
             self._Connection['RequireSigning'] = True
+            negContextCount = negResp['NegotiateContextCount']
+            # Process the Contexts as specified in section 3.2.5.2
+            if negContextCount > 0:
+                self.processContextList(negContextCount, negResp['NegotiateContextList'])
 
         if (negResp['Capabilities'] & SMB2_GLOBAL_CAP_LEASING) == SMB2_GLOBAL_CAP_LEASING:
             self._Connection['SupportsFileLeasing'] = True
@@ -914,6 +945,9 @@ class SMB3:
         packet = self.SMB_PACKET()
         packet['Command'] = SMB2_SESSION_SETUP
         packet['Data']    = sessionSetup
+
+        # Initiate session preauth hash
+        self._Session['PreauthIntegrityHashValue'] = self._Connection['PreauthIntegrityHashValue']
 
         packetID = self.sendSMB(packet)
         ans = self.recvSMB(packetID)

--- a/impacket/smb3structs.py
+++ b/impacket/smb3structs.py
@@ -618,6 +618,7 @@ class SMB2NegotiateContext(Structure):
         ('ContextType','<H=0'),
         ('DataLength','<H=0'),
         ('Reserved','<L=0'),
+        ('_Data', '_-Data', 'self["DataLength"]'),
         ('Data',':=""'),
     )
 
@@ -626,6 +627,7 @@ class SMB2PreAuthIntegrityCapabilities(Structure):
     structure = (
         ('HashAlgorithmCount','<H=0'),
         ('SaltLength','<H=0'),
+		('_HashAlgorithms', '_-HashAlgorithms', 'self["HashAlgorithmCount"]*2'),
         ('HashAlgorithms',':=""'),
         ('Salt',':=""'),
     )
@@ -634,7 +636,7 @@ class SMB2PreAuthIntegrityCapabilities(Structure):
 class SMB2EncryptionCapabilities(Structure):
     structure = (
         ('CipherCount','<H=0'),
-        ('Ciphers','<H=0'),
+        ('Ciphers',':=""'),
     )
 
 # SMB2_COMPRESSION_CAPABILITIES

--- a/impacket/smb3structs.py
+++ b/impacket/smb3structs.py
@@ -627,7 +627,7 @@ class SMB2PreAuthIntegrityCapabilities(Structure):
     structure = (
         ('HashAlgorithmCount','<H=0'),
         ('SaltLength','<H=0'),
-		('_HashAlgorithms', '_-HashAlgorithms', 'self["HashAlgorithmCount"]*2'),
+        ('_HashAlgorithms', '_-HashAlgorithms', 'self["HashAlgorithmCount"]*2'),
         ('HashAlgorithms',':=""'),
         ('Salt',':=""'),
     )


### PR DESCRIPTION
- Added the Session.PreAuthIntegrityHashValue initialization during login.
- Added Negotiate Context processing as is described in [MS-SMB2] 3.2.5.2. It can now be detected whether the server supports encryption in SMB 3.1.1.
- Improved SMB 3.1.1 Negotiate Context structures.
- It fixes #1370.