### PR TITLE
fix `ModuleNotFoundError: No module named 'impacket'` which happens when running the scripts from the examples directory in BASH terminal

### DIFF
--- a/examples/Get-GPPPassword.py
+++ b/examples/Get-GPPPassword.py
@@ -32,6 +32,15 @@ from Cryptodome.Util.Padding import unpad
 
 import charset_normalizer as chardet
 
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.examples import logger, utils
 from impacket.smbconnection import SMBConnection, SMB2_DIALECT_002, SMB2_DIALECT_21, SMB_DIALECT, SessionError

--- a/examples/GetADUsers.py
+++ b/examples/GetADUsers.py
@@ -30,6 +30,16 @@ import logging
 import sys
 from datetime import datetime
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.dcerpc.v5.samr import UF_ACCOUNTDISABLE
 from impacket.examples import logger

--- a/examples/GetNPUsers.py
+++ b/examples/GetNPUsers.py
@@ -36,6 +36,16 @@ from binascii import hexlify
 from pyasn1.codec.der import decoder, encoder
 from pyasn1.type.univ import noValue
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.dcerpc.v5.samr import UF_ACCOUNTDISABLE, UF_DONT_REQUIRE_PREAUTH
 from impacket.examples import logger

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -37,6 +37,16 @@ from datetime import datetime
 from binascii import hexlify, unhexlify
 
 from pyasn1.codec.der import decoder
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.dcerpc.v5.samr import UF_ACCOUNTDISABLE, UF_TRUSTED_FOR_DELEGATION, \
     UF_TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION

--- a/examples/addcomputer.py
+++ b/examples/addcomputer.py
@@ -27,6 +27,17 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import os
+import sys
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.examples import logger
 from impacket.examples.utils import parse_credentials

--- a/examples/atexec.py
+++ b/examples/atexec.py
@@ -28,6 +28,16 @@ import time
 import random
 import logging
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.examples import logger
 from impacket import version
 from impacket.dcerpc.v5 import tsch, transport

--- a/examples/dcomexec.py
+++ b/examples/dcomexec.py
@@ -46,6 +46,15 @@ import time
 from base64 import b64encode
 
 from six import PY2, PY3
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.dcerpc.v5.dcom.oaut import IID_IDispatch, string_to_bin, IDispatch, DISPPARAMS, DISPATCH_PROPERTYGET, \
     VARIANT, VARENUM, DISPATCH_METHOD

--- a/examples/dpapi.py
+++ b/examples/dpapi.py
@@ -45,6 +45,16 @@ from hashlib import pbkdf2_hmac
 
 from Cryptodome.Cipher import AES, PKCS1_v1_5
 from Cryptodome.Hash import HMAC, SHA1, MD4
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.uuid import bin_to_string
 from impacket import crypto
 from impacket.smbconnection import SMBConnection

--- a/examples/esentutl.py
+++ b/examples/esentutl.py
@@ -23,6 +23,16 @@ import sys
 import logging
 import argparse
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.examples import logger
 from impacket import version
 from impacket.ese import ESENT_DB

--- a/examples/exchanger.py
+++ b/examples/exchanger.py
@@ -32,6 +32,16 @@ import binascii
 import sys
 from six import PY3
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import uuid, version
 from impacket.http import AUTH_BASIC
 from impacket.examples import logger

--- a/examples/findDelegation.py
+++ b/examples/findDelegation.py
@@ -26,6 +26,16 @@ import argparse
 import logging
 import sys
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.dcerpc.v5.samr import UF_ACCOUNTDISABLE, UF_TRUSTED_FOR_DELEGATION, UF_TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION
 from impacket.examples import logger

--- a/examples/getArch.py
+++ b/examples/getArch.py
@@ -29,6 +29,16 @@ import argparse
 import logging
 import sys
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.examples import logger
 from impacket.dcerpc.v5.rpcrt import DCERPCException

--- a/examples/getPac.py
+++ b/examples/getPac.py
@@ -35,6 +35,16 @@ from six import b
 from pyasn1.codec.der import decoder, encoder
 from pyasn1.type.univ import noValue
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.dcerpc.v5.rpcrt import TypeSerialization1
 from impacket.examples import logger

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -50,6 +50,15 @@ from six import b
 from pyasn1.codec.der import decoder, encoder
 from pyasn1.type.univ import noValue
 
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.examples import logger
 from impacket.examples.utils import parse_credentials

