### PR TITLE
start remote registry as unprivileged user in reg.py

### DIFF
--- a/examples/reg.py
+++ b/examples/reg.py
@@ -425,8 +425,10 @@ class RegHandler:
             raise Exception('Error parsing keyName %s' % keyName)
         if rootKey.upper() == 'HKLM':
             ans = rrp.hOpenLocalMachine(dce)
-        elif rootKey.upper() == 'HKU':
+        elif rootKey.upper() == 'HKCU':
             ans = rrp.hOpenCurrentUser(dce)
+        elif rootKey.upper() == 'HKU':
+            ans = rrp.hOpenUsers(dce)
         elif rootKey.upper() == 'HKCR':
             ans = rrp.hOpenClassesRoot(dce)
         else:
@@ -532,7 +534,7 @@ if __name__ == '__main__':
     query_parser.add_argument('-keyName', action='store', required=True,
                               help='Specifies the full path of the subkey. The '
                                    'keyName must include a valid root key. Valid root keys for the local computer are: HKLM,'
-                                   ' HKU, HKCR.')
+                                   ' HKU, HKCU, HKCR.')
     query_parser.add_argument('-v', action='store', metavar="VALUENAME", required=False, help='Specifies the registry '
                            'value name that is to be queried. If omitted, all value names for keyName are returned. ')
     query_parser.add_argument('-ve', action='store_true', default=False, required=False, help='Queries for the default '
@@ -545,7 +547,7 @@ if __name__ == '__main__':
     add_parser.add_argument('-keyName', action='store', required=True,
                               help='Specifies the full path of the subkey. The '
                                    'keyName must include a valid root key. Valid root keys for the local computer are: HKLM,'
-                                   ' HKU, HKCR.')
+                                   ' HKU, HKCU, HKCR.')
     add_parser.add_argument('-v', action='store', metavar="VALUENAME", required=False, help='Specifies the registry '
                            'value name that is to be set.')
     add_parser.add_argument('-vt', action='store', metavar="VALUETYPE", required=False, help='Specifies the registry '
@@ -560,7 +562,7 @@ if __name__ == '__main__':
     delete_parser.add_argument('-keyName', action='store', required=True,
                               help='Specifies the full path of the subkey. The '
                                    'keyName must include a valid root key. Valid root keys for the local computer are: HKLM,'
-                                   ' HKU, HKCR.')
+                                   ' HKU, HKCU, HKCR.')
     delete_parser.add_argument('-v', action='store', metavar="VALUENAME", required=False, help='Specifies the registry '
                            'value name that is to be deleted.')
     delete_parser.add_argument('-va', action='store_true', required=False, help='Delete all values under this key.')
@@ -576,7 +578,7 @@ if __name__ == '__main__':
     save_parser.add_argument('-keyName', action='store', required=True,
                                help='Specifies the full path of the subkey. The '
                                     'keyName must include a valid root key. Valid root keys for the local computer are: HKLM,'
-                                    ' HKU, HKCR.')
+                                    ' HKU, HKCU, HKCR.')
     save_parser.add_argument('-o', dest='outputPath', action='store', metavar='\\\\192.168.0.2\share', required=True, help='Output UNC path the target system must export the registry saves to')
 
     # A special backup command to save HKLM\SAM, HKLM\SYSTEM and HKLM\SECURITY


### PR DESCRIPTION
This PR implements the trick discovered by @antonioCoco in https://twitter.com/splinter_code/status/1715876413474025704 to trigger the start of the RemoteRegistry service as unprivileged user by opening the winreg named pipe over SMB.
Additionally `HKEY_USERS` can now be accessed trough `reg.py`.

![demo](https://github.com/fortra/impacket/assets/57419228/9a27321f-0fa2-4b8f-9685-4c108d0dcf92)