### PR TITLE
Fix small mistake in `net.py` output

### DIFF
--- a/examples/net.py
+++ b/examples/net.py
@@ -357,12 +357,12 @@ class Net:
             print("[+] {} account deleted succesfully!".format(self.__action))
 
         elif self.__is_option_present(self.__options, 'join'):
-            print("[*] Adding user account '{}' to group '{}'".format(self.__options.name, self.__options.join))
+            print("[*] Adding user account '{}' to group '{}'".format(self.__options.join, self.__options.name))
             actionObject.Join(self.__options.name, self.__options.join)
             print("[+] User account added to {} succesfully!".format(self.__options.name))
 
         elif self.__is_option_present(self.__options, 'unjoin'):
-            print("[*] Removing user account '{}' from group '{}'".format(self.__options.name, self.__options.unjoin))
+            print("[*] Removing user account '{}' from group '{}'".format(self.__options.unjoin, self.__options.name))
             actionObject.UnJoin(self.__options.name, self.__options.unjoin)
             print("[+] User account removed from {} succesfully!".format(self.__options.name))
 


### PR DESCRIPTION
When adding or removing a user from a group using `net.py`, the current output is displayed:

```
$ net.py 'administrator:Password123@192.168.88.134' localgroup -name Administrators -join test
Impacket v0.12.0.dev1+20230928.173259.06217f05 - Copyright 2023 Fortra

[*] Adding user account 'Administrators' to group 'test'
[+] User account added to Administrators succesfully!
$ net.py 'administrator:Password123@192.168.88.134' localgroup -name Administrators -unjoin test
Impacket v0.12.0.dev1+20230928.173259.06217f05 - Copyright 2023 Fortra

[*] Removing user account 'Administrators' from group 'test'
[+] User account removed from Administrators succesfully!
```

This PR fixes this mistake.