### PR TITLE
Address DHCP python3 bug

### DIFF
--- a/impacket/dhcp.py
+++ b/impacket/dhcp.py
@@ -7,6 +7,7 @@
 # for more information.
 #
 
+import six
 from impacket import structure
 from impacket.ImpactPacket import ProtocolPacket
 
@@ -171,9 +172,9 @@ class DhcpPacket(ProtocolPacket, structure.Structure):
         answer = []
         i = 0
         while i < len(options)-1:
-            name, format = self.getOptionNameAndFormat(ord(options[i]))
+            name, format = self.getOptionNameAndFormat(options[i] if six.PY3 else ord(options[i]))
             # size = self.calcUnpackSize(format, options[i+1:])
-            size = ord(options[i+1])
+            size = options[i+1] if six.PY3 else ord(options[i+1])
             # print i, name, format, size
             value = self.unpack(format, options[i+2:i+2+size])
             answer.append((name, value))

--- a/impacket/dhcp.py
+++ b/impacket/dhcp.py
@@ -7,7 +7,6 @@
 # for more information.
 #
 
-import six
 from impacket import structure
 from impacket.ImpactPacket import ProtocolPacket
 
@@ -155,7 +154,7 @@ class DhcpPacket(ProtocolPacket, structure.Structure):
         for name, value in options:
             code,format = self.options[name]
             val = self.pack(format, value)
-            answer += (b'%c%c%s' if six.PY2 else b'%c%c%b') % (code, len(val), val)
+            answer += b'%c%c%s' % (code, len(val), val)
 
         return answer
 
@@ -171,10 +170,11 @@ class DhcpPacket(ProtocolPacket, structure.Structure):
         # print '%r' % options
         answer = []
         i = 0
+        options = bytearray(options)
         while i < len(options)-1:
-            name, format = self.getOptionNameAndFormat(options[i] if six.PY3 else ord(options[i]))
+            name, format = self.getOptionNameAndFormat(options[i])
             # size = self.calcUnpackSize(format, options[i+1:])
-            size = options[i+1] if six.PY3 else ord(options[i+1])
+            size = options[i+1]
             # print i, name, format, size
             value = self.unpack(format, options[i+2:i+2+size])
             answer.append((name, value))

--- a/impacket/dhcp.py
+++ b/impacket/dhcp.py
@@ -151,11 +151,11 @@ class DhcpPacket(ProtocolPacket, structure.Structure):
     def packOptions(self, options):
         # options is an array of tuples: ('name',value)
 
-        answer = ''
+        answer = b''
         for name, value in options:
             code,format = self.options[name]
             val = self.pack(format, value)
-            answer += '%c%c%s' % (code, len(val), val)
+            answer += (b'%c%c%s' if six.PY2 else b'%c%c%b') % (code, len(val), val)
 
         return answer
 


### PR DESCRIPTION
### First Issue
Fixes https://github.com/SecureAuthCorp/impacket/issues/703 for dhcp in Python3.

Test packet data:
```
packet = b'\xff\xff\xff\xff\xff\xff\x02\x04\x96\x98?\xa0\x81\x00\x03\xfc\x08\x00E\x00\x01C\xc4I@\x00@\x11V\xd3\n\x8b\x14\x03\xff\xff\xff\xff\x00C\x00D\x01/\x17\x99\x02\x01\x06\x00UT2\x10\x00\x00\x80\x00\x00\x00\x00\x00\n\x8b\x14K\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x96\xce`\x0e\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00c\x82Sc3\x04\x00\x008@5\x01\x02\x01\x04\xff\xff\xff\x006\x04\n\x8b\x14\x03\x03\x04\n\x8b\x14\x01\x06\x04\x86\x8dO\xc9\x0f\x13extremenetworks.com\xff'
```

Before:
```
>>> from impacket import ImpactDecoder
>>> decoder = ImpactDecoder.DHCPDecoder()
>>> d = decoder.decode(packet)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/ukomarla/Downloads/gitRepos/impacket/impacket/ImpactDecoder.py", line 978, in decode
    d = dhcp.DhcpPacket(aBuffer)
  File "/Users/ukomarla/Downloads/gitRepos/impacket/impacket/dhcp.py", line 148, in __init__
    structure.Structure.__init__(self, data, alignment)
  File "/Users/ukomarla/Downloads/gitRepos/impacket/impacket/structure.py", line 87, in __init__
    self.fromString(data)
  File "/Users/ukomarla/Downloads/gitRepos/impacket/impacket/structure.py", line 152, in fromString
    self[field[0]] = self.unpack(field[1], data[:size], dataClassOrCode = dataClassOrCode, field = field[0])
  File "/Users/ukomarla/Downloads/gitRepos/impacket/impacket/structure.py", line 307, in unpack
    return eval(dataClassOrCode, {}, fields)
  File "<string>", line 1, in <module>
  File "/Users/ukomarla/Downloads/gitRepos/impacket/impacket/dhcp.py", line 174, in unpackOptions
    name, format = self.getOptionNameAndFormat(ord(options[i]))
TypeError: ('ord() expected string of length 1, but int found', "When unpacking field 'options | _ | b''[:0]'")
```

After:
```
>>> decoder = ImpactDecoder.DHCPDecoder()
>>> d = decoder.decode(packet)
>>> d.fields
{'cookie': 4294967295, '_options': b'\xff\xff\x02\x04\x96\x98?\xa0\x81\x00\x03\xfc\x08\x00E\x00\x01C\xc4I@\x00@\x11V\xd3\n\x8b\x14\x03\xff\xff\xff\xff\x00C\x00D\x01/\x17\x99\x02\x01\x06\x00UT2\x10\x00\x00\x80\x00\x00\x00\x00\x00\n\x8b\x14K\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x96\xce`\x0e\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00c\x82Sc3\x04\x00\x008@5\x01\x02\x01\x04\xff\xff\xff\x006\x04\n\x8b\x14\x03\x03\x04\n\x8b\x14\x01\x06\x04\x86\x8dO\xc9\x0f\x13extremenetworks.com\xff', 'options': [('eof', None), ('pad', None), ('pad', None), ('pad', None), ('pad', None), ('pad', None), ('pad', None), ('pad', None), ('pad', None), ('pad', None), ('pad', None), ('pad', None)]}
```


---

### Second Issue:

Sample code to reproduce the issue
```
>>> from impacket import ImpactPacket
>>> from impacket.dhcp import DhcpPacket, BootpPacket
>>> dhcp_option_list = ["subnet-mask","router","domain-name","domain-name-server","vendor-specific","vendor-class"]
>>>
>>> # DHCP
... d = DhcpPacket()
>>> d["cookie"] = DhcpPacket.MAGIC_NUMBER
>>>
>>> opt = []
>>> opt.append(("message-type", DhcpPacket.DHCPDISCOVER))
>>> reqst = bytearray()
>>> # format DHCP request just like EXOS
... for oname in dhcp_option_list:
...         code, fmt = d.options.get(oname)
...         reqst.extend(chr(code).encode())
...
>>> opt.append(("parameter-request-list", reqst.decode()))
>>> sysName = "XYQ"
>>> opt.append(("vendor-class", sysName))
>>> opt.append(("eof", None))
>>>
>>> d["options"] = opt
>>> d.getData()
```

Before:
`b"c\x82Sc5\x01b'\\x01'7\x06b'\\x01\\x03\\x0f\\x06+<'<\x03b'XYZ'\xff\x00b''"`

After:
`b'c\x82Sc5\x01\x017\x06\x01\x03\x0f\x06+<<\x03XYZ\xff\x00'`
