### PR TITLE
dpapi: Fix printing master key

### DIFF
--- a/examples/dpapi.py
+++ b/examples/dpapi.py
@@ -318,7 +318,7 @@ class DPAPI:
                         break
                 masterkey=b''.join(resp['ppDataOut'][beginning:])
                 print('Decrypted key using rpc call')
-                print('Decrypted key: 0x%s' % hexlify(masterkey[beginning:]).decode())
+                print('Decrypted key: 0x%s' % hexlify(masterkey).decode())
                 return
 
             else:


### PR DESCRIPTION
The code looks for leading zero bytes and removes them, but then uses the number of zero bytes (in variable beginning) to trim the key again just before printing. This commit fixes the code to only trim once.

The code was verified to work and print the same DPAPI master key as Mimikatz and the other methods implemented by Impacket.