### PR TITLE
[ntlmrelayx] SID Bruteforce over SMB

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -148,6 +148,7 @@ def start_servers(options, threads):
         c.setExeFile(options.e)
         c.setCommand(options.c)
         c.setEnumLocalAdmins(options.enum_local_admins)
+        c.setEnumDomain(options.enum_domain)
         c.setDisableMulti(options.no_multirelay)
         c.setEncoding(codec)
         c.setMode(mode)
@@ -290,6 +291,7 @@ if __name__ == '__main__':
     smboptions.add_argument('-e', action='store', required=False, metavar = 'FILE', help='File to execute on the target system. '
                                      'If not specified, hashes will be dumped (secretsdump.py must be in the same directory)')
     smboptions.add_argument('--enum-local-admins', action='store_true', required=False, help='If relayed user is not admin, attempt SAMR lookup to see who is (only works pre Win 10 Anniversary)')
+    smboptions.add_argument('--enum-domain', action='store_true', required=False, help='Enumerate domain')
 
     #RPC arguments
     rpcoptions = parser.add_argument_group("RPC client options")

--- a/impacket/examples/ntlmrelayx/attacks/smbattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/smbattack.py
@@ -59,6 +59,20 @@ class SMBAttack(ProtocolAttack):
             self.shell = MiniImpacketShell(self.__SMBConnection, self.tcpshell)
             self.shell.cmdloop()
             return
+        if self.config.enumDomain:
+            from impacket.examples.ntlmrelayx.utils.enum import EnumDomain
+            try:
+                LOG.info("Enumerate domain though SID Bruteforce...")
+                enumDomain = EnumDomain(self.__SMBConnection)
+                domainUsers = enumDomain.enumerateDomain()
+                with open("domain_enum.csv","w+") as f:
+                    for domainUser in domainUsers:
+                        (sid, domain, username, usage) = domainUser
+                        LOG.debug( "%s: %s\\%s (%s)" % (sid, domain, username,usage))
+                        f.write("%s,%s\\%s,%s\n" % (sid, domain, username,usage))
+                LOG.info("Bruteforce finish! Results written in domain_enum.csv")
+            except Exception as e:
+                LOG.error(str(e))
         if self.config.exeFile is not None:
             result = self.installService.install()
             if result is True:

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -62,6 +62,7 @@ class NTLMRelayxConfig:
         self.exeFile = None
         self.interactive = False
         self.enumLocalAdmins = False
+        self.enumDomain = False
         self.SMBServerChallenge = None
 
         # RPC options
@@ -139,6 +140,9 @@ class NTLMRelayxConfig:
 
     def setEnumLocalAdmins(self, enumLocalAdmins):
         self.enumLocalAdmins = enumLocalAdmins
+
+    def setEnumDomain(self, enumDomain):
+        self.enumDomain = enumDomain
 
     def setDisableMulti(self, disableMulti):
         self.disableMulti = disableMulti

--- a/impacket/examples/ntlmrelayx/utils/enum.py
+++ b/impacket/examples/ntlmrelayx/utils/enum.py
@@ -15,8 +15,9 @@
 #   Ronnie Flathers / @ropnop
 #
 from impacket.dcerpc.v5 import transport, lsat, samr, lsad
+from impacket.dcerpc.v5.samr import SID_NAME_USE
 from impacket.dcerpc.v5.dtypes import MAXIMUM_ALLOWED
-
+from impacket.dcerpc.v5.rpcrt import DCERPCException
 
 class EnumLocalAdmins:
     def __init__(self, smbConnection):
@@ -64,3 +65,51 @@ class EnumLocalAdmins:
             names.append("{}\\{}".format(resp['ReferencedDomains']['Domains'][item['DomainIndex']]['Name'], item['Name']))
         dce.disconnect()
         return names
+
+class EnumDomain:
+    def __init__(self, smbConnection):
+        self.__smbConnection = smbConnection
+        self.__lsaBinding = r'ncacn_np:445[\pipe\lsarpc]'
+
+    def enumerateDomain(self):
+        domainUsers = self.__getDomainUsers()
+        return domainUsers
+
+    def __getDomainUsers(self):
+        
+        rpc = transport.DCERPCTransportFactory(self.__lsaBinding)
+        rpc.set_smb_connection(self.__smbConnection)
+        dce = rpc.get_dce_rpc()
+        dce.connect()
+        dce.bind(lsat.MSRPC_UUID_LSAT)
+        resp = lsad.hLsarOpenPolicy2(dce, MAXIMUM_ALLOWED | lsat.POLICY_LOOKUP_NAMES)
+        resp2 = lsad.hLsarQueryInformationPolicy2(dce, resp['PolicyHandle'],lsad.POLICY_INFORMATION_CLASS.PolicyPrimaryDomainInformation)
+        domainSid = resp2['PolicyInformation']['PolicyPrimaryDomainInfo']['Sid'].formatCanonical()
+        resolved_rids = []
+        maxRidBruteforce = 50000
+        batchSize = 5000
+        
+        for count in range(int(maxRidBruteforce / batchSize + 1)):
+            step = count*batchSize
+            if step == maxRidBruteforce:
+                break
+            sids = list()
+            for i in range(step, step + batchSize):
+                sids.append('%s-%d' % (domainSid,i))
+            try:
+                lsat.hLsarLookupSids(dce, resp['PolicyHandle'], sids)
+            except DCERPCException as e:
+                if 'STATUS_NONE_MAPPED' in str(e):
+                    continue
+                elif 'STATUS_SOME_NOT_MAPPED' in str(e):
+                    resp3 = e.get_packet()
+                else:
+                    break
+
+            for index, user in enumerate(resp3['TranslatedNames']['Names']):
+                if user['Use'] != SID_NAME_USE.SidTypeUnknown:
+                    resolved_rids.append((('%s-%d' % (domainSid,count + index)), resp3['ReferencedDomains']['Domains'][user['DomainIndex']]['Name'], user['Name'],
+                        SID_NAME_USE.enumItems(user['Use']).name))
+
+        dce.disconnect()
+        return resolved_rids


### PR DESCRIPTION
This PR will add domain enumeration through SID bruteforce in ntlmrelayx.
This allows to retrieve a list of valid users with ntlmrelay via SMB authentication, and by targeting any domain joined machine.

![image](https://user-images.githubusercontent.com/68540460/211871364-0f834589-514c-47e4-bd20-66260dcc9ffa.png)

