### PR TITLE
tds.py: fixed python3 incompatibility when receiving over TLS socket

### DIFF
--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -590,7 +590,7 @@ class MSSQL:
     def socketRecv(self, packetSize):
         data = self.socket.recv(packetSize)
         if self.tlsSocket is not None:
-            dd = ''
+            dd = b''
             self.tlsSocket.bio_write(data)
             while True:
                 try:


### PR DESCRIPTION
When using `mssqlclient.py` against a server that enforces the use of TLS, an exception occurs due to a string vs bytes incompatibility:

![impacket-bug](https://user-images.githubusercontent.com/5670236/228776557-fa4033ac-ad8b-4bea-8b00-83d7bd8b5b4a.png)

This appears to be a Python 2 leftover since strings and byte strings were the same at that time. In order to be compatible with Python 3, I turned the string into a byte string. Confirmed it is working as expected now.