### PR TITLE
Modified parse_target regex to support backslashes

### DIFF
--- a/impacket/examples/utils.py
+++ b/impacket/examples/utils.py
@@ -16,7 +16,7 @@ import re
 
 
 # Regular expression to parse target information
-target_regex = re.compile(r"(?:(?:([^/@:]*)/)?([^@:]*)(?::([^@]*))?@)?(.*)")
+target_regex = re.compile(r"(?:(?:([^/@:\\]*)[/\\])?([^@:]*)(?::([^@]*))?@)?(.*)")
 
 
 # Regular expression to parse credentials information


### PR DESCRIPTION
This change fixes #1527 as the regex now accepts backslashes as a domain separator