### PR TITLE
Adds getters for ServiceInstall service and binary name

### DIFF
--- a/impacket/examples/serviceinstall.py
+++ b/impacket/examples/serviceinstall.py
@@ -46,6 +46,14 @@ class ServiceInstall:
 
         self.share = ''
 
+    @property
+    def serviceName(self):
+        return self.__service_name
+
+    @property
+    def binaryServiceName(self):
+        return self.__binary_service_name
+
     def getShare(self):
         return self.share
 


### PR DESCRIPTION
This PR proposes simple getters for service name and binary service name in the ServiceInstall class.
The problem it solves is that when installing a service without providing any names, the class generates them randomly, but there is no way to get the generated names.

It allows to get the names generated randomly when no name is provided in the constructor. It can be useful for logging for example, but also to interact with the services installed without having to provide names and remember them outside of the class.