### PR TITLE
mssqlclient: Add `-target-ip`

### DIFF
--- a/examples/mssqlclient.py
+++ b/examples/mssqlclient.py
@@ -35,7 +35,6 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(add_help = True, description = "TDS client implementation (SSL supported).")
 
     parser.add_argument('target', action='store', help='[[domain/]username[:password]@]<targetName or address>')
-    parser.add_argument('-port', action='store', default='1433', help='target MSSQL port (default 1433)')
     parser.add_argument('-db', action='store', help='MSSQL database instance (default None)')
     parser.add_argument('-windows-auth', action='store_true', default=False, help='whether or not to use Windows '
                                                                                   'Authentication (default False)')
@@ -52,11 +51,16 @@ if __name__ == '__main__':
                        'ones specified in the command line')
     group.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key to use for Kerberos Authentication '
                                                                             '(128 or 256 bits)')
+
+    group = parser.add_argument_group('connection')
+
     group.add_argument('-dc-ip', action='store',metavar = "ip address",  help='IP Address of the domain controller. If '
                        'ommited it use the domain part (FQDN) specified in the target parameter')
     group.add_argument('-target-ip', action='store', metavar = "ip address",
                        help='IP Address of the target machine. If omitted it will use whatever was specified as target. '
                             'This is useful when target is the NetBIOS name and you cannot resolve it')
+    group.add_argument('-port', action='store', default='1433', help='target MSSQL port (default 1433)')
+
 
     if len(sys.argv)==1:
         parser.print_help()

--- a/examples/mssqlclient.py
+++ b/examples/mssqlclient.py
@@ -54,6 +54,9 @@ if __name__ == '__main__':
                                                                             '(128 or 256 bits)')
     group.add_argument('-dc-ip', action='store',metavar = "ip address",  help='IP Address of the domain controller. If '
                        'ommited it use the domain part (FQDN) specified in the target parameter')
+    group.add_argument('-target-ip', action='store', metavar = "ip address",
+                       help='IP Address of the target machine. If omitted it will use whatever was specified as target. '
+                            'This is useful when target is the NetBIOS name and you cannot resolve it')
 
     if len(sys.argv)==1:
         parser.print_help()
@@ -68,7 +71,7 @@ if __name__ == '__main__':
     else:
         logging.getLogger().setLevel(logging.INFO)
 
-    domain, username, password, address = parse_target(options.target)
+    domain, username, password, remoteName = parse_target(options.target)
 
     if domain is None:
         domain = ''
@@ -77,10 +80,13 @@ if __name__ == '__main__':
         from getpass import getpass
         password = getpass("Password:")
 
+    if options.target_ip is None:
+        options.target_ip = remoteName
+
     if options.aesKey is not None:
         options.k = True
 
-    ms_sql = tds.MSSQL(address, int(options.port))
+    ms_sql = tds.MSSQL(options.target_ip, int(options.port), remoteName)
     ms_sql.connect()
     try:
         if options.k is True:


### PR DESCRIPTION
mssqlclient doesn't have equivalent of `-target-ip`, which makes it impossible to perform Kerberos authetication without proper DNS configuration on the local machine. 

As it is now, this is what happens (without the DNS configured):
 - **using hostname as target**:  The tool won't be able to resolve the target IP, so it won't even open the connection.
 - **using IP as target** with **-k**:  The tool will open the connection, but will not be able to find/request proper TGS with the service name as it only has the IP address.