### PR TITLE
Update ccache.py to enhance the ability of dealing with cross realm ticket

### DIFF
--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -616,7 +616,8 @@ class CCache:
 
         creds = None
         if target != '':
-            principal = '%s@%s' % (target.upper(), domain.upper())
+            targetRealm = target.replace(target.split('.')[0]+'.', '')
+            principal = '%s@%s' % (target.upper(), targetRealm.upper())
             creds = ccache.getCredential(principal)
 
         TGT = None

--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -623,7 +623,10 @@ class CCache:
         TGT = None
         TGS = None
         if creds is None:
-            principal = 'krbtgt/%s@%s' % (domain.upper(), domain.upper())
+            targetRealm = domain
+            if target != '':
+                targetRealm = target.replace(target.split('.')[0]+'.', '')
+            principal = 'krbtgt/%s@%s' % (targetRealm.upper(), domain.upper())
             creds = ccache.getCredential(principal)
             if creds is not None:
                 LOG.debug('Using TGT from cache')

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -418,7 +418,11 @@ def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey):
 
     reqBody['kdc-options'] = constants.encodeFlags(opts)
     seq_set(reqBody, 'sname', serverName.components_to_asn1)
-    reqBody['realm'] = domain
+    targetServerName = ''
+    for i, c in enumerate(serverName.components):
+        targetServerName = c
+    targetRealm = targetServerName.replace(targetServerName.split('.')[0]+'.', '')
+    reqBody['realm'] = targetRealm
 
     now = datetime.datetime.utcnow() + datetime.timedelta(days=1)
 


### PR DESCRIPTION
when using the example script `atexec.py` with a cross realm ticket, I got a wrong realm error:

```
Impacket v0.10.0 - Copyright 2022 SecureAuth Corporation

[!] This will work ONLY on Windows >= Vista
[-] Kerberos SessionError: KDC_ERR_WRONG_REALM(Reserved for future use)
```

so I started debugging it and located this issue to lib file `impacket/krb5/ccache.py`, I modified it, get the right realm from the variable `target` for variable `principal`, after that, the issue is solved

and I also made a little change to `impacket/krb5/kerberosv5.py` so corss realm TGT (referral TGT) ticket can be handled correctly too