--- a/examples/getTGT.py
+++ b/examples/getTGT.py
@@ -24,6 +24,16 @@ import logging
 import sys
 from binascii import unhexlify
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.examples import logger
 from impacket.examples.utils import parse_credentials

--- a/examples/goldenPac.py
+++ b/examples/goldenPac.py
@@ -44,6 +44,16 @@ from binascii import unhexlify
 from threading import Thread, Lock
 from six import PY3
 
+import sys
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.dcerpc.v5 import epm
 from impacket.dcerpc.v5.drsuapi import MSRPC_UUID_DRSUAPI, hDRSDomainControllerInfo, DRSBind, NTDSAPI_CLIENT_GUID, \
     DRS_EXTENSIONS_INT, DRS_EXT_GETCHGREQ_V6, DRS_EXT_GETCHGREPLY_V6, DRS_EXT_GETCHGREQ_V8, DRS_EXT_STRONG_ENCRYPTION, \

--- a/examples/karmaSMB.py
+++ b/examples/karmaSMB.py
@@ -64,6 +64,15 @@ except ImportError:
     import configparser as ConfigParser
 from threading import Thread
 
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.examples import logger
 from impacket import smbserver, smb, version
 import impacket.smb3structs as smb2

--- a/examples/keylistattack.py
+++ b/examples/keylistattack.py
@@ -29,6 +29,16 @@ import logging
 import os
 import random
 
+import sys
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.examples import logger
 from impacket.examples.secretsdump import RemoteOperations, KeyListSecrets
 from impacket.examples.utils import parse_target

--- a/examples/kintercept.py
+++ b/examples/kintercept.py
@@ -29,6 +29,17 @@ import struct, socket, argparse, asyncore
 from binascii import crc32
 from pyasn1.codec.der import decoder, encoder
 from pyasn1.type.univ import noValue
+import os
+import sys
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.krb5 import constants
 from impacket.krb5.crypto import Cksumtype

--- a/examples/lookupsid.py
+++ b/examples/lookupsid.py
@@ -24,6 +24,16 @@ import logging
 import argparse
 import codecs
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.examples import logger
 from impacket.examples.utils import parse_target
 from impacket import version

--- a/examples/machine_role.py
+++ b/examples/machine_role.py
@@ -23,6 +23,16 @@ import sys
 import logging
 import argparse
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.examples import logger
 from impacket.examples.utils import parse_target
 from impacket import version

--- a/examples/mimikatz.py
+++ b/examples/mimikatz.py
@@ -25,6 +25,15 @@ import logging
 import os
 import sys
 
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.dcerpc.v5 import epm, mimilib
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_LEVEL_PKT_PRIVACY, RPC_C_AUTHN_GSS_NEGOTIATE

--- a/examples/mqtt_check.py
+++ b/examples/mqtt_check.py
@@ -24,6 +24,16 @@ import argparse
 import logging
 import sys
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.examples import logger
 from impacket.examples.utils import parse_target

--- a/examples/mssqlclient.py
+++ b/examples/mssqlclient.py
@@ -21,6 +21,16 @@ import argparse
 import sys
 import logging
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.examples import logger
 from impacket.examples.mssqlshell import SQLSHELL
 from impacket.examples.utils import parse_target

--- a/examples/mssqlinstance.py
+++ b/examples/mssqlinstance.py
@@ -23,6 +23,16 @@ import argparse
 import sys
 import logging
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.examples import logger
 from impacket import version, tds
 

--- a/examples/netview.py
+++ b/examples/netview.py
@@ -58,6 +58,16 @@ from threading import Thread, Event
 from queue import Queue
 from time import sleep
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.examples import logger
 from impacket.examples.utils import parse_credentials
 from impacket import version

--- a/examples/nmapAnswerMachine.py
+++ b/examples/nmapAnswerMachine.py
@@ -15,6 +15,17 @@ try:
 except ImportError:
     import pcapy
 
