### PR TITLE
[rbcd.py] Handled SID not found in LDAP error

### DIFF
--- a/examples/rbcd.py
+++ b/examples/rbcd.py
@@ -371,8 +371,10 @@ class RBCD(object):
                 logging.info('Accounts allowed to act on behalf of other identity:')
                 for ace in sd['Dacl'].aces:
                     SID = ace['Ace']['Sid'].formatCanonical()
-                    SamAccountName = self.get_sid_info(ace['Ace']['Sid'].formatCanonical())[1]
-                    logging.info('    %-10s   (%s)' % (SamAccountName, SID))
+                    SidInfos = self.get_sid_info(ace['Ace']['Sid'].formatCanonical())
+                    if SidInfos:
+                        SamAccountName = SidInfos[1]
+                        logging.info('    %-10s   (%s)' % (SamAccountName, SID))
             else:
                 logging.info('Attribute msDS-AllowedToActOnBehalfOfOtherIdentity is empty')
         except IndexError:


### PR DESCRIPTION
When an SID couldn't be found in LDAP, the script was crashing because the `get_sid_info()` function was returning `False` but the returned value was then read like a list, hence raising an `TypeError: 'bool' object is not subscriptable` error.
This is fixed now, the value returned by the function is checked before attempting at parsing it.