### PR TITLE
Update httprelayclient.py to force NTLM auth if anonymous auth is enabled (ADCS)

### DIFF
--- a/impacket/examples/ntlmrelayx/clients/httprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/httprelayclient.py
@@ -70,6 +70,7 @@ class HTTPRelayClient(ProtocolClient):
             LOG.error('No authentication requested by the server for url %s' % self.targetHost)
             if self.serverConfig.isADCSAttack:
                 LOG.info('IIS cert server may allow anonymous authentication, sending NTLM auth anyways')
+                self.authenticationMethod = "NTLM"
             else:
                 return False
 


### PR DESCRIPTION
The httprelayclient has an option where it tries "sending NTLM auth anyways" if the `--adcs` flag is specified.
The client will however not set the variable `self.authenticationMethod` and the code will subsequently fail.

If the variable is not set, the following error will occur:
```
[*] Status code returned: 200. Authentication does not seem required for URL
[-] No authentication requested by the server for url XXX
[*] IIS cert server may allow anonymous authentication, sending NTLM auth anyways
[+] Exception:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/impacket/examples/ntlmrelayx/servers/smbrelayserver.py", line 286, in SmbSessionSetup
    challengeMessage = self.do_ntlm_negotiate(client, token)
  File "/usr/lib/python3/dist-packages/impacket/examples/ntlmrelayx/servers/smbrelayserver.py", line 866, in do_ntlm_negotiate
    return client.sendNegotiate(token)
  File "/usr/lib/python3/dist-packages/impacket/examples/ntlmrelayx/clients/httprelayclient.py", line 83, in sendNegotiate
    serverChallengeBase64 = re.search(('%s ([a-zA-Z0-9+/]+={0,2})' % self.authenticationMethod), res.getheader('WWW-Authenticate')).group(1)
  File "/usr/lib/python3.10/re.py", line 200, in search
    return _compile(pattern, flags).search(string)
TypeError: expected string or bytes-like object
```

This pull requests sets the `self.authenticationMethod` to `NTLM` if the respective branch is executed.