### PR TITLE
Fix minor "get_instace" typo

### DIFF
--- a/impacket/ntlm.py
+++ b/impacket/ntlm.py
@@ -941,7 +941,7 @@ class NTLM_HTTP(object):
     MSG_TYPE = None
 
     @classmethod
-    def get_instace(cls,msg_64):
+    def get_instance(cls,msg_64):
         msg = None
         msg_type = 0
         if msg_64 != '':


### PR DESCRIPTION
Even though it doesn't seem to be actually called (neither with nor without the typo) 🤷‍♂️, I think it's better to fix this.