### PR TITLE
Add dissect.esedb compatibility to secretsdump

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,8 @@ setup(
     scripts=glob.glob(os.path.join('examples', '*.py')),
     data_files=data_files,
     install_requires=['pyasn1>=0.2.3', 'pycryptodomex', 'pyOpenSSL>=21.0.0', 'six', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6',
-                      'ldapdomaindump>=0.9.0', 'flask>=1.0', 'future', 'charset_normalizer', 'dsinternals'],
+                      'ldapdomaindump>=0.9.0', 'flask>=1.0', 'future', 'charset_normalizer', 'dsinternals',
+                      'dissect.esedb>=3.4'],
     extras_require={'pyreadline:sys_platform=="win32"': [],
                     },
     classifiers=[


### PR DESCRIPTION
See #1448. I'm not sure how tightly integrated you'd want this to be in impacket, so I opted for a simple compatibility shim. This can of course be changed to a full replacement of the existing ESE implementation.

@dirkjanm 