### PR TITLE
Ticketer: Added extra-pac implementation

### DIFF
--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -59,7 +59,7 @@ from pyasn1.codec.der import encoder, decoder
 from pyasn1.type.univ import noValue
 
 from impacket import version
-from impacket.dcerpc.v5.dtypes import RPC_SID
+from impacket.dcerpc.v5.dtypes import RPC_SID, SID
 from impacket.dcerpc.v5.ndr import NDRULONG
 from impacket.dcerpc.v5.samr import NULL, GROUP_MEMBERSHIP, SE_GROUP_MANDATORY, SE_GROUP_ENABLED_BY_DEFAULT, \
     SE_GROUP_ENABLED, USER_NORMAL_ACCOUNT, USER_DONT_EXPIRE_PASSWORD
@@ -77,7 +77,6 @@ from impacket.krb5.pac import KERB_SID_AND_ATTRIBUTES, PAC_SIGNATURE_DATA, PAC_I
     PAC_ATTRIBUTE_INFO
 from impacket.krb5.types import KerberosTime, Principal
 from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGS
-from impacket.ldap.ldaptypes import LDAP_SID
 
 
 class TICKETER:
@@ -103,7 +102,7 @@ class TICKETER:
         t *= 10000000
         t += 116444736000000000
         return t
-    
+
     @staticmethod
     def getPadLength(data_length):
         return ((data_length + 7) // 8 * 8) - data_length
@@ -282,7 +281,7 @@ class TICKETER:
         pad = self.getPadLength(total_len)
         samName += b'\x00' * pad
 
-        user_sid = LDAP_SID()
+        user_sid = SID()
         user_sid.fromCanonical(f"{self.__options.domain_sid}-{self.__options.user_id}")
         upnDnsInfo['SidLength'] = len(user_sid)
         upnDnsInfo['SidOffset'] = total_len + pad
@@ -305,6 +304,7 @@ class TICKETER:
 
     def createRequestorInfoPac(self, pacInfos):
         pacRequestor = PAC_REQUESTOR()
+        pacRequestor['UserSid'] = SID()
         pacRequestor['UserSid'].fromCanonical(f"{self.__options.domain_sid}-{self.__options.user_id}")
 
         pacInfos[PAC_REQUESTOR_INFO] = pacRequestor.getData()
@@ -451,7 +451,7 @@ class TICKETER:
         flags.append(TicketFlags.forwardable.value)
         flags.append(TicketFlags.proxiable.value)
         flags.append(TicketFlags.renewable.value)
-        if self.__domain == self.__server: 
+        if self.__domain == self.__server:
             flags.append(TicketFlags.initial.value)
         flags.append(TicketFlags.pre_authent.value)
         encTicketPart['flags'] = encodeFlags(flags)

--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -248,8 +248,8 @@ class TICKETER:
 
         if self.__options.extra_pac:
             self.createUpnDnsPac(pacInfos)
-        self.createAttributesInfoPac(pacInfos)
-        self.createRequestorInfoPac(pacInfos)
+            self.createAttributesInfoPac(pacInfos)
+            self.createRequestorInfoPac(pacInfos)
 
         return pacInfos
 

--- a/impacket/krb5/pac.py
+++ b/impacket/krb5/pac.py
@@ -12,7 +12,7 @@
 # Author:
 #   Alberto Solino (@agsolino)
 #
-from impacket.dcerpc.v5.dtypes import ULONG, RPC_UNICODE_STRING, FILETIME, PRPC_SID, USHORT, RPC_SID
+from impacket.dcerpc.v5.dtypes import ULONG, RPC_UNICODE_STRING, FILETIME, PRPC_SID, USHORT, RPC_SID, SID
 from impacket.dcerpc.v5.ndr import NDRSTRUCT, NDRUniConformantArray, NDRPOINTER
 from impacket.dcerpc.v5.nrpc import USER_SESSION_KEY, CHAR_FIXED_8_ARRAY, PUCHAR_ARRAY, PRPC_UNICODE_STRING_ARRAY
 from impacket.dcerpc.v5.rpcrt import TypeSerialization1
@@ -263,29 +263,8 @@ class PAC_ATTRIBUTE_INFO(NDRSTRUCT):
     )
 
 # 2.15 PAC_REQUESTOR
-# It should be RPC_SID (with NDRSTRUCT sub-class) but the impacket implementation is malfunctioning: https://github.com/SecureAuthCorp/impacket/issues/1386
-#class PAC_REQUESTOR(NDRSTRUCT):
-#    structure = (
-#        ('UserSid', RPC_SID),
-#    )
-# In the meantime, using LDAP_SID with minimal custom implementation
-class PAC_REQUESTOR:
+class PAC_REQUESTOR(Structure):
+    structure = (
+        ('UserSid',':',SID),
+    )
 
-    def __init__(self, data=None):
-        self.fields = {'UserSid': LDAP_SID(data)}
-
-    # For other method not implemented, directly call 'UserSid' field
-    def __getitem__(self, key):
-        return self.fields[key]
-
-    def __setitem__(self, key, value):
-        self.fields[key] = value
-
-    def getData(self):
-        return self.fields['UserSid'].getData()
-
-    def __str__(self):
-        return self.getData()
-
-    def __len__(self):
-        return len(self.getData())


### PR DESCRIPTION
Extra-PAC implementation by @Dramelac. Additions detailed in https://github.com/fortra/impacket/pull/1391.

This PR adds a new SID structure [[MS-DTYP] 2.4.2.2 SID](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/f992ad60-0fe4-4b87-9fed-beb478836861). This is a packet representation of the SID type for use by block protocols.
Removed LDAP_SID structure in the example.


Example of use:
ticketer.py -aesKey 78738d... -domain-sid S-1-5-21-22... -domain contoso.com -extra-pac -user-id 1108 username