### PR TITLE
Bug Fix: Net.py had text in the wrong order

### DIFF
--- a/examples/net.py
+++ b/examples/net.py
@@ -357,12 +357,12 @@ class Net:
             print("[+] {} account deleted succesfully!".format(self.__action))
 
         elif self.__is_option_present(self.__options, 'join'):
-            print("[*] Adding user account '{}' to group '{}'".format(self.__options.name, self.__options.join))
+            print("[*] Adding user account '{}' to group '{}'".format(self.__options.join,self.__options.name))
             actionObject.Join(self.__options.name, self.__options.join)
             print("[+] User account added to {} succesfully!".format(self.__options.name))
 
         elif self.__is_option_present(self.__options, 'unjoin'):
-            print("[*] Removing user account '{}' from group '{}'".format(self.__options.name, self.__options.unjoin))
+            print("[*] Removing user account '{}' from group '{}'".format(self.__options.unjoin,self.__options.name))
             actionObject.UnJoin(self.__options.name, self.__options.unjoin)
             print("[+] User account removed from {} succesfully!".format(self.__options.name))
 


### PR DESCRIPTION
Hi,

Just fixing a small bug which I noticed in my reporting. Using net.py it had the text in the wrong order when adding or removing a user from a group. Better described with the images below:

Before Fix:
![image](https://github.com/fortra/impacket/assets/33097451/41224011-6431-4610-bde7-aabc2ced66ba)
![image](https://github.com/fortra/impacket/assets/33097451/d042e9f4-a403-4590-8d87-7498b80de922)

After Fix:
![image](https://github.com/fortra/impacket/assets/33097451/3faa9e0e-2995-4489-8c4c-a55877875198)
![image](https://github.com/fortra/impacket/assets/33097451/947d9fdb-c266-462f-badc-bc5a0b45eac3)





