### PR TITLE
Deleted hardcoded service name in smbexec and ensure that the output file is deleted

### DIFF
--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -57,7 +57,6 @@ from impacket.krb5.keytab import Keytab
 OUTPUT_FILENAME = '__output'
 SMBSERVER_DIR   = '__tmp'
 DUMMY_SHARE     = 'TMP'
-SERVICE_NAME    = 'BTOBTO'
 CODEC = sys.stdout.encoding
 
 class SMBServer(Thread):
@@ -120,7 +119,7 @@ class SMBServer(Thread):
 
 class CMDEXEC:
     def __init__(self, username='', password='', domain='', hashes=None, aesKey=None, doKerberos=None,
-                 kdcHost=None, mode=None, share=None, port=445, serviceName=SERVICE_NAME, shell_type=None):
+                 kdcHost=None, mode=None, share=None, port=445, serviceName='BTOBTO', shell_type=None):
 
         self.__username = username
         self.__password = password
@@ -338,7 +337,7 @@ if __name__ == '__main__':
                        'name and you cannot resolve it')
     group.add_argument('-port', choices=['139', '445'], nargs='?', default='445', metavar="destination port",
                        help='Destination port to connect to SMB Server')
-    group.add_argument('-service-name', action='store', metavar="service_name", default = SERVICE_NAME, help='The name of the'
+    group.add_argument('-service-name', action='store', metavar="service_name", help='The name of the'
                                          'service used to trigger the payload')
 
     group = parser.add_argument_group('authentication')
@@ -394,6 +393,11 @@ if __name__ == '__main__':
     if options.aesKey is not None:
         options.k = True
 
+    if options.service_name is None:
+        options.service_name = ''.join([random.choice(string.ascii_letters) for i in range(8)])
+
+    logging.info(options.service_name)
+    
     try:
         executer = CMDEXEC(username, password, domain, options.hashes, options.aesKey, options.k, options.dc_ip,
                            options.mode, options.share, int(options.port), options.service_name, options.shell_type)

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -206,8 +206,13 @@ class RemoteShell(cmd.Cmd):
         self.transferClient = rpc.get_smb_connection()
         self.do_cd('')
 
-    def finish(self):
-        logging.info("FINISH!")
+    def finish(self):        
+        # Just in case the ouput file is still in the share
+        try:
+            self.transferClient.deleteFile(self.__share, OUTPUT_FILENAME)
+        except:
+            pass
+        
         # Just in case the service is still created
         try:
            self.__scmr = self.__rpc.get_dce_rpc()
@@ -223,8 +228,7 @@ class RemoteShell(cmd.Cmd):
         except scmr.DCERPCException:
            pass
         
-        # Just in case the ouput file is still in the share
-        self.transferClient.deleteFile(self.__share, OUTPUT_FILENAME)
+
 
     def do_shell(self, s):
         os.system(s)

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -119,12 +119,11 @@ class SMBServer(Thread):
 
 class CMDEXEC:
     def __init__(self, username='', password='', domain='', hashes=None, aesKey=None, doKerberos=None,
-                 kdcHost=None, mode=None, share=None, port=445, serviceName='BTOBTO', shell_type=None):
+                 kdcHost=None, mode=None, share=None, port=445, serviceName=None, shell_type=None):
 
         self.__username = username
         self.__password = password
         self.__port = port
-        self.__serviceName = serviceName
         self.__domain = domain
         self.__lmhash = ''
         self.__nthash = ''
@@ -137,6 +136,11 @@ class CMDEXEC:
         self.shell = None
         if hashes is not None:
             self.__lmhash, self.__nthash = hashes.split(':')
+
+        if serviceName is None:
+            self.__serviceName = ''.join([random.choice(string.ascii_letters) for i in range(8)])
+        else:
+            self.__serviceName = serviceName
 
     def run(self, remoteName, remoteHost):
         stringbinding = r'ncacn_np:%s[\pipe\svcctl]' % remoteName
@@ -400,9 +404,6 @@ if __name__ == '__main__':
 
     if options.aesKey is not None:
         options.k = True
-
-    if options.service_name is None:
-        options.service_name = ''.join([random.choice(string.ascii_letters) for i in range(8)])
 
     try:
         executer = CMDEXEC(username, password, domain, options.hashes, options.aesKey, options.k, options.dc_ip,

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -207,6 +207,7 @@ class RemoteShell(cmd.Cmd):
         self.do_cd('')
 
     def finish(self):
+        logging.info("FINISH!")
         # Just in case the service is still created
         try:
            self.__scmr = self.__rpc.get_dce_rpc()
@@ -221,6 +222,9 @@ class RemoteShell(cmd.Cmd):
            scmr.hRCloseServiceHandle(self.__scmr, service)
         except scmr.DCERPCException:
            pass
+        
+        # Just in case the ouput file is still in the share
+        self.transferClient.deleteFile(self.__share, OUTPUT_FILENAME)
 
     def do_shell(self, s):
         os.system(s)
@@ -396,8 +400,6 @@ if __name__ == '__main__':
     if options.service_name is None:
         options.service_name = ''.join([random.choice(string.ascii_letters) for i in range(8)])
 
-    logging.info(options.service_name)
-    
     try:
         executer = CMDEXEC(username, password, domain, options.hashes, options.aesKey, options.k, options.dc_ip,
                            options.mode, options.share, int(options.port), options.service_name, options.shell_type)

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -231,8 +231,6 @@ class RemoteShell(cmd.Cmd):
            scmr.hRCloseServiceHandle(self.__scmr, service)
         except scmr.DCERPCException:
            pass
-        
-
 
     def do_shell(self, s):
         os.system(s)


### PR DESCRIPTION
The service name for smbexec was hardcoded to ‘BTOBTO’, now if not specified as a parameter, the service name will be randomly generated. Also the output file is also deleted on the share in on finish just in case the file is still there.