### PR TITLE
Fix Space bug

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -353,7 +353,7 @@ if __name__ == '__main__':
     shadowcredentials.add_argument('--shadow-target', action='store', required=False, help='target account (user or computer$) to populate msDS-KeyCredentialLink from')
     shadowcredentials.add_argument('--pfx-password', action='store', required=False,
                                    help='password for the PFX stored self-signed certificate (will be random if not set, not needed when exporting to PEM)')
-    shadowcredentials.add_argument('--export-type', action='store', required=False, choices=["PEM", " PFX"], type=lambda choice: choice.upper(), default="PFX",
+    shadowcredentials.add_argument('--export-type', action='store', required=False, choices=["PEM", "PFX"], type=lambda choice: choice.upper(), default="PFX",
                                    help='choose to export cert+private key in PEM or PFX (i.e. #PKCS12) (default: PFX))')
     shadowcredentials.add_argument('--cert-outfile-path', action='store', required=False, help='filename to store the generated self-signed PEM or PFX certificate and key')
 


### PR DESCRIPTION
There is a bug when trying to use the parameter `--export-type` with the value `" PFX"` instead of just using the default option the Shadow Credential attack will not output any certificate, as `ldapattack.py` only checks for `"PFX"` without a space.

[ldapattack.py line 319](https://github.com/SecureAuthCorp/impacket/blob/master/impacket/examples/ntlmrelayx/attacks/ldapattack.py#L319)

Greetings
