### PR TITLE
The tree command of "smbclient.py" does not parse the path correct.

### DIFF
--- a/impacket/examples/smbclient.py
+++ b/impacket/examples/smbclient.py
@@ -433,20 +433,13 @@ class MiniImpacketShell(cmd.Cmd):
             LOG.error("No share selected")
             return
 
-        if(not filepath.startswith("/")):
-            filepath = self.pwd + "/" + filepath + "/*"
-        if(filepath == "" or filepath == "./" or filepath == "./*"):
-            filepath = self.pwd + "/*"
-        if(filepath.startswith("./")):
-            filepath = self.pwd + filepath.strip(".")
-        if("./" in filepath and not filepath.startswith("./") and not filepath.endswith("./")):
-            filepath = filepath.replace("./","")
-        if(filepath.endswith("/") or not filepath.endswith("/*")):
-            filepath = filepath + "/*"
-        if(filepath.endswith("/*/*")):
-            filepath = filepath.replace("/*/*", "/*")
         filepath = filepath.replace("\\", "/")
-        
+        if not filepath.startswith("/"):
+            filepath = self.pwd.replace("\\", "/")  + "/" + filepath
+        if(not filepath.endswith("/*")):
+            filepath = filepath + "/*"
+        filepath = os.path.abspath(filepath).replace("//","/")
+
         for LINE in self.smb.listPath(self.share, filepath):
             if(LINE.is_directory()):
                 if(LINE.get_longname() == "." or LINE.get_longname() == ".."):

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -411,6 +411,9 @@ def findFirst2(path, fileName, level, searchAttributes, pktFlags=smb.SMB.FLAGS2_
         files.append(os.path.join(dirName, '..'))
 
     if pattern != '':
+        if not os.path.exists(dirName):
+            return None, 0, STATUS_OBJECT_NAME_NOT_FOUND
+
         for file in os.listdir(dirName):
             if fnmatch.fnmatch(file.lower(), pattern.lower()):
                 entry = os.path.join(dirName, file)


### PR DESCRIPTION
The tree command of "smbclient.py" does not parse the path correct.


Reproduce bug:

Server Side:
```
mkdir /tmp/smb /tmp/smb/test/ /tmp/smb/test/folder; touch /tmp/smb/test/file /tmp/smb/test/folder/file

tree /tmp/smb
/tmp/smb
└── test
    ├── file
    └── folder
        └── file

sudo smbserver.py share /tmp/smb
```

Client Side:
```
Impacket v0.12.0.dev1+20230907.33311.3f645107 - Copyright 2023 Fortra

Type help for list of commands
# use share
# tree
//test/folder
//test/file
Finished - 3 files and folders
# tree .
[-] SMB SessionError: STATUS_OBJECT_PATH_SYNTAX_BAD(The object path component was not a directory object.)
# cd test
# tree
/test//file
/test/folder/file
Finished - 2 files and folders
# tree /
[-] SMB SessionError: STATUS_OBJECT_PATH_SYNTAX_BAD(The object path component was not a directory object.)
```