+import os
+import sys
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import ImpactPacket
 from impacket import ImpactDecoder
 from impacket.ImpactPacket import TCPOption, array_tobytes

--- a/examples/ntfs-read.py
+++ b/examples/ntfs-read.py
@@ -41,6 +41,15 @@ except ImportError:
   import readline
 from six import PY2, text_type
 from datetime import datetime
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.examples import logger
 from impacket import version
 from impacket.structure import Structure

--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -47,6 +47,16 @@ import json
 from time import sleep
 from threading import Thread
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.examples import logger
 from impacket.examples.ntlmrelayx.servers import SMBRelayServer, HTTPRelayServer, WCFRelayServer, RAWRelayServer

--- a/examples/ping.py
+++ b/examples/ping.py
@@ -32,6 +32,16 @@ import socket
 import time
 import sys
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import ImpactDecoder, ImpactPacket
 
 if len(sys.argv) < 3:

--- a/examples/ping6.py
+++ b/examples/ping6.py
@@ -31,6 +31,16 @@ import socket
 import time
 import sys
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import ImpactDecoder, IP6, ICMP6, version
 
 print(version.BANNER)

--- a/examples/psexec.py
+++ b/examples/psexec.py
@@ -29,6 +29,15 @@ import string
 import time
 from six import PY3
 
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.examples import logger
 from impacket import version, smb
 from impacket.smbconnection import SMBConnection

--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -79,6 +79,15 @@ except ImportError:
      logging.critical('This module needs pyasn1 installed')
      logging.critical('You can get it from https://pypi.python.org/pypi/pyasn1')
      sys.exit(1)
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.krb5.types import Principal, KerberosTime
 from impacket.krb5 import constants

--- a/examples/rbcd.py
+++ b/examples/rbcd.py
@@ -27,6 +27,16 @@ import ldapdomaindump
 from binascii import unhexlify
 from ldap3.protocol.formatters.formatters import format_sid
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.examples import logger, utils
 from impacket.ldap import ldaptypes

--- a/examples/rdp_check.py
+++ b/examples/rdp_check.py
@@ -22,6 +22,17 @@
 
 from struct import pack, unpack
 
+import os
+import sys
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.examples import logger
 from impacket.examples.utils import parse_target
 from impacket.structure import Structure

--- a/examples/reg.py
+++ b/examples/reg.py
@@ -35,6 +35,16 @@ import sys
 import time
 from struct import unpack
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.dcerpc.v5 import transport, rrp, scmr, rpcrt
 from impacket.examples import logger

--- a/examples/registry-read.py
+++ b/examples/registry-read.py
@@ -24,6 +24,16 @@ import argparse
 import ntpath
 from binascii import unhexlify, hexlify
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.examples import logger
 from impacket import version
 from impacket import winregistry

--- a/examples/rpcdump.py
+++ b/examples/rpcdump.py
@@ -24,6 +24,16 @@ import sys
 import logging
 import argparse
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.http import AUTH_NTLM
 from impacket.examples import logger
 from impacket.examples.utils import parse_target

--- a/examples/rpcmap.py
+++ b/examples/rpcmap.py
@@ -35,6 +35,16 @@ import sys
 import logging
 import argparse
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.http import AUTH_BASIC
 from impacket.examples import logger, rpcdatabase
 from impacket.examples.utils import parse_credentials

--- a/examples/sambaPipe.py
+++ b/examples/sambaPipe.py
@@ -34,6 +34,16 @@ import logging
 import sys
 from os import path
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.examples import logger
 from impacket.examples.utils import parse_target

--- a/examples/samrdump.py
+++ b/examples/samrdump.py
@@ -26,6 +26,16 @@ import argparse
 import codecs
 
 from datetime import datetime
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.examples import logger
 from impacket.examples.utils import parse_target
 from impacket import version

--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -56,6 +56,15 @@ import logging
 import os
 import sys
 
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.examples import logger
 from impacket.examples.utils import parse_target

--- a/examples/services.py
+++ b/examples/services.py
@@ -27,6 +27,16 @@ import argparse
 import logging
 import codecs
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.examples import logger
 from impacket.examples.utils import parse_target
 from impacket import version

