### PR TITLE
Modify build and test job for Python 3.6

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -40,7 +40,7 @@ jobs:
   test:
     name: Run unit tests and build wheel
     needs: lint
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     if:
       github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
       github.repository
@@ -48,11 +48,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9"]
         experimental: [false]
+        os: [ubuntu-latest]
         include:
+          - python-version: "3.6"
+            experimental: false
+            os: ubuntu-20.04
           - python-version: "3.10"
             experimental: true
+            os: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
 
     steps:


### PR DESCRIPTION
Python 3.6 has reached end-of-live, for that reason is no longer support on newer ubuntu version: actions/setup-python#544. Changed to ubuntu-20.04.