### PR TITLE
fix endless loop in FIND_NEXT2

### DIFF
--- a/impacket/smb.py
+++ b/impacket/smb.py
@@ -3974,7 +3974,7 @@ class SMB(object):
                         findNextParameter['SID'] = sid
                         findNextParameter['SearchCount'] = 1024
                         findNextParameter['InformationLevel'] = SMB_FIND_FILE_BOTH_DIRECTORY_INFO
-                        findNextParameter['ResumeKey'] = 0
+                        findNextParameter['ResumeKey'] = record["FileIndex"]
                         findNextParameter['Flags'] = SMB_FIND_RETURN_RESUME_KEYS | SMB_FIND_CLOSE_AT_EOS
                         if self.__flags2 & SMB.FLAGS2_UNICODE:
                             findNextParameter['FileName'] = resume_filename + b'\x00\x00'


### PR DESCRIPTION
This fixes an endless loop between client and server in certain situations, when there is more files then fits into a single response.

According to
https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/80dc980e-fe03-455c-ada6-7c5dd6c551ba the `ResumeKey` parameter within FIND_NEXT2 request is mandatory and shall be equal to a value of `FileIndex` of the last file from the previous response. of FIND_FIRST2 or FIND_NEXT2, according:
https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/891140f4-45fc-4a7c-801d-f182a29ed4d1

Confirmed through a tcpdump of `smbclient` interracting with the same host, where impacket enters the endless loop.