### PR TITLE
Security fixes for priv esc vulns in smbexec and secretsdump

### DIFF
--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -53,7 +53,6 @@ from impacket.dcerpc.v5 import transport, scmr
 from impacket.krb5.keytab import Keytab
 
 OUTPUT_FILENAME = '__output'
-BATCH_FILENAME  = 'execute.bat'
 SMBSERVER_DIR   = '__tmp'
 DUMMY_SHARE     = 'TMP'
 SERVICE_NAME    = 'BTOBTO'
@@ -176,7 +175,6 @@ class RemoteShell(cmd.Cmd):
         self.__share = share
         self.__mode = mode
         self.__output = '\\\\127.0.0.1\\' + self.__share + '\\' + OUTPUT_FILENAME
-        self.__batchFile = '%TEMP%\\' + BATCH_FILENAME
         self.__outputBuffer = b''
         self.__command = ''
         self.__shell = '%COMSPEC% /Q /c '
@@ -274,12 +272,14 @@ class RemoteShell(cmd.Cmd):
             data = '$ProgressPreference="SilentlyContinue";' + data
             data = self.__pwsh + b64encode(data.encode('utf-16le')).decode()
 
-        command = self.__shell + 'echo ' + data + ' ^> ' + self.__output + ' 2^>^&1 > ' + self.__batchFile + ' & ' + \
-                  self.__shell + self.__batchFile
+        batchFile = '%SYSTEMROOT%\\' + ''.join([random.choice(string.ascii_letters) for _ in range(8)]) + '.bat'
+                
+        command = self.__shell + 'echo ' + data + ' ^> ' + self.__output + ' 2^>^&1 > ' + batchFile + ' & ' + \
+                  self.__shell + batchFile
 
         if self.__mode == 'SERVER':
             command += ' & ' + self.__copyBack
-        command += ' & ' + 'del ' + self.__batchFile
+        command += ' & ' + 'del ' + batchFile
 
         logging.debug('Executing %s' % command)
         resp = scmr.hRCreateServiceW(self.__scmr, self.__scHandle, self.__serviceName, self.__serviceName,

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -36,6 +36,8 @@ from __future__ import division
 from __future__ import print_function
 import sys
 import os
+import random
+import string
 import cmd
 import argparse
 try:

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -886,11 +886,11 @@ class RemoteOperations:
         except:
             raise Exception("Can't open %s hive" % hiveName)
         keyHandle = ans['phkResult']
-        rrp.hBaseRegSaveKey(self.__rrp, keyHandle, tmpFileName)
+        rrp.hBaseRegSaveKey(self.__rrp, keyHandle, '..\\Temp\\'+tmpFileName)
         rrp.hBaseRegCloseKey(self.__rrp, keyHandle)
         rrp.hBaseRegCloseKey(self.__rrp, regHandle)
         # Now let's open the remote file, so it can be read later
-        remoteFileName = RemoteFile(self.__smbConnection, 'SYSTEM32\\'+tmpFileName)
+        remoteFileName = RemoteFile(self.__smbConnection, 'Temp\\'+tmpFileName)
         return remoteFileName
 
     def saveSAM(self):


### PR DESCRIPTION
Storing the SAM and SECURITY hive in a folder where local unprivileged users can read them results in a privilege escalation vulnerability.

Storing the execute.bat in C:\Windows\Temp where local unprivileged users can prepopulate them (and thus have write access)  results in a privilege escalation vulnerability.

https://disobey.fi/2023/profile/finding_vulnerabilities_in_offensive
