### PR TITLE
Added enum_perms feature in smbclient.py to enumerate shares permissions

### DIFF
--- a/impacket/examples/smbclient.py
+++ b/impacket/examples/smbclient.py
@@ -27,6 +27,7 @@ import ntpath
 from six import PY2
 from impacket.dcerpc.v5 import samr, transport, srvs
 from impacket.dcerpc.v5.dtypes import NULL
+from impacket.examples.utils import gen_random_string
 from impacket import LOG
 from impacket.smbconnection import SMBConnection, SMB2_DIALECT_002, SMB2_DIALECT_21, SMB_DIALECT, SessionError, \
     FILE_READ_DATA, FILE_SHARE_READ, FILE_SHARE_WRITE
@@ -105,6 +106,7 @@ class MiniImpacketShell(cmd.Cmd):
  login_hash {domain/username,lmhash:nthash} - logs into the current SMB connection using the password hashes
  logoff - logs off
  shares - list available shares
+ enum_perms - enumerate shares permissions
  use {sharename} - connect to an specific share
  cd {path} - changes the current directory to {path}
  lcd {path} - changes the current local directory to {path}
@@ -327,6 +329,44 @@ class MiniImpacketShell(cmd.Cmd):
         resp = self.smb.listShares()
         for i in range(len(resp)):
             print(resp[i]['shi1_netname'][:-1])
+
+    def do_enum_perms(self, line):
+        if self.loggedIn is False:
+            LOG.error("Not logged in")
+            return
+        temp_dir = ntpath.normpath("\\" + gen_random_string())
+        permissions = []
+        shares = self.smb.listShares()
+
+        for share in shares:
+            share_name = share["shi1_netname"][:-1]
+            share_remark = share["shi1_remark"][:-1]
+            share_info = {"name": share_name, "remark": share_remark, "access": []}
+            read = False
+            write = False
+            try:
+                self.smb.listPath(share_name, "*")
+                read = True
+                share_info["access"].append("READ")
+            except SessionError as e:
+                pass
+
+            try:
+                self.smb.createDirectory(share_name, temp_dir)
+                self.smb.deleteDirectory(share_name, temp_dir)
+                write = True
+                share_info["access"].append("WRITE")
+            except SessionError as e:
+                pass
+
+            permissions.append(share_info)
+        
+        for share in permissions:
+            name = share["name"]
+            remark = share["remark"]
+            perms = share["access"]
+            print(f"{name:<15} {','.join(perms):<15} {remark}")
+
 
     def do_use(self,line):
         if self.loggedIn is False:

--- a/impacket/examples/utils.py
+++ b/impacket/examples/utils.py
@@ -12,7 +12,9 @@
 # Author:
 #   Martin Gallo (@martingalloar)
 #
+import random
 import re
+import string
 
 
 # Regular expression to parse target information
@@ -58,3 +60,6 @@ def parse_credentials(credentials):
     domain, username, password = credential_regex.match(credentials).groups('')
 
     return domain, username, password
+
+def gen_random_string(length=10):
+    return "".join(random.sample(string.ascii_letters, int(length)))


### PR DESCRIPTION
I've wanted to enumerate shares permissions right in impacket's smbclient.py. So, I've added a `do_enum_perms` function to smbclient.py and updated `do_help` function. To check for `WRITE` permission I've added `gen_random_string` function to utils to generate random names of directories.

The idea and a part of code are taken from crackmapexec. You can see the difference with standard `shares` command below.

`shares` command:

![image](https://github.com/fortra/impacket/assets/80809363/f3122232-0f9d-44de-a09a-21a99938b9e9)

`enum_perms` command:

![image](https://github.com/fortra/impacket/assets/80809363/2ee1eca8-3c1f-4a1e-aa31-3067e77bc2a3)
