### PR TITLE
Update: example/lookupsid.py with Kerberos auth option

### DIFF
--- a/examples/lookupsid.py
+++ b/examples/lookupsid.py
@@ -40,7 +40,7 @@ class LSALookupSid:
         }
 
     def __init__(self, username='', password='', domain='', port = None,
-                 hashes = None, domain_sids = False, maxRid=4000):
+                 hashes = None, domain_sids = False, use_kerberos = False, maxRid=4000):
 
         self.__username = username
         self.__password = password
@@ -50,6 +50,7 @@ class LSALookupSid:
         self.__lmhash = ''
         self.__nthash = ''
         self.__domain_sids = domain_sids
+        self.__doKerberos = use_kerberos
         if hashes is not None:
             self.__lmhash, self.__nthash = hashes.split(':')
 
@@ -61,6 +62,7 @@ class LSALookupSid:
         logging.info('StringBinding %s'%stringbinding)
         rpctransport = transport.DCERPCTransportFactory(stringbinding)
         rpctransport.set_dport(self.__port)
+        rpctransport.set_kerberos(self.__doKerberos)
 
         if self.KNOWN_PROTOCOLS[self.__port]['set_host']:
             rpctransport.setRemoteHost(remoteHost)
@@ -168,6 +170,7 @@ if __name__ == '__main__':
 
     group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
     group.add_argument('-no-pass', action="store_true", help='don\'t ask for password (useful when proxying through smbrelayx)')
+    group.add_argument('--use-kerberos', action="store_true", help='use kerberos auth instead')
 
     if len(sys.argv)==1:
         parser.print_help()
@@ -190,7 +193,7 @@ if __name__ == '__main__':
     if options.target_ip is None:
         options.target_ip = remoteName
 
-    lookup = LSALookupSid(username, password, domain, int(options.port), options.hashes, options.domain_sids, options.maxRid)
+    lookup = LSALookupSid(username, password, domain, int(options.port), options.hashes, options.domain_sids, options.use_kerberos, options.maxRid)
     try:
         lookup.dump(remoteName, options.target_ip)
     except:


### PR DESCRIPTION
Tested on HTB Scrambled

```bash
python examples/lookupsid.py 'scrm.local/sqlsvc@dc1.scrm.local' -no-pass --use-kerberos
Impacket v0.11.0 - Copyright 2023 Fortra

[*] Brute forcing SIDs at dc1.scrm.local
[*] StringBinding ncacn_np:dc1.scrm.local[\pipe\lsarpc]
[*] Domain SID is: S-1-5-21-2743207045-1827831105-2542523200
<SNIP>...

python examples/lookupsid.py 'scrm.local/sqlsvc@dc1.scrm.local' -no-pass
Impacket v0.11.0 - Copyright 2023 Fortra

[*] Brute forcing SIDs at dc1.scrm.local
[*] StringBinding ncacn_np:dc1.scrm.local[\pipe\lsarpc]
[-] SMB SessionError: STATUS_NOT_SUPPORTED(The request is not supported.)

python examples/lookupsid.py 'scrm.local/sqlsvc@dc1.scrm.local'
Impacket v0.11.0 - Copyright 2023 Fortra

Password:
```