### PR TITLE
Fix crash in winregistry.py

### DIFF
--- a/impacket/winregistry.py
+++ b/impacket/winregistry.py
@@ -385,8 +385,8 @@ class Registry:
         return parentKey
 
     def printValue(self, valueType, valueData):
-        if valueType == REG_SZ or valueType == REG_EXPAND_SZ:
-            if type(valueData) is int:
+        if valueType in [REG_SZ, REG_EXPAND_SZ, REG_MULTISZ]:
+            if isinstance(valueData, int):
                 print('NULL')
             else:
                 print("%s" % (valueData.decode('utf-16le')))
@@ -406,8 +406,6 @@ class Registry:
                     print(" NULL")
             except:
                 print(" NULL")
-        elif valueType == REG_MULTISZ:
-            print("%s" % (valueData.decode('utf-16le')))
         else:
             print("Unknown Type 0x%x!" % valueType)
             hexdump(valueData)


### PR DESCRIPTION
I encountered the following crash when using `registry-read.py`:

```
$ registry-read.py registry__system.hiv enum_values -name 'ControlSet001\Services\LanmanServer\Parameters'
Impacket v0.10.0 - Copyright 2022 SecureAuth Corporation

[ControlSet001\Services\LanmanServer\Parameters]

[b'EnableAuthenticateUserSharing', b'NullSessionPipes', b'ServiceDll', b'ServiceDllUnloadOnStop', b'autodisconnect', b'enableforcedlogoff', b'enablesecuritysignature', b'requiresecuritysignature', b'restrictnullsessaccess', b'Guid']
  b'EnableAuthenticateUserSharing':  0
  b'NullSessionPipes'           :  Traceback (most recent call last):
  File "/home/laxa/.local/bin/registry-read.py", line 172, in <module>
    main()
  File "/home/laxa/.local/bin/registry-read.py", line 161, in main
    enumValues(reg, options.name)
  File "/home/laxa/.local/bin/registry-read.py", line 97, in enumValues
    reg.printValue(data[0],data[1])
  File "/home/laxa/.local/lib/python3.9/site-packages/impacket/winregistry.py", line 410, in printValue
    print("%s" % (valueData.decode('utf-16le')))
AttributeError: 'int' object has no attribute 'decode'
```

This patch is straightforward and fix the aforementioned issue.