--- a/examples/smbclient.py
+++ b/examples/smbclient.py
@@ -22,6 +22,16 @@ from __future__ import print_function
 import sys
 import logging
 import argparse
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.examples import logger
 from impacket.examples.utils import parse_target
 from impacket.examples.smbclient import MiniImpacketShell

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -48,6 +48,15 @@ import logging
 from threading import Thread
 from base64 import b64encode
 
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.examples import logger
 from impacket.examples.utils import parse_target
 from impacket import version, smbserver

--- a/examples/smbpasswd.py
+++ b/examples/smbpasswd.py
@@ -44,6 +44,16 @@ import logging
 from getpass import getpass
 from argparse import ArgumentParser
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.examples import logger
 from impacket.examples.utils import parse_target

--- a/examples/smbrelayx.py
+++ b/examples/smbrelayx.py
@@ -57,6 +57,15 @@ from struct import pack, unpack
 from threading import Thread
 from six import PY2
 
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.dcerpc.v5 import nrpc
 from impacket.dcerpc.v5 import transport

--- a/examples/smbserver.py
+++ b/examples/smbserver.py
@@ -18,6 +18,16 @@ import sys
 import argparse
 import logging
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.examples import logger
 from impacket import smbserver, version
 from impacket.ntlm import compute_lmhash, compute_nthash

--- a/examples/sniff.py
+++ b/examples/sniff.py
@@ -31,6 +31,16 @@ from threading import Thread
 import pcapy
 from pcapy import findalldevs, open_live
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.ImpactDecoder import EthDecoder, LinuxSLLDecoder
 
 

--- a/examples/sniffer.py
+++ b/examples/sniffer.py
@@ -28,6 +28,16 @@ from select import select
 import socket
 import sys
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import ImpactDecoder
 
 DEFAULT_PROTOCOLS = ('icmp', 'tcp', 'udp')

--- a/examples/split.py
+++ b/examples/split.py
@@ -28,6 +28,16 @@ import sys
 import pcapy
 from pcapy import open_offline
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.ImpactDecoder import EthDecoder, LinuxSLLDecoder
 
 

--- a/examples/ticketConverter.py
+++ b/examples/ticketConverter.py
@@ -28,6 +28,17 @@
 import argparse
 import struct
 
+import os
+import sys
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.krb5.ccache import CCache
 

--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -58,6 +58,16 @@ from binascii import unhexlify
 from pyasn1.codec.der import encoder, decoder
 from pyasn1.type.univ import noValue
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.dcerpc.v5.dtypes import RPC_SID, SID
 from impacket.dcerpc.v5.ndr import NDRULONG

--- a/examples/tstool.py
+++ b/examples/tstool.py
@@ -33,6 +33,16 @@ import logging
 import sys
 from struct import unpack
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket import version
 from impacket.examples import logger
 from impacket.examples.utils import parse_target

--- a/examples/wmiexec.py
+++ b/examples/wmiexec.py
@@ -33,6 +33,15 @@ import logging
 import ntpath
 from base64 import b64encode
 
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.examples import logger
 from impacket.examples.utils import parse_target
 from impacket import version

--- a/examples/wmipersist.py
+++ b/examples/wmipersist.py
@@ -53,6 +53,16 @@ import sys
 import argparse
 import logging
 
+import os
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.examples import logger
 from impacket.examples.utils import parse_target
 from impacket import version

--- a/examples/wmiquery.py
+++ b/examples/wmiquery.py
@@ -28,6 +28,15 @@ import sys
 import os
 import logging
 
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
 from impacket.examples import logger
 from impacket.examples.utils import parse_target
 from impacket import version


### PR DESCRIPTION
Since every single Python script in the `examples` directory failed to run in BASH terminal, I sat down and fixed each of them with this one workaround I know well: the absolute path to the local module must be appended to `sys.path` before you can import the local module.

This fix doesn't cause any regression — it only allows the scripts in the `examples` directory to run in BASH terminal without error.

Older related issues:
* https://github.com/fortra/impacket/issues/1366
* https://github.com/fortra/impacket/issues/1180
* https://github.com/fortra/impacket/issues/1083
* https://github.com/fortra/impacket/issues/1078