### PR TITLE
Modified getKerberosTGS function in GetUserSPNs.py

### DIFF
--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -394,7 +394,7 @@ class GetUserSPNs:
                         principalName.components = [downLevelLogonName]
 
                         tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(principalName, self.__domain,
-                                                                                self.__kdcHost,
+                                                                                self.__kdcIP,
                                                                                 TGT['KDC_REP'], TGT['cipher'],
                                                                                 TGT['sessionKey'])
                         self.outputTGS(tgs, oldSessionKey, sessionKey, sAMAccountName,
@@ -432,7 +432,7 @@ class GetUserSPNs:
                 principalName.components = [username]
 
                 tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(principalName, self.__domain,
-                                                                        self.__kdcHost,
+                                                                        self.__kdcIP,
                                                                         TGT['KDC_REP'], TGT['cipher'],
                                                                         TGT['sessionKey'])
                 self.outputTGS(tgs, oldSessionKey, sessionKey, username, username, fd)


### PR DESCRIPTION
After PR #1363, the function _getKerberosTGS()_ in _GetUserSPNs.py_ receives the KDC host name instead of its IP address. This PR modifies that. It should fix #1468.