### PR TITLE
Encode passwords before deriving Kerberos keys

### DIFF
--- a/impacket/krb5/crypto.py
+++ b/impacket/krb5/crypto.py
@@ -58,7 +58,7 @@ from Cryptodome.Cipher import AES, DES3, ARC4, DES
 from Cryptodome.Hash import HMAC, MD4, MD5, SHA
 from Cryptodome.Protocol.KDF import PBKDF2
 from Cryptodome.Util.number import GCD as gcd
-from six import b, PY3, indexbytes
+from six import b, PY3, indexbytes, binary_type
 
 
 def get_random_bytes(lenBytes):
@@ -366,9 +366,9 @@ class _DESCBC(_SimplifiedEnctype):
     def string_to_key(cls, string, salt, params):
         if params is not None and params != b'':
             raise ValueError('Invalid DES string-to-key parameters')
-        if not isinstance(string, six.binary_type):
+        if not isinstance(string, binary_type):
             string = string.encode("utf-8")
-        if not isinstance(salt, six.binary_type):
+        if not isinstance(salt, binary_type):
             salt = salt.encode("utf-8")
 
         key = cls.mit_des_string_to_key(string, salt)
@@ -413,9 +413,9 @@ class _DES3CBC(_SimplifiedEnctype):
     def string_to_key(cls, string, salt, params):
         if params is not None and params != b'':
             raise ValueError('Invalid DES3 string-to-key parameters')
-        if not isinstance(string, six.binary_type):
+        if not isinstance(string, binary_type):
             string = string.encode("utf-8")
-        if not isinstance(salt, six.binary_type):
+        if not isinstance(salt, binary_type):
             salt = salt.encode("utf-8")
 
         k = cls.random_to_key(_nfold(string + salt, 21))
@@ -443,9 +443,9 @@ class _AESEnctype(_SimplifiedEnctype):
 
     @classmethod
     def string_to_key(cls, string, salt, params):
-        if not isinstance(string, six.binary_type):
+        if not isinstance(string, binary_type):
             string = string.encode("utf-8")
-        if not isinstance(salt, six.binary_type):
+        if not isinstance(salt, binary_type):
             salt = salt.encode("utf-8")
 
         (iterations,) = unpack('>L', params or b'\x00\x00\x10\x00')

--- a/impacket/krb5/crypto.py
+++ b/impacket/krb5/crypto.py
@@ -366,6 +366,11 @@ class _DESCBC(_SimplifiedEnctype):
     def string_to_key(cls, string, salt, params):
         if params is not None and params != b'':
             raise ValueError('Invalid DES string-to-key parameters')
+        if not isinstance(string, bytes):
+            string = string.encode("utf-8")
+        if not isinstance(salt, bytes):
+            salt = salt.encode("utf-8")
+
         key = cls.mit_des_string_to_key(string, salt)
         return key
     
@@ -408,6 +413,11 @@ class _DES3CBC(_SimplifiedEnctype):
     def string_to_key(cls, string, salt, params):
         if params is not None and params != b'':
             raise ValueError('Invalid DES3 string-to-key parameters')
+        if not isinstance(string, bytes):
+            string = string.encode("utf-8")
+        if not isinstance(salt, bytes):
+            salt = salt.encode("utf-8")
+
         k = cls.random_to_key(_nfold(string + salt, 21))
         return cls.derive(k, b'kerberos')
 
@@ -433,6 +443,11 @@ class _AESEnctype(_SimplifiedEnctype):
 
     @classmethod
     def string_to_key(cls, string, salt, params):
+        if not isinstance(string, bytes):
+            string = string.encode("utf-8")
+        if not isinstance(salt, bytes):
+            salt = salt.encode("utf-8")
+
         (iterations,) = unpack('>L', params or b'\x00\x00\x10\x00')
         prf = lambda p, s: HMAC.new(p, s, SHA).digest()
         seed = PBKDF2(string, salt, cls.seedsize, iterations, prf)

--- a/impacket/krb5/crypto.py
+++ b/impacket/krb5/crypto.py
@@ -366,9 +366,9 @@ class _DESCBC(_SimplifiedEnctype):
     def string_to_key(cls, string, salt, params):
         if params is not None and params != b'':
             raise ValueError('Invalid DES string-to-key parameters')
-        if not isinstance(string, bytes):
+        if not isinstance(string, six.binary_type):
             string = string.encode("utf-8")
-        if not isinstance(salt, bytes):
+        if not isinstance(salt, six.binary_type):
             salt = salt.encode("utf-8")
 
         key = cls.mit_des_string_to_key(string, salt)
@@ -413,9 +413,9 @@ class _DES3CBC(_SimplifiedEnctype):
     def string_to_key(cls, string, salt, params):
         if params is not None and params != b'':
             raise ValueError('Invalid DES3 string-to-key parameters')
-        if not isinstance(string, bytes):
+        if not isinstance(string, six.binary_type):
             string = string.encode("utf-8")
-        if not isinstance(salt, bytes):
+        if not isinstance(salt, six.binary_type):
             salt = salt.encode("utf-8")
 
         k = cls.random_to_key(_nfold(string + salt, 21))
@@ -443,9 +443,9 @@ class _AESEnctype(_SimplifiedEnctype):
 
     @classmethod
     def string_to_key(cls, string, salt, params):
-        if not isinstance(string, bytes):
+        if not isinstance(string, six.binary_type):
             string = string.encode("utf-8")
-        if not isinstance(salt, bytes):
+        if not isinstance(salt, six.binary_type):
             salt = salt.encode("utf-8")
 
         (iterations,) = unpack('>L', params or b'\x00\x00\x10\x00')


### PR DESCRIPTION
According to RFC 3961 and 3962, the password and salt in the string-to-key functions is assumed to be an UTF-8 encoded string. Closes #1491.

The following listings show the key derivation for multiple non-ASCII passwords and salts. The results agree with the test vectors in RFC 3961 and 3962. Note that there is an error in RFC 3961 and 3962: The `g-clef` symbol is Unicode point 0x11D1E and not 0x1101E (see [errata](https://www.rfc-editor.org/errata/rfc3961)).

### DES

Test vector from [RFC 3961 A2](https://www.rfc-editor.org/rfc/rfc3961.html#appendix-A.2).

Before:
```
>>> from impacket.krb5 import crypto
>>> crypto._DESCBC.string_to_key("ß", "ATHENA.MIT.EDUJurišić", None).contents.hex()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/kali/src/impacket/impacket/krb5/crypto.py", line 369, in string_to_key
    key = cls.mit_des_string_to_key(string, salt)
  File "/home/kali/src/impacket/impacket/krb5/crypto.py", line 315, in mit_des_string_to_key
    s = _zeropad(string + salt, cls.padsize)
  File "/home/kali/src/impacket/impacket/krb5/crypto.py", line 98, in _zeropad
    return s + b'\0'*padlen
TypeError: can only concatenate str (not "bytes") to str
```
After:
```
>>> from impacket.krb5 import crypto
>>> crypto._DESCBC.string_to_key("ß", "ATHENA.MIT.EDUJurišić", None).contents.hex()
'62c81a5232b5e69d'
>>> crypto._DESCBC.string_to_key("\U0001d11e", "EXAMPLE.COMpianist", None).contents.hex()
'4ffb26bab0cd9413'
```

### 3DES 

Test vector from [RFC 3961 A4](https://www.rfc-editor.org/rfc/rfc3961.html#appendix-A.4).

Before:
```
>>> from impacket.krb5 import crypto
>>> crypto._DES3CBC.string_to_key("ß", "ATHENA.MIT.EDUJurišić", None).contents.hex()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/kali/src/impacket/impacket/krb5/crypto.py", line 411, in string_to_key
    k = cls.random_to_key(_nfold(string + salt, 21))
  File "/home/kali/src/impacket/impacket/krb5/crypto.py", line 145, in _nfold
    bigstr += rotate_right(ba, 13 * i)
  File "/home/kali/src/impacket/impacket/krb5/crypto.py", line 123, in rotate_right
    ba = bytearray(ba)
TypeError: string argument without an encoding
```
After:
```
>>> from impacket.krb5 import crypto
>>> crypto._DES3CBC.string_to_key("ß", "ATHENA.MIT.EDUJurišić", None).contents.hex()
'16d5a40e1ce3bacb61b9dce00470324c831973a7b952feb0'
>>> crypto._DES3CBC.string_to_key("\U0001d11e", "EXAMPLE.COMpianist", None).contents.hex()
'85763726585dbc1cce6ec43e1f751f07f1c4cbb098f40b19'
```

### AES 

Test vector from [RFC 3962](https://www.rfc-editor.org/rfc/rfc3962.html). 

Before:
```
>>> from impacket.krb5 import crypto
>>> crypto._AES256CTS.string_to_key("\U0001d11e", "EXAMPLE.COMpianist", b"\x00\x00\x00\x32").contents.hex()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/kali/src/impacket/impacket/krb5/crypto.py", line 438, in string_to_key
    seed = PBKDF2(string, salt, cls.seedsize, iterations, prf)
  File "/usr/lib/python3/dist-packages/Cryptodome/Protocol/KDF.py", line 140, in PBKDF2
    password = tobytes(password)
  File "/usr/lib/python3/dist-packages/Cryptodome/Util/py3compat.py", line 130, in tobytes
    return s.encode(encoding)
UnicodeEncodeError: 'latin-1' codec can't encode character '\U0001d11e' in position 0: ordinal not in range(256)
```

After:
```
>>> from impacket.krb5 import crypto
>>> crypto._AES256CTS.string_to_key("\U0001d11e", "EXAMPLE.COMpianist", b"\x00\x00\x00\x32").contents.hex()
'4b6d9839f84406df1f09cc166db4b83c571848b784a3d6bdc346589a3e393f9e'
```