### PR TITLE
Allow weak TLS ciphers for LDAP connections

### DIFF
--- a/examples/addcomputer.py
+++ b/examples/addcomputer.py
@@ -148,7 +148,7 @@ class ADDCOMPUTER:
             connectTo = self.__targetIp
         try:
             user = '%s\\%s' % (self.__domain, self.__username)
-            tls = ldap3.Tls(validate=ssl.CERT_NONE, version=ssl.PROTOCOL_TLSv1_2)
+            tls = ldap3.Tls(validate=ssl.CERT_NONE, version=ssl.PROTOCOL_TLSv1_2, ciphers='ALL:@SECLEVEL=0')
             try:
                 ldapServer = ldap3.Server(connectTo, use_ssl=True, port=self.__port, get_info=ldap3.ALL, tls=tls)
                 if self.__doKerberos:
@@ -164,7 +164,7 @@ class ADDCOMPUTER:
 
             except ldap3.core.exceptions.LDAPSocketOpenError:
                 #try tlsv1
-                tls = ldap3.Tls(validate=ssl.CERT_NONE, version=ssl.PROTOCOL_TLSv1)
+                tls = ldap3.Tls(validate=ssl.CERT_NONE, version=ssl.PROTOCOL_TLSv1_2, ciphers='ALL:@SECLEVEL=0')
                 ldapServer = ldap3.Server(connectTo, use_ssl=True, port=self.__port, get_info=ldap3.ALL, tls=tls)
                 if self.__doKerberos:
                     ldapConn = ldap3.Connection(ldapServer)

--- a/examples/addcomputer.py
+++ b/examples/addcomputer.py
@@ -164,7 +164,7 @@ class ADDCOMPUTER:
 
             except ldap3.core.exceptions.LDAPSocketOpenError:
                 #try tlsv1
-                tls = ldap3.Tls(validate=ssl.CERT_NONE, version=ssl.PROTOCOL_TLSv1_2, ciphers='ALL:@SECLEVEL=0')
+                tls = ldap3.Tls(validate=ssl.CERT_NONE, version=ssl.PROTOCOL_TLSv1, ciphers='ALL:@SECLEVEL=0')
                 ldapServer = ldap3.Server(connectTo, use_ssl=True, port=self.__port, get_info=ldap3.ALL, tls=tls)
                 if self.__doKerberos:
                     ldapConn = ldap3.Connection(ldapServer)

--- a/examples/rbcd.py
+++ b/examples/rbcd.py
@@ -483,7 +483,7 @@ def init_ldap_connection(target, tls_version, args, domain, username, password, 
     if tls_version is not None:
         use_ssl = True
         port = 636
-        tls = ldap3.Tls(validate=ssl.CERT_NONE, version=tls_version)
+        tls = ldap3.Tls(validate=ssl.CERT_NONE, version=tls_version, ciphers='ALL:@SECLEVEL=0')
     else:
         use_ssl = False
         port = 389


### PR DESCRIPTION
In Python3.10, the default TLS cipher settings have been set to a more secure level. See: https://bugs.python.org/issue43998

The change makes sense for general users, but Impacket is regularly used to access old Windows computers that present certs signed using MD5 or don't support anything higher than TLSv1.0. Impacket users arguably care more about exploiting weaknesses than requiring super secure TLS settings, so this patch lowers the cipher settings to the lowest value. This is in line with the current behavior of not validating certificates at all.

Note that this will not help if the TLS handshake fails due to certificate issues until this bug is fixed in ldap3: https://github.com/cannatag/ldap3/pull/1067