### PR TITLE
Added 'simple' authentication choice for scripts that use LDAPConnection.

### DIFF
--- a/examples/GetADUsers.py
+++ b/examples/GetADUsers.py
@@ -226,14 +226,15 @@ if __name__ == '__main__':
 
     group.add_argument('-authentication-choice', action="store", choices=['simple','sicilyNegotiate'], default='sicilyNegotiate', 
                        help='LDAP authentication choice between simple and NTLM.'
-                            ' If ommited it use sicilyNegotiate (NTLM).')
+                            '\'simple\' must be used with password and not NTLM.'
+                            'If omitted it use sicilyNegotiate (NTLM).')
 
     group = parser.add_argument_group('connection')
     group.add_argument('-dc-ip', action='store', metavar='ip address', help='IP Address of the domain controller. If '
-                                                                              'ommited it use the domain part (FQDN) '
+                                                                              'omitted it use the domain part (FQDN) '
                                                                               'specified in the target parameter')
     group.add_argument('-dc-host', action='store', metavar='hostname', help='Hostname of the domain controller to use. '
-                                                                              'If ommited, the domain part (FQDN) '
+                                                                              'If omitted, the domain part (FQDN) '
                                                                               'specified in the account parameter will be used')
 
     if len(sys.argv)==1:
@@ -258,7 +259,7 @@ if __name__ == '__main__':
         logging.critical('Domain should be specified!')
         sys.exit(1)
 
-    if password == '' and username != '' and options.hashes is None and options.no_pass is False and options.aesKey is None:
+    if password == '' and username != '' and options.authentication_choice == 'simple' or (options.hashes is None and options.no_pass is False and options.aesKey is None):
         from getpass import getpass
         password = getpass("Password:")
 

--- a/examples/GetADUsers.py
+++ b/examples/GetADUsers.py
@@ -47,6 +47,7 @@ class GetADUsers:
         self.__target = None
         self.__lmhash = ''
         self.__nthash = ''
+        self.__authenticationChoice = cmdLineOptions.authentication_choice
         self.__aesKey = cmdLineOptions.aesKey
         self.__doKerberos = cmdLineOptions.k
         #[!] in this script the value of -dc-ip option is self.__kdcIP and the value of -dc-host option is self.__kdcHost
@@ -149,7 +150,7 @@ class GetADUsers:
         try:
             ldapConnection = ldap.LDAPConnection('ldap://%s' % self.__target, self.baseDN, self.__kdcIP)
             if self.__doKerberos is not True:
-                ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
+                ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash, self.__authenticationChoice)
             else:
                 ldapConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
                                              self.__aesKey, kdcHost=self.__kdcIP)
@@ -158,7 +159,7 @@ class GetADUsers:
                 # We need to try SSL
                 ldapConnection = ldap.LDAPConnection('ldaps://%s' % self.__target, self.baseDN, self.__kdcIP)
                 if self.__doKerberos is not True:
-                    ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
+                    ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash, self.__authenticationChoice)
                 else:
                     ldapConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
                                                  self.__aesKey, kdcHost=self.__kdcIP)
@@ -222,6 +223,10 @@ if __name__ == '__main__':
                                                        'line')
     group.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key to use for Kerberos Authentication '
                                                                             '(128 or 256 bits)')
+
+    group.add_argument('-authentication-choice', action="store", choices=['simple','sicilyNegotiate'], default='sicilyNegotiate', 
+                       help='LDAP authentication choice between simple and NTLM.'
+                            ' If ommited it use sicilyNegotiate (NTLM).')
 
     group = parser.add_argument_group('connection')
     group.add_argument('-dc-ip', action='store', metavar='ip address', help='IP Address of the domain controller. If '

--- a/examples/GetNPUsers.py
+++ b/examples/GetNPUsers.py
@@ -396,14 +396,15 @@ if __name__ == '__main__':
 
     group.add_argument('-authentication-choice', action="store", choices=['simple','sicilyNegotiate'], default='sicilyNegotiate', 
                        help='LDAP authentication choice between simple and NTLM.'
-                            ' If ommited it use sicilyNegotiate (NTLM).')
+                            '\'simple\' must be used with password and not NTLM.'
+                            'If omitted it use sicilyNegotiate (NTLM).')
     
     group = parser.add_argument_group('connection')
     group.add_argument('-dc-ip', action='store', metavar='ip address', help='IP Address of the domain controller. If '
-                                                                              'ommited it use the domain part (FQDN) '
+                                                                              'omitted it use the domain part (FQDN) '
                                                                               'specified in the target parameter')
     group.add_argument('-dc-host', action='store', metavar='hostname', help='Hostname of the domain controller to use. '
-                                                                              'If ommited, the domain part (FQDN) '
+                                                                              'If omitted, the domain part (FQDN) '
                                                                               'specified in the account parameter will be used')
 
     if len(sys.argv)==1:
