### PR TITLE
Impacket #1434: Added `SMB2_FILE_ALLOCATION_INFO` type determination, referenced Samba code

### DIFF
--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -3476,6 +3476,9 @@ class SMB2Commands:
                         except Exception as e:
                             smbServer.log("smb2SetInfo: %s" % e, logging.ERROR)
                             errorCode = STATUS_ACCESS_DENIED
+                    elif informationLevel == smb2.SMB2_FILE_ALLOCATION_INFO:
+                        # See https://github.com/samba-team/samba/blob/master/source3/smbd/smb2_trans2.c#LL5201C8-L5201C39
+                        errorCode = STATUS_SUCCESS
                     else:
                         smbServer.log('Unknown level for set file info! 0x%x' % informationLevel, logging.ERROR)
                         # UNSUPPORTED

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -3478,6 +3478,7 @@ class SMB2Commands:
                             errorCode = STATUS_ACCESS_DENIED
                     elif informationLevel == smb2.SMB2_FILE_ALLOCATION_INFO:
                         # See https://github.com/samba-team/samba/blob/master/source3/smbd/smb2_trans2.c#LL5201C8-L5201C39
+                        smbServer.log("Warning: SMB2_FILE_ALLOCATION_INFO not implemented")
                         errorCode = STATUS_SUCCESS
                     else:
                         smbServer.log('Unknown level for set file info! 0x%x' % informationLevel, logging.ERROR)


### PR DESCRIPTION
Added `SMB2_FILE_ALLOCATION_INFO` type determination, but did not implement anything. The code is based on `Samba`'s [smb2_trans2.c](https://github.com/samba-team/samba/blob/master/source3/smbd/smb2_trans2.c#LL5201C8-L5201C39)



This may solve https://github.com/fortra/impacket/issues/1434