### PR TITLE
ntlmrelayx.py: Hide unnecessary 'Unsupported MechType' log messages

### DIFF
--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -258,7 +258,7 @@ class SMBRelayServer(Thread):
                        mechStr = MechTypes[mechType]
                    else:
                        mechStr = hexlify(mechType)
-                   smbServer.log("Unsupported MechType '%s'" % mechStr, logging.CRITICAL)
+                   smbServer.log("Unsupported MechType '%s'" % mechStr, logging.DEBUG)
                    # We don't know the token, we answer back again saying
                    # we just support NTLM.
                    respToken = SPNEGO_NegTokenResp()

--- a/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
@@ -158,7 +158,7 @@ class WCFRelayServer(Thread):
                                 mechStr = MechTypes[mechType]
                             else:
                                 mechStr = hexlify(mechType)
-                            LOG.error("Unsupported MechType '%s'" % mechStr)
+                            LOG.debug("Unsupported MechType '%s'" % mechStr)
                             # We don't know the token, we answer back again saying
                             # we just support NTLM.
                             respToken = SPNEGO_NegTokenResp()

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -2457,7 +2457,7 @@ class SMBCommands:
                             mechStr = MechTypes[mechType]
                         else:
                             mechStr = hexlify(mechType)
-                        smbServer.log("Unsupported MechType '%s'" % mechStr, logging.CRITICAL)
+                        smbServer.log("Unsupported MechType '%s'" % mechStr, logging.DEBUG)
                         # We don't know the token, we answer back again saying
                         # we just support NTLM.
                         # ToDo: Build this into a SPNEGO_NegTokenResp()
@@ -2859,7 +2859,7 @@ class SMB2Commands:
                         mechStr = MechTypes[mechType]
                     else:
                         mechStr = hexlify(mechType)
-                    smbServer.log("Unsupported MechType '%s'" % mechStr, logging.CRITICAL)
+                    smbServer.log("Unsupported MechType '%s'" % mechStr, logging.DEBUG)
                     # We don't know the token, we answer back again saying
                     # we just support NTLM.
                     # ToDo: Build this into a SPNEGO_NegTokenResp()


### PR DESCRIPTION
This PR changes the log level for `Unsupported MechType` messages from `CRITICAL` to `DEBUG`. These messages occur almost exclusively during SMB authentication when the counterpart prefers Kerberos over NTLM. I think there is no reason that these messages should be displayed outside of debug mode because they imply that something is wrong when rejecting the Kerberos preference is perfectly normal when NTLM is negotiated.