### PR TITLE
support sasl authentication in ldap protocol

### DIFF
--- a/tests/SMB_RPC/test_ldap.py
+++ b/tests/SMB_RPC/test_ldap.py
@@ -19,7 +19,7 @@ from impacket.ldap.ldaptypes import SR_SECURITY_DESCRIPTOR
 
 class LDAPTests(RemoteTestCase):
     def connect(self, login=True):
-        self.ldapConnection = ldap.LDAPConnection(self.url, self.baseDN)
+        self.ldapConnection = ldap.LDAPConnection(self.url, self.baseDN, self.machine)
         if login:
             self.ldapConnection.login(self.username, self.password)
         return self.ldapConnection
@@ -80,6 +80,14 @@ class LDAPTests(RemoteTestCase):
             user=self.username, password=self.password, domain=self.domain
         )
 
+        self.dummySearch(ldapConnection)
+
+    def test_saslNtlm(self):
+        ldapConnection = self.connect(False)
+        ldapConnection.login(
+            user=self.username, password=self.password, domain=self.domain,
+            authenticationChoice="sasl"
+        )
         self.dummySearch(ldapConnection)
 
     def test_kerberosLogin(self):


### PR DESCRIPTION
This PR adds NTLM authentication support to ldap protocol, using **SASL (Simple Authentication and Security Layer)** mechanism. Included features:

- Use `GSS-SPNEGO` in sasl
- Support NT hash for authentication
- Related test case

Read more information in Microsoft documentations for [MS-ADTS](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/989e0748-0953-455d-9d37-d08dfbf3998b).