### PR TITLE
Enhanced MSSQLShell in NTLMRelayX leveraging TcpShell & output messages

### DIFF
--- a/impacket/examples/mssqlshell.py
+++ b/impacket/examples/mssqlshell.py
@@ -21,6 +21,14 @@ import os
 import cmd
 import sys
 
+def handle_lastError(f):
+    def wrapper(*args):
+        try:
+            f(*args)
+        finally:
+            if(args[0].sql.lastError):
+                print(args[0].sql.lastError)
+    return wrapper
 
 class SQLSHELL(cmd.Cmd):
     def __init__(self, SQL, show_queries=False, tcpShell=None):
@@ -97,14 +105,17 @@ class SQLSHELL(cmd.Cmd):
             self.sql_query(exec_as)
             self.sql.printReplies()
 
+    @handle_lastError
     def do_exec_as_login(self, s):
         exec_as = "execute as login='%s';" % s
         self.execute_as(exec_as)
 
+    @handle_lastError
     def do_exec_as_user(self, s):
         exec_as = "execute as user='%s';" % s
         self.execute_as(exec_as)
 
+    @handle_lastError
     def do_use_link(self, s):
         if s == 'localhost':
             self.at = []
@@ -128,6 +139,7 @@ class SQLSHELL(cmd.Cmd):
     def do_shell(self, s):
         os.system(s)
 
+    @handle_lastError
     def do_xp_dirtree(self, s):
         try:
             self.sql_query("exec master.sys.xp_dirtree '%s',1,1" % s)
@@ -136,6 +148,7 @@ class SQLSHELL(cmd.Cmd):
         except:
             pass
 
+    @handle_lastError
     def do_xp_cmdshell(self, s):
         try:
             self.sql_query("exec master..xp_cmdshell '%s'" % s)
@@ -145,6 +158,7 @@ class SQLSHELL(cmd.Cmd):
         except:
             pass
 
