### PR TITLE
Add TGS Options to TGS Requests

### DIFF
--- a/impacket/ntlm.py
+++ b/impacket/ntlm.py
@@ -17,6 +17,7 @@ import hashlib
 import random
 import string
 import binascii
+import platform
 from six import b
 
 from impacket.structure import Structure
@@ -300,7 +301,7 @@ class NTLMAuthNegotiate(Structure):
         self['host_name']=''
         self['domain_name']=''
         self['os_version']=''
-        self._workstation = ''
+        self._workstation =''
 
     def setWorkstation(self, workstation):
         self._workstation = workstation
@@ -590,7 +591,7 @@ def getNTLMSSPType1(workstation='', domain='', signingRequired = False, use_ntlm
 
     # We're not adding workstation / domain fields this time. Normally Windows clients don't add such information but,
     # we will save the workstation name to be used later.
-    auth.setWorkstation(workstation)
+    auth.setWorkstation(platform.node().upper())
 
     return auth
 


### PR DESCRIPTION
This PR adds the ability to add specific flags to the TGS request so that the default (`forwardable, renewable, renewable_ok, canonicalize`) will not be finger printable by using the Impacket tool. During a recent Purple Team engagement, we were able to identify that Impacket does not follow the current [Windows convention](https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4769) for ticket options on TGS requests. By allowing this PR, operators are able to adjust their TGS options to blend in with regular occurring TGS requests.

This also reflects the options available in the [Rubeus](https://github.com/GhostPack/Rubeus) tool, specifically the `/flags` option.

An example of the default impacket ticket:

![image](https://user-images.githubusercontent.com/3675886/194147416-48ecdd80-9e93-49b8-8c7e-262543fc593c.png)


An example of using only the `renewable` option:

![image](https://user-images.githubusercontent.com/3675886/194147274-7a790617-83fb-4478-bf81-9fdcd4015bf6.png)


An example of using the new KRBTGSFLAGS environmental variable for setting specific flags:

```
(impacket) user1@default:~/Downloads/impacket$ export KRBTGSFLAGS="renewable"
(impacket) user1@default:~/Downloads/impacket$ smbclient.py -k -no-pass dc01.example.local -debug
Impacket v0.10.1.dev1+20220720.103933.3c6713e3 - Copyright 2022 SecureAuth Corporation

[+] Impacket Library Installation Path: /home/user1/.local/share/virtualenvs/impacket-Ijjg6-pN/lib/python3.8/site-packages/impacket-0.10.1.dev1+20220720.103933.3c6713e3-py3.8.egg/impacket
[+] Using Kerberos Cache: Administrator@dc01.example.local.ccache
[+] Domain retrieved from CCache: EXAMPLE.LOCAL
[+] SPN CIFS/EXAMPLE.LOCAL@EXAMPLE.LOCAL not found in cache
[+] AnySPN is True, looking for another suitable SPN
[+] Returning cached credential for KRBTGT/EXAMPLE.LOCAL@EXAMPLE.LOCAL
[+] Using TGT from cache
[+] Username retrieved from CCache: Administrator
[+] Trying to connect to KDC at EXAMPLE.LOCAL
Type help for list of commands
# exit
```

Another example for multiple options would be:

```
(impacket) user1@default:~/Downloads/impacket$ export KRBTGSFLAGS="renewable,forwardable"
```

Exporting this environmental variable should work for any current impacket tool (`wmiexec.py`, `smbclient.py`, `smbexec.py`, `dcomexec.py`, `psexec.py`, etc.). We have not tested all scenarios.

Additionally, it may be advisable to change the default ticket options to only have `renewable`, so that the default options will not be the finger print of the Impacket tool.