### PR TITLE
mssqlshell: switch back to current db after `enum_impersonate`

### DIFF
--- a/impacket/examples/mssqlshell.py
+++ b/impacket/examples/mssqlshell.py
@@ -38,7 +38,7 @@ class SQLSHELL(cmd.Cmd):
     disable_xp_cmdshell        - you know what it means
     enum_db                    - enum databases
     enum_links                 - enum linked servers
-    enum_impersonate           - check logins that can be impersonate
+    enum_impersonate           - check logins that can be impersonated
     enum_logins                - enum login users
     enum_users                 - enum current db users
     enum_owner                 - enum db owner
@@ -203,6 +203,7 @@ class SQLSHELL(cmd.Cmd):
             pass
 
     def do_enum_impersonate(self, line):
+        old_db = self.sql.currentDB
         try:
             self.sql_query("select name from sys.databases")
             result = []
@@ -232,6 +233,8 @@ class SQLSHELL(cmd.Cmd):
             self.sql.printRows()
         except:
             pass
+        finally:
+            self.sql_query("use " + old_db)
 
     def do_enum_logins(self, line):
         try:


### PR DESCRIPTION
When running `enum_impersonate` in the SQL shell, it will cycle through all available databases and remains in the last one. This is unexpected because it silently changes the current database. The following screenshot illustrates the issue.

![enum_impersonate-users](https://github.com/fortra/impacket/assets/5670236/2ba88195-6d80-415f-9339-ce96751c4ee4)

This change ensures the current database after running `enum_impersonate` is the same as before.