### PR TITLE
Fixing Kerberos Name Type in AS requests

### DIFF
--- a/examples/GetNPUsers.py
+++ b/examples/GetNPUsers.py
@@ -130,7 +130,7 @@ class GetUserNoPreAuth:
         asReq = AS_REQ()
 
         domain = self.__domain.upper()
-        serverName = Principal('krbtgt/%s' % domain, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
+        serverName = Principal('krbtgt/%s' % domain, type=constants.PrincipalNameType.NT_SRV_INST.value)
 
         pacRequest = KERB_PA_PAC_REQUEST()
         pacRequest['include-pac'] = requestPAC

--- a/examples/getPac.py
+++ b/examples/getPac.py
@@ -231,7 +231,7 @@ class S4U2SELF:
         reqBody['kdc-options'] = constants.encodeFlags(opts)
 
         serverName = Principal(self.__username, type=constants.PrincipalNameType.NT_UNKNOWN.value)
-        #serverName = Principal('krbtgt/%s' % domain, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
+        #serverName = Principal('krbtgt/%s' % domain, type=constants.PrincipalNameType.NT_SRV_INST.value)
 
         seq_set(reqBody, 'sname', serverName.components_to_asn1)
         reqBody['realm'] = str(decodedTGT['crealm'])

--- a/examples/goldenPac.py
+++ b/examples/goldenPac.py
@@ -980,7 +980,7 @@ class MS14_068:
                 authTime = encASRepPart['authtime']
 
                 serverName = Principal('krbtgt/%s' % self.__domain.upper(),
-                                       type=constants.PrincipalNameType.NT_PRINCIPAL.value)
+                                       type=constants.PrincipalNameType.NT_SRV_INST.value)
                 tgs, cipher, oldSessionKey, sessionKey = self.getKerberosTGS(serverName, domain, self.__kdcHost, tgt,
                                                                              cipher, sessionKey, authTime)
 

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -114,7 +114,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
     asReq = AS_REQ()
 
     domain = domain.upper()
-    serverName = Principal('krbtgt/%s'%domain, type=constants.PrincipalNameType.NT_PRINCIPAL.value)  
+    serverName = Principal('krbtgt/%s'%domain, type=constants.PrincipalNameType.NT_SRV_INST.value)
 
     pacRequest = KERB_PA_PAC_REQUEST()
     pacRequest['include-pac'] = requestPAC


### PR DESCRIPTION
Hello there,

It was discovered that Impacket uses the KRB_NT_PRINCIPAL name type in AS-REQs instead of the KRB_NT_SRV_INST name type which was required by the specification (RFC 4120).

In some cases this can lead to a KRB_AP_ERR_BAD_INTEGRITY error when a received TGT is used. This may be a behavior of a fully-updated Windows machine but I don't know perhaps it's for some obscure configurations only.