@@ -442,7 +443,7 @@ if __name__ == '__main__':
         logging.critical('Domain should be specified!')
         sys.exit(1)
 
-    if password == '' and username != '' and options.hashes is None and options.no_pass is False and options.aesKey is None:
+    if password == '' and username != '' and options.authentication_choice == 'simple' or (options.hashes is None and options.no_pass is False and options.aesKey is None):
         from getpass import getpass
         password = getpass("Password:")
 

--- a/examples/GetNPUsers.py
+++ b/examples/GetNPUsers.py
@@ -73,6 +73,7 @@ class GetUserNoPreAuth:
         self.__target = None
         self.__lmhash = ''
         self.__nthash = ''
+        self.__authenticationChoice = cmdLineOptions.authentication_choice
         self.__no_pass = cmdLineOptions.no_pass
         self.__outputFileName = cmdLineOptions.outputfile
         self.__outputFormat = cmdLineOptions.format
@@ -242,7 +243,7 @@ class GetUserNoPreAuth:
         try:
             ldapConnection = ldap.LDAPConnection('ldap://%s' % self.__target, self.baseDN, self.__kdcIP)
             if self.__doKerberos is not True:
-                ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
+                ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash, self.__authenticationChoice)
             else:
                 ldapConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
                                              self.__aesKey, kdcHost=self.__kdcIP)
@@ -251,7 +252,7 @@ class GetUserNoPreAuth:
                 # We need to try SSL
                 ldapConnection = ldap.LDAPConnection('ldaps://%s' % self.__target, self.baseDN, self.__kdcIP)
                 if self.__doKerberos is not True:
-                    ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
+                    ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash, self.__authenticationChoice)
                 else:
                     ldapConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
                                                  self.__aesKey, kdcHost=self.__kdcIP)
@@ -393,6 +394,10 @@ if __name__ == '__main__':
     group.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key to use for Kerberos Authentication '
                                                                             '(128 or 256 bits)')
 
+    group.add_argument('-authentication-choice', action="store", choices=['simple','sicilyNegotiate'], default='sicilyNegotiate', 
+                       help='LDAP authentication choice between simple and NTLM.'
+                            ' If ommited it use sicilyNegotiate (NTLM).')
+    
     group = parser.add_argument_group('connection')
     group.add_argument('-dc-ip', action='store', metavar='ip address', help='IP Address of the domain controller. If '
                                                                               'ommited it use the domain part (FQDN) '

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -481,15 +481,16 @@ if __name__ == '__main__':
                                                                           '(128 or 256 bits)')
     group.add_argument('-authentication-choice', action="store", choices=['simple','sicilyNegotiate'], default='sicilyNegotiate', 
                        help='LDAP authentication choice between simple and NTLM.'
-                            ' If ommited it use sicilyNegotiate (NTLM).')
+                            '\'simple\' must be used with password and not NTLM.'
+                            'If omitted it use sicilyNegotiate (NTLM).')
 
     group = parser.add_argument_group('connection')
     group.add_argument('-dc-ip', action='store', metavar='ip address', help='IP Address of the domain controller. If '
-                                                                            'ommited it use the domain part (FQDN) '
+                                                                            'omitted it use the domain part (FQDN) '
                                                                             'specified in the target parameter. Ignored'
                                                                             'if -target-domain is specified.')
     group.add_argument('-dc-host', action='store', metavar='hostname', help='Hostname of the domain controller to use. '
-                                                                            'If ommited, the domain part (FQDN) '
+                                                                            'If omitted, the domain part (FQDN) '
                                                                             'specified in the account parameter will be used')
 
     if len(sys.argv) == 1:
@@ -519,7 +520,7 @@ if __name__ == '__main__':
     else:
         targetDomain = userDomain
 
-    if password == '' and username != '' and options.hashes is None and options.no_pass is False and options.aesKey is None:
+    if password == '' and username != '' and options.authentication_choice == 'simple' or (options.hashes is None and options.no_pass is False and options.aesKey is None):
         from getpass import getpass
 
         password = getpass("Password:")

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -80,6 +80,7 @@ class GetUserSPNs:
         self.__targetDomain = target_domain
         self.__lmhash = ''
         self.__nthash = ''
+        self.__authenticationChoice = cmdLineOptions.authentication_choice
         self.__outputFileName = cmdLineOptions.outputfile
         self.__usersFile = cmdLineOptions.usersfile
         self.__aesKey = cmdLineOptions.aesKey
@@ -267,7 +268,7 @@ class GetUserSPNs:
         try:
             ldapConnection = ldap.LDAPConnection('ldap://%s' % self.__target, self.baseDN, self.__kdcIP)
             if self.__doKerberos is not True:
-                ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
+                ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash, self.__authenticationChoice)
             else:
                 ldapConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash,
                                              self.__nthash,
@@ -277,7 +278,7 @@ class GetUserSPNs:
                 # We need to try SSL
                 ldapConnection = ldap.LDAPConnection('ldaps://%s' % self.__target, self.baseDN, self.__kdcIP)
                 if self.__doKerberos is not True:
-                    ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
+                    ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash, self.__authenticationChoice)
                 else:
                     ldapConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash,
                                                  self.__nthash,
@@ -478,6 +479,9 @@ if __name__ == '__main__':
                             'line')
     group.add_argument('-aesKey', action="store", metavar="hex key", help='AES key to use for Kerberos Authentication '
                                                                           '(128 or 256 bits)')
+    group.add_argument('-authentication-choice', action="store", choices=['simple','sicilyNegotiate'], default='sicilyNegotiate', 
+                       help='LDAP authentication choice between simple and NTLM.'
+                            ' If ommited it use sicilyNegotiate (NTLM).')
 
     group = parser.add_argument_group('connection')
     group.add_argument('-dc-ip', action='store', metavar='ip address', help='IP Address of the domain controller. If '

--- a/examples/findDelegation.py
+++ b/examples/findDelegation.py
@@ -61,6 +61,7 @@ class FindDelegation:
         self.__targetDomain = target_domain
         self.__lmhash = ''
         self.__nthash = ''
+        self.__authenticationChoice = cmdLineOptions.authentication_choice
         self.__aesKey = cmdLineOptions.aesKey
         self.__doKerberos = cmdLineOptions.k
         #[!] in this script the value of -dc-ip option is self.__kdcIP and the value of -dc-host option is self.__kdcHost
@@ -125,7 +126,7 @@ class FindDelegation:
         try:
             ldapConnection = ldap.LDAPConnection('ldap://%s' % self.__target, self.baseDN, self.__kdcIP)
             if self.__doKerberos is not True:
-                ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
+                ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash, self.__authenticationChoice)
             else:
                 ldapConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
                                              self.__aesKey, kdcHost=self.__kdcIP)
@@ -134,7 +135,7 @@ class FindDelegation:
                 # We need to try SSL
                 ldapConnection = ldap.LDAPConnection('ldaps://%s' % self.__target, self.baseDN, self.__kdcIP)
                 if self.__doKerberos is not True:
-                    ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
+                    ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash, self.__authenticationChoice)
                 else:
                     ldapConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
                                                  self.__aesKey, kdcHost=self.__kdcIP)
@@ -269,6 +270,10 @@ if __name__ == '__main__':
     group.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key to use for Kerberos Authentication '
                                                                             '(128 or 256 bits)')
 
+    group.add_argument('-authentication-choice', action="store", choices=['simple','sicilyNegotiate'], default='sicilyNegotiate', 
+                       help='LDAP authentication choice between simple and NTLM.'
+                            ' If ommited it use sicilyNegotiate (NTLM).')
+    
     group = parser.add_argument_group('connection')
     group.add_argument('-dc-ip', action='store', metavar='ip address', help='IP Address of the domain controller. If '
                                                                               'ommited it use the domain part (FQDN) '

--- a/examples/findDelegation.py
+++ b/examples/findDelegation.py
@@ -272,15 +272,16 @@ if __name__ == '__main__':
 
     group.add_argument('-authentication-choice', action="store", choices=['simple','sicilyNegotiate'], default='sicilyNegotiate', 
                        help='LDAP authentication choice between simple and NTLM.'
-                            ' If ommited it use sicilyNegotiate (NTLM).')
+                            '\'simple\' must be used with password and not NTLM.'
+                            'If omitted it use sicilyNegotiate (NTLM).')
     
     group = parser.add_argument_group('connection')
     group.add_argument('-dc-ip', action='store', metavar='ip address', help='IP Address of the domain controller. If '
-                                                                              'ommited it use the domain part (FQDN) '
+                                                                              'omitted it use the domain part (FQDN) '
                                                                               'specified in the target parameter. Ignored'
                                                                               'if -target-domain is specified.')
     group.add_argument('-dc-host', action='store', metavar='hostname', help='Hostname of the domain controller to use. '
-                                                                              'If ommited, the domain part (FQDN) '
+                                                                              'If omitted, the domain part (FQDN) '
                                                                               'specified in the account parameter will be used')
 
     if len(sys.argv)==1:
@@ -310,7 +311,7 @@ if __name__ == '__main__':
     else:
         targetDomain = userDomain
 
-    if password == '' and username != '' and options.hashes is None and options.no_pass is False and options.aesKey is None:
+    if password == '' and username != '' and options.authentication_choice == 'simple' or (options.hashes is None and options.no_pass is False and options.aesKey is None):
         from getpass import getpass
         password = getpass("Password:")
 


### PR DESCRIPTION
I ran into an environment that denied Kerberos or NTLM authentication and the only way for me to authenticate was to use the authentication choice `simple`. Since that I had to modify `GetUserSPNs.py` to achieve this, I decided to integrate it to every script that used `LDAPConnection`, make the option an argument in the usage and do a pull request for everyone to enjoy.