### PR TITLE
Replace flake8 with ruff --fix

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,32 +10,17 @@ env:
 
 jobs:
   lint:
-    name: Check syntax errors and warnings
+    name: Lint Python code with ruff
     runs-on: ubuntu-latest
     if:
       github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
       github.repository
 
     steps:
-      - name: Checkout Impacket
-        uses: actions/checkout@v3
-
-      - name: Setup Python 3.8
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-
-      - name: Install Python dependencies
-        run: |
-          python -m pip install flake8
-
-      - name: Check syntax errors
-        run: |
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-
-      - name: Check PEP8 warnings
-        run: |
-          flake8 . --count --ignore=E1,E2,E3,E501,W291,W293 --exit-zero --max-complexity=65 --max-line-length=127 --statistics
+      - uses: actions/checkout@v3
+      - run: pip install --user ruff
+      - run: ruff --format=github --line-length=66423 --target-version=py37
+                  --ignore=E101,E401,E402,E701,E703,E711,E712,E713,E714,E721,E722,E731,E741,F401,F403,F405,F601,F811,F841,F901 .
 
   test:
     name: Run unit tests and build wheel

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: pip install --user ruff
       - run: ruff --format=github --line-length=66423 --target-version=py37
-                  --ignore=E101,E401,E402,E701,E703,E711,E712,E713,E714,E721,E722,E731,E741,F401,F403,F405,F601,F811,F841,F901 .
+                  --ignore=E101,E401,E402,E701,E721,E722,E731,E741,F401,F403,F405,F601,F811,F841 .
 
   test:
     name: Run unit tests and build wheel

--- a/examples/Get-GPPPassword.py
+++ b/examples/Get-GPPPassword.py
@@ -91,7 +91,7 @@ class GetGPPasswords(object):
             properties_list = root.getElementsByTagName("Properties")
             # function to get attribute if it exists, returns "" if empty
             read_or_empty = lambda element, attribute: (
-                element.getAttribute(attribute) if element.getAttribute(attribute) != None else "")
+                element.getAttribute(attribute) if element.getAttribute(attribute) is not None else "")
             for properties in properties_list:
                 results.append({
                     'newname': read_or_empty(properties, 'newName'),
@@ -122,7 +122,7 @@ class GetGPPasswords(object):
             raise
         output = fh.getvalue()
         encoding = chardet.detect(output)["encoding"]
-        if encoding != None:
+        if encoding is not None:
             filecontent = output.decode(encoding).rstrip()
             if 'cpassword' in filecontent:
                 logging.debug(filecontent)

--- a/examples/addcomputer.py
+++ b/examples/addcomputer.py
@@ -76,7 +76,7 @@ class ADDCOMPUTER:
         if self.__doKerberos and cmdLineOptions.dc_host is None:
             raise ValueError("Kerberos auth requires DNS name of the target DC. Use -dc-host.")
 
-        if self.__method == 'LDAPS' and not '.' in self.__domain:
+        if self.__method == 'LDAPS' and '.' not in self.__domain:
                 logging.warning('\'%s\' doesn\'t look like a FQDN. Generating baseDN will probably fail.' % self.__domain)
 
         if cmdLineOptions.hashes is not None:
@@ -95,7 +95,7 @@ class ADDCOMPUTER:
             self.__computerPassword = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(32))
 
         if self.__target is None:
-            if not '.' in self.__domain:
+            if '.' not in self.__domain:
                 logging.warning('No DC host set and \'%s\' doesn\'t look like a FQDN. DNS resolution of short names will probably fail.' % self.__domain)
             self.__target = self.__domain
 

--- a/examples/exchanger.py
+++ b/examples/exchanger.py
@@ -109,7 +109,7 @@ class Exchanger:
         self.__outputFd = open(self.__outputFileName, 'w+')
 
     def print(self, text):
-        if self.__outputFd != None:
+        if self.__outputFd is not None:
             if PY3:
                 self.__outputFd.write(text + '\n')
             else:
@@ -127,7 +127,7 @@ class Exchanger:
             return base64.b64encode(bytestr)
 
     def __del__(self):
-        if self.__outputFd != None:
+        if self.__outputFd is not None:
             self.__outputFd.close()
         self.__outputFd = None
 
@@ -338,9 +338,9 @@ class NSPIAttacks(Exchanger):
         MIds_print = []
 
         for MId in self.htable:
-            if parent_guid == None and 'parent_guid' not in self.htable[MId]:
+            if parent_guid is None and 'parent_guid' not in self.htable[MId]:
                 MIds_print.append(MId)
-            elif parent_guid != None and 'parent_guid' in self.htable[MId] and self.htable[MId]['parent_guid'] == parent_guid:
+            elif parent_guid is not None and 'parent_guid' in self.htable[MId] and self.htable[MId]['parent_guid'] == parent_guid:
                 MIds_print.append(MId)
 
         for MId in MIds_print:
@@ -384,9 +384,9 @@ class NSPIAttacks(Exchanger):
             if MId != 0:
                 self.print_htable(parent_guid=ab['guid'])
 
-        if parent_guid == None:
+        if parent_guid is None:
             for MId in self.htable:
-                if self.htable[MId]['printed'] == False:
+                if self.htable[MId]["printed"] is False:
                     print("Found parentless object!")
                     print("Name: %s" % self.htable[MId]['name'])
                     print("Guid: %s" % uuid.bin_to_string(self.htable[MId]['guid']).lower())
@@ -437,7 +437,7 @@ class NSPIAttacks(Exchanger):
             else:
                 self.print("%s: %s" % (property_name, row_simpl[aulPropTag]))
 
-        if empty == False and delimiter != None:
+        if empty is False and delimiter is not None:
             self.print(delimiter)
 
     def load_props(self):
@@ -463,11 +463,11 @@ class NSPIAttacks(Exchanger):
         if self.anyExistingContainerID == -1:
             self.load_htable_containerid()
 
-        if table_MId == None and eTable == None:
+        if table_MId is None and eTable is None:
             raise Exception("Wrong arguments!")
-        elif table_MId != None and eTable != None:
+        elif table_MId is not None and eTable is not None:
             raise Exception("Wrong arguments!")
-        elif table_MId != None:
+        elif table_MId is not None:
             # Let's call NspiUpdateStat
             # It's important when the given MId is taken from the hierarchy table,
             # especially in Multi-Tenant environments
@@ -513,7 +513,7 @@ class NSPIAttacks(Exchanger):
             useAsExplicitTable = True
 
         while True:
-            if eTable == None:
+            if eTable is None:
                 resp = nspi.hNspiQueryRows(self.__dce, self.__handler,
                     pStat=self.stat, Count=count, pPropTags=firstReqProps)
                 self.stat = resp['pStat']
@@ -542,7 +542,7 @@ class NSPIAttacks(Exchanger):
                     return False
 
             if useAsExplicitTable:
-                if eTable == None:
+                if eTable is None:
                     eTableInt = []
                     for row in resp_rows:
                         eTableInt.append(row[PR_INSTANCE_KEY])
@@ -588,7 +588,7 @@ class NSPIAttacks(Exchanger):
                     self.print_row(row, DELIMITER)
 
             # When the caller specified eTable it's always one NspiQueryRows call
-            if eTable != None:
+            if eTable is not None:
                 break
 
             # Table end reached
@@ -601,9 +601,9 @@ class NSPIAttacks(Exchanger):
                 break
 
     def req_print_guid(self, guid=None, attrs=[], count=50, guidFile=None):
-        if guid == None and guidFile == None:
+        if guid is None and guidFile is None:
             raise Exception("Wrong arguments!")
-        elif guid != None and guidFile != None:
+        elif guid is not None and guidFile is not None:
             raise Exception("Wrong arguments!")
 
         if attrs == []:
@@ -739,7 +739,7 @@ class ExchangerHelper:
         self.exch.set_credentials(self.__username, self.__password, self.__domain, options.hashes)
         self.exch.set_extended_output(options.debug)
 
-        if submodule in ['dump-tables', 'guid-known', 'dnt-lookup'] and options.output_file != None:
+        if submodule in ['dump-tables', 'guid-known', 'dnt-lookup'] and options.output_file is not None:
             self.exch.set_output_file(options.output_file)
 
         self.exch.connect_rpc(self.__remoteName, options.rpc_hostname)
@@ -756,19 +756,19 @@ class ExchangerHelper:
         self.exch.disconnect()
 
     def nspi_check(self, submodule, options):
-        if submodule == 'dump-tables' and options.name == None and options.guid == None:
+        if submodule == 'dump-tables' and options.name is None and options.guid is None:
             dump_tables.print_help()
             sys.exit(1)
 
-        if submodule == 'dump-tables' and options.name != None and options.guid != None:
+        if submodule == 'dump-tables' and options.name is not None and options.guid is not None:
             logging.error("Specify only one of -name or -guid")
             sys.exit(1)
 
-        if submodule == 'guid-known' and options.guid == None and options.guid_file == None:
+        if submodule == 'guid-known' and options.guid is None and options.guid_file is None:
             guid_known.print_help()
             sys.exit(1)
 
-        if submodule == 'guid-known' and options.guid != None and options.guid_file != None:
+        if submodule == 'guid-known' and options.guid is not None and options.guid_file is not None:
             logging.error("Specify only one of -guid or -guid-file")
             sys.exit(1)
 
@@ -783,7 +783,7 @@ class ExchangerHelper:
     def nspi_dump_tables(self, options):
         self.exch.set_output_type(options.output_type)
 
-        if options.lookup_type == None or options.lookup_type == 'MINIMAL':
+        if options.lookup_type is None or options.lookup_type == 'MINIMAL':
             propTags = NSPIAttacks.PROPS_MINUMAL
         elif options.lookup_type == 'EXTENDED':
             propTags = NSPIAttacks.PROPS_EXTENDED
@@ -793,7 +793,7 @@ class ExchangerHelper:
             # FULL
             propTags = []
 
-        if options.name != None and options.name.lower() in ['gal', 'default global address list', 'global address list']:
+        if options.name is not None and options.name.lower() in ['gal', 'default global address list', 'global address list']:
             logging.info("Lookuping Global Address List")
             table_MId = 0
         else:
@@ -805,7 +805,7 @@ class ExchangerHelper:
             # may not work in Multi-Tenant environments
             self.exch.load_htable()
 
-            if options.guid != None:
+            if options.guid is not None:
                 logging.info("Search for an address book with objectGUID = %s" % options.guid)
                 guid = uuid.string_to_bin(options.guid)
                 name = None
@@ -845,7 +845,7 @@ class ExchangerHelper:
     def nspi_guid_known(self, options):
         self.exch.set_output_type(options.output_type)
 
-        if options.lookup_type == None or options.lookup_type == 'MINIMAL':
+        if options.lookup_type is None or options.lookup_type == 'MINIMAL':
             propTags = NSPIAttacks.PROPS_MINUMAL
         elif options.lookup_type == 'EXTENDED':
             propTags = NSPIAttacks.PROPS_EXTENDED
@@ -853,13 +853,13 @@ class ExchangerHelper:
             # FULL
             propTags = []
 
-        if options.guid != None:
+        if options.guid is not None:
             self.exch.req_print_guid(options.guid, propTags)
         else:
             self.exch.req_print_guid(attrs=propTags, count=options.rows_per_request, guidFile=options.guid_file)
 
     def nspi_dnt_lookup(self, options):
-        if options.lookup_type == None or options.lookup_type == 'EXTENDED':
+        if options.lookup_type is None or options.lookup_type == 'EXTENDED':
             propTags = NSPIAttacks.PROPS_EXTENDED
         elif options.lookup_type == 'GUIDS':
             propTags = NSPIAttacks.PROPS_GUID
@@ -1029,7 +1029,7 @@ if __name__ == '__main__':
                              "You can try to request different DNT range")
 
         if 'Connection reset by peer' in error_text and \
-            exchHelper.exch._rpctransport.rts_ping_received == True and \
+            exchHelper.exch._rpctransport.rts_ping_received is True and \
             options.submodule.lower() == 'dnt-lookup':
             logging.critical("Most likely ntdsai.dll in lsass.exe has crashed "
                              "on a Domain Controller while processing a DNT which "

--- a/examples/netview.py
+++ b/examples/netview.py
@@ -318,7 +318,7 @@ class USERENUM:
             key = '%s\x01%s' % (userName, sourceIP)
             myEntry = '%s\x01%s' % (self.__username, myIP)
             tmpSession.append(key)
-            if not(key in self.__targets[target]['Sessions']):
+            if key not in self.__targets[target]['Sessions']:
                 # Skipping myself
                 if key != myEntry:
                     self.__targets[target]['Sessions'].append(key)
@@ -402,7 +402,7 @@ class USERENUM:
             logonDomain = session['wkui1_logon_domain'][:-1]
             key = '%s\x01%s' % (userName, logonDomain)
             tmpLoggedUsers.add(key)
-            if not(key in self.__targets[target]['LoggedIn']):
+            if key not in self.__targets[target]['LoggedIn']:
                 self.__targets[target]['LoggedIn'].add(key)
                 # Are we filtering users?
                 if self.__filterUsers is not None:

--- a/examples/nmapAnswerMachine.py
+++ b/examples/nmapAnswerMachine.py
@@ -451,7 +451,7 @@ class NMAP2UDPResponder(ClosedUDPResponder):
        try: ipl = int(f['IPL'], 16)
        except: ipl = None
 
-       if not ipl is None:
+       if ipl is not None:
           data = out_onion[O_ICMP_DATA].get_packet()
           out_onion[O_ICMP].contains(ImpactPacket.Data())
           ip_and_icmp_len = out_onion[O_IP].get_size()

--- a/examples/psexec.py
+++ b/examples/psexec.py
@@ -287,7 +287,7 @@ class RemoteStdOutPipe(Pipes):
                         promptRegex = rb'([a-zA-Z]:[\\\/])((([a-zA-Z0-9 -\.]*)[\\\/]?)+(([a-zA-Z0-9 -\.]+))?)?>$'
 
                         endsWithPrompt = bool(re.match(promptRegex, __stdoutOutputBuffer) is not None)
-                        if endsWithPrompt == True:
+                        if endsWithPrompt is True:
                             # All data, we shouldn't have encoding errors
                             # Adding a space after the prompt because it's beautiful
                             __stdoutData = __stdoutOutputBuffer + b" "

--- a/examples/rpcmap.py
+++ b/examples/rpcmap.py
@@ -151,7 +151,7 @@ class RPCMap():
                 logging.info("Target MGMT interface not available")
                 logging.info("Bruteforcing UUIDs. The result may not be complete.")
                 self.bruteforce_uuids()
-            elif str(e).find('rpc_s_access_denied') and self.__msrpc_lockout_protection == False:
+            elif str(e).find('rpc_s_access_denied') and self.__msrpc_lockout_protection is False:
                 logging.info("Target MGMT interface requires authentication, but no credentials provided.")
                 logging.info("Bruteforcing UUIDs. The result may not be complete.")
                 self.bruteforce_uuids()

--- a/impacket/dcerpc/v5/nspi.py
+++ b/impacket/dcerpc/v5/nspi.py
@@ -1100,7 +1100,7 @@ def simplifyPropertyRowSet(propertyRowSet):
 def hNspiBind(dce, pStat=None):
     request = NspiBind()
 
-    if pStat == None:
+    if pStat is None:
         request['pStat']['CodePage'] = CP_TELETEX
     else:
         request['pStat'] = pStat
@@ -1131,7 +1131,7 @@ def hNspiQueryRows(dce, handler, dwFlags=fSkipObjects, pStat=None, ContainerID=0
     request['dwFlags'] = dwFlags
     request['Count'] = Count
 
-    if pStat == None:
+    if pStat is None:
         request['pStat']['ContainerID'] = ContainerID
     else:
         request['pStat'] = pStat

--- a/impacket/dcerpc/v5/transport.py
+++ b/impacket/dcerpc/v5/transport.py
@@ -434,7 +434,7 @@ class HTTPTransport(TCPTransport, RPCProxyClient):
                 raise DCERPCException("RPC Proxy port must be 80 or 443")
 
     def connect(self):
-        if self._useRpcProxy == False:
+        if self._useRpcProxy is False:
             # Connecting directly to the ncacn_http port
             #
             # Here we using RPC over HTTPv1 instead complex RPC over HTTP v2 syntax
@@ -458,7 +458,7 @@ class HTTPTransport(TCPTransport, RPCProxyClient):
         return self._transport.recv(self, forceRecv, count)
 
     def get_socket(self):
-        if self._useRpcProxy == False:
+        if self._useRpcProxy is False:
             return TCPTransport.get_socket(self)
         else:
             raise DCERPCException("This method is not supported for RPC Proxy connections")

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -683,7 +683,7 @@ class LDAPAttack(ProtocolAttack):
                 else:
                     uuid = bin_to_string(ace["Ace"]["ObjectType"]).lower()
 
-                if not uuid in enrollment_uuids:
+                if uuid not in enrollment_uuids:
                     continue
 
                 enrollment_principals.add(sid)

--- a/impacket/examples/ntlmrelayx/utils/targetsutils.py
+++ b/impacket/examples/ntlmrelayx/utils/targetsutils.py
@@ -138,7 +138,7 @@ class TargetsProcessor:
                 LOG.debug("No more targets for user %s" % identity)
                 return None
             # Multirelay feature is disabled, general candidates are attacked just one time
-            elif multiRelay == False:
+            elif multiRelay is False:
                 for target in self.generalCandidates:
                     match = [x for x in self.finishedAttacks if x.hostname == target.netloc]
                     if len(match) == 0:

--- a/impacket/examples/os_ident.py
+++ b/impacket/examples/os_ident.py
@@ -69,7 +69,7 @@ class os_id_test:
         pass
 
     def get_result_dict(self):
-        return self.__result_dict;
+        return self.__result_dict
 
     def get_final_result(self):
         "Returns a string representation of the final result of this test or None if no response was received"
@@ -195,7 +195,7 @@ class udp_closed_probe(os_id_test):
             return 0
   
         if icmp.get_icmp_code() != ICMP.ICMP_UNREACH_PORT:
-            return 0;
+            return 0
         
         
         self.err_data = icmp.child()
@@ -994,7 +994,7 @@ class OS_ID:
         self.__ports = ports
 
     def releasePcap(self):
-        if not (self.p is None):
+        if self.p is not None:
             self.p.close()
 
     def get_new_id(self):
@@ -1435,7 +1435,7 @@ class nmap1_seq_container(os_id_test):
             map(lambda x, gcd = self.seq_gcd: x / gcd, self.seq_diffs)
             for i in xrange(0, self.seq_num_responses - 1):
                 if abs(self.seq_responses[i+1].get_seq() - self.seq_responses[i].get_seq()) > 50000000:
-                    seqclass = nmap1_seq.SEQ_TR;
+                    seqclass = nmap1_seq.SEQ_TR
                     self.index = 9999999
                     break
                 avg_incr += self.seq_diffs[i]

--- a/impacket/helper.py
+++ b/impacket/helper.py
@@ -120,7 +120,7 @@ class ProtocolPacketMetaklass(type):
     def __new__(cls, name, bases, d):
         d["_fields"] = []
         items = list(d.items())
-        if not object in bases:
+        if object not in bases:
             bases += (object,)
         for k,v in items:
             if isinstance(v, Field):

--- a/impacket/http.py
+++ b/impacket/http.py
@@ -125,7 +125,7 @@ class HTTPClientSecurityProvider:
 
     def get_auth_headers_basic(self, http_obj, method, path, headers):
         if self.__lmhash != '' or self.__nthash != '' or \
-           self.__aesKey != '' or self.__TGT != None or self.__TGS != None:
+           self.__aesKey != '' or self.__TGT is not None or self.__TGS is not None:
             raise Exception('Basic authentication in HTTP connection used, '
                             'so set a plaintext credentials to connect.')
 
@@ -182,7 +182,7 @@ class HTTPClientSecurityProvider:
         return serverChallenge, None
 
     def get_auth_headers_auto(self, http_obj, method, path, headers):
-        if self.__aesKey != '' or self.__TGT != None or self.__TGS != None:
+        if self.__aesKey != '' or self.__TGT is not None or self.__TGS is not None:
             raise Exception('NTLM authentication in HTTP connection used, ' \
                             'cannot use Kerberos.')
 

--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -736,7 +736,7 @@ class SMB3:
         #Handle mutual authentication
         opts = list()
 
-        if mutualAuth == True:
+        if mutualAuth is True:
             from impacket.krb5.constants import APOptions
             opts.append(constants.APOptions.mutual_required.value)
 
@@ -786,7 +786,7 @@ class SMB3:
             self._Session['Connection']      = self._NetBIOSSession.get_socket()
 
 
-            if mutualAuth == True:
+            if mutualAuth is True:
                 #Lets get the session key in the AP_REP
                 from impacket.krb5.asn1 import AP_REP, EncAPRepPart
                 from impacket.krb5.crypto import Key, _enctype_table

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -2991,7 +2991,7 @@ class SMB2Commands:
                 # No credentials provided, let's grant access
                 if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_ANONYMOUS:
                     isAnonymus = True
-                    if smbServer._SMBSERVER__anonymousLogon == False:
+                    if smbServer._SMBSERVER__anonymousLogon is False:
                         errorCode = STATUS_ACCESS_DENIED
                     else:
                         errorCode = STATUS_SUCCESS

--- a/tests/dcerpc/__init__.py
+++ b/tests/dcerpc/__init__.py
@@ -45,7 +45,7 @@ class DCERPCTests(RemoteTestCase):
         """
         string_binding = string_binding or self.string_binding
         if not string_binding:
-            raise NotImplemented("String binding must be defined")
+            raise NotImplementedError("String binding must be defined")
 
         rpc_transport = transport.DCERPCTransportFactory(string_binding)
 


### PR DESCRIPTION
Fixes: #1538 

This is a superset of #1538 with the addition of:
% `ruff --select=E703,E711,E712,E713,E714,F901 --fix .`
```
Found 64 errors (64 fixed, 0 remaining).

  3	E703	[*] Statement ends with an unnecessary semicolon
 41	E711	[*] Comparison to `None` should be `cond is None`
 11	E712	[*] Comparison to `False` should be `cond is False` or `if not cond:`
  6	E713	[*] Test for membership should be `not in`
  2	E714	[*] Test for object identity should be `is not`
  1	F901	[*] `raise NotImplemented` should be `raise NotImplementedError`
```