### PR TITLE
smbexec: Fixup Python 3 compat and workaround TCP over NetBIOS being disabled

### DIFF
--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -176,7 +176,7 @@ class RemoteShell(cmd.Cmd):
         cmd.Cmd.__init__(self)
         self.__share = share
         self.__mode = mode
-        self.__output = '\\\\127.0.0.1\\' + self.__share + '\\' + OUTPUT_FILENAME
+        self.__output = '\\\\%COMPUTERNAME%\\' + self.__share + '\\' + OUTPUT_FILENAME
         self.__outputBuffer = b''
         self.__command = ''
         self.__shell = '%COMSPEC% /Q /c '

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -264,8 +264,8 @@ class RemoteShell(cmd.Cmd):
             self.transferClient.getFile(self.__share, OUTPUT_FILENAME, output_callback)
             self.transferClient.deleteFile(self.__share, OUTPUT_FILENAME)
         else:
-            fd = open(SMBSERVER_DIR + '/' + OUTPUT_FILENAME,'r')
-            output_callback(fd.read().encode('utf-8'))
+            fd = open(SMBSERVER_DIR + '/' + OUTPUT_FILENAME,'rb')
+            output_callback(fd.read())
             fd.close()
             os.unlink(SMBSERVER_DIR + '/' + OUTPUT_FILENAME)
 

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -95,7 +95,7 @@ class SMBServer(Thread):
         smbConfig.set('IPC$','comment','')
         smbConfig.set('IPC$','read only','yes')
         smbConfig.set('IPC$','share type','3')
-        smbConfig.set('IPC$','path')
+        smbConfig.set('IPC$','path','')
 
         self.smb = smbserver.SMBSERVER(('0.0.0.0',445), config_parser = smbConfig)
         logging.info('Creating tmp directory')
@@ -265,7 +265,7 @@ class RemoteShell(cmd.Cmd):
             self.transferClient.deleteFile(self.__share, OUTPUT_FILENAME)
         else:
             fd = open(SMBSERVER_DIR + '/' + OUTPUT_FILENAME,'r')
-            output_callback(fd.read())
+            output_callback(fd.read().encode('utf-8'))
             fd.close()
             os.unlink(SMBSERVER_DIR + '/' + OUTPUT_FILENAME)
 


### PR DESCRIPTION
See also the PR in the downstream project here https://github.com/3ndG4me/AutoBlue-MS17-010/pull/40.  PR cover letter copied here:

---

For the non-default "SERVER" mode imports are missing and some Python 3 compatibility tweaks weren't caught yet (`fd.read()` returns String and the commandparser seems to have changed).

Also, if TCP over NetBIOS isn't enabled, resolution of network shares in UNC paths through IP won't work:
https://superuser.com/a/1241871

This will then trigger commands for creating files not being executed properly, resulting in object not found errors.  This PR fixes https://github.com/3ndG4me/AutoBlue-MS17-010/issues/38