+    @handle_lastError
     def do_sp_start_job(self, s):
         try:
             self.sql_query("DECLARE @job NVARCHAR(100);"
@@ -166,6 +180,7 @@ class SQLSHELL(cmd.Cmd):
         else:
             os.chdir(s)
 
+    @handle_lastError
     def do_enable_xp_cmdshell(self, line):
         try:
             self.sql_query("exec master.dbo.sp_configure 'show advanced options',1;RECONFIGURE;"
@@ -175,6 +190,7 @@ class SQLSHELL(cmd.Cmd):
         except:
             pass
 
+    @handle_lastError
     def do_disable_xp_cmdshell(self, line):
         try:
             self.sql_query("exec sp_configure 'xp_cmdshell', 0 ;RECONFIGURE;exec sp_configure "
@@ -184,6 +200,7 @@ class SQLSHELL(cmd.Cmd):
         except:
             pass
 
+    @handle_lastError
     def do_enum_links(self, line):
         self.sql_query("EXEC sp_linkedservers")
         self.sql.printReplies()
@@ -192,11 +209,13 @@ class SQLSHELL(cmd.Cmd):
         self.sql.printReplies()
         self.sql.printRows()
 
+    @handle_lastError
     def do_enum_users(self, line):
         self.sql_query("EXEC sp_helpuser")
         self.sql.printReplies()
         self.sql.printRows()
 
+    @handle_lastError
     def do_enum_db(self, line):
         try:
             self.sql_query("select name, is_trustworthy_on from sys.databases")
@@ -205,6 +224,7 @@ class SQLSHELL(cmd.Cmd):
         except:
             pass
 
+    @handle_lastError
     def do_enum_owner(self, line):
         try:
             self.sql_query("SELECT name [Database], suser_sname(owner_sid) [Owner] FROM sys.databases")
@@ -213,6 +233,7 @@ class SQLSHELL(cmd.Cmd):
         except:
             pass
 
+    @handle_lastError
     def do_enum_impersonate(self, line):
         old_db = self.sql.currentDB
         try:
@@ -247,6 +268,7 @@ class SQLSHELL(cmd.Cmd):
         finally:
             self.sql_query("use " + old_db)
 
+    @handle_lastError
     def do_enum_logins(self, line):
         try:
             self.sql_query("select r.name,r.type_desc,r.is_disabled, sl.sysadmin, sl.securityadmin, "
@@ -258,6 +280,7 @@ class SQLSHELL(cmd.Cmd):
         except:
             pass
 
+    @handle_lastError
     def default(self, line):
         try:
             self.sql_query(line)

--- a/impacket/examples/mssqlshell.py
+++ b/impacket/examples/mssqlshell.py
@@ -19,11 +19,22 @@
 
 import os
 import cmd
+import sys
 
 
 class SQLSHELL(cmd.Cmd):
-    def __init__(self, SQL, show_queries=False):
-        cmd.Cmd.__init__(self)
+    def __init__(self, SQL, show_queries=False, tcpShell=None):
+        if tcpShell is not None:
+            cmd.Cmd.__init__(self, stdin=tcpShell.stdin, stdout=tcpShell.stdout)
+            sys.stdout = tcpShell.stdout
+            sys.stdin = tcpShell.stdin
+            sys.stderr = tcpShell.stdout
+            self.use_rawinput = False
+            self.shell = tcpShell
+        else:
+            cmd.Cmd.__init__(self)
+            self.shell = None
+
         self.sql = SQL
         self.show_queries = show_queries
         self.at = []
@@ -259,4 +270,6 @@ class SQLSHELL(cmd.Cmd):
         pass
 
     def do_exit(self, line):
+        if self.shell is not None:
+            self.shell.close()
         return True

--- a/impacket/examples/ntlmrelayx/attacks/mssqlattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/mssqlattack.py
@@ -18,22 +18,34 @@
 from impacket import LOG
 from impacket.examples.mssqlshell import SQLSHELL
 from impacket.examples.ntlmrelayx.attacks import ProtocolAttack
+from impacket.examples.ntlmrelayx.utils.tcpshell import TcpShell
 
 PROTOCOL_ATTACK_CLASS = "MSSQLAttack"
 
 class MSSQLAttack(ProtocolAttack):
     PLUGIN_NAMES = ["MSSQL"]
+    def __init__(self, config, MSSQLclient, username):
+        ProtocolAttack.__init__(self, config, MSSQLclient, username)
+        if self.config.interactive:
+            # Launch locally listening interactive shell.
+            self.tcp_shell = TcpShell()
+
     def run(self):
+        if self.config.interactive:
+            if self.tcp_shell is not None:
+                LOG.info('Started interactive MSSQL shell via TCP on 127.0.0.1:%d' % self.tcp_shell.port)
+                # Start listening and launch interactive shell.
+                self.tcp_shell.listen()
+                mssql_shell = SQLSHELL(self.client, tcpShell=self.tcp_shell)
+                mssql_shell.cmdloop()
+                return
+
         if self.config.queries is not None:
             for query in self.config.queries:
                 LOG.info('Executing SQL: %s' % query)
                 self.client.sql_query(query)
                 self.client.printReplies()
                 self.client.printRows()
-        elif self.config.interactive is True:
-            shell = SQLSHELL(self.client)
-            shell.cmdloop()
-            return
         else:
             LOG.error('No SQL queries specified for MSSQL relay!')
 

--- a/impacket/examples/ntlmrelayx/attacks/mssqlattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/mssqlattack.py
@@ -43,9 +43,13 @@ class MSSQLAttack(ProtocolAttack):
         if self.config.queries is not None:
             for query in self.config.queries:
                 LOG.info('Executing SQL: %s' % query)
-                self.client.sql_query(query)
-                self.client.printReplies()
-                self.client.printRows()
+                try:
+                    self.client.sql_query(query)
+                    self.client.printReplies()
+                    self.client.printRows()
+                finally:
+                    if(self.client.lastError):
+                        print(self.client.lastError)
         else:
             LOG.error('No SQL queries specified for MSSQL relay!')
 

--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -1022,7 +1022,6 @@ class MSSQL:
                 if key['TokenType'] == TDS_ERROR_TOKEN:
                     error =  "ERROR(%s): Line %d: %s" % (key['ServerName'].decode('utf-16le'), key['LineNumber'], key['MsgText'].decode('utf-16le'))                                      
                     self.lastError = SQLErrorException("ERROR: Line %d: %s" % (key['LineNumber'], key['MsgText'].decode('utf-16le')))
-                    LOG.error(error)
 
                 elif key['TokenType'] == TDS_INFO_TOKEN:
                     LOG.info("INFO(%s): Line %d: %s" % (key['ServerName'].decode('utf-16le'), key['LineNumber'], key['MsgText'].decode('utf-16le')))


### PR DESCRIPTION
This PR fixes https://github.com/fortra/impacket/issues/1612

Followed the same approach as it was followed in SMB / LDAP interactive shells.

Leveraging [TcpShell](https://github.com/fortra/impacket/blob/3f645107bb4db65fd8a328399031a257723c6bfb/impacket/examples/ntlmrelayx/utils/tcpshell.py#L21) to avoid mixing messages with the relay

Also have fixed an issue by which error messages of SQL commands were shown in the NTLMRelayX console, instead tha the SQLShell

Linked https://github.com/fortra/impacket/pull/1613