### PR TITLE
ntlmrelayx.py: Fix problem with SMB MessageID for the SOCKS proxy.

### DIFF
--- a/impacket/examples/ntlmrelayx/servers/socksplugins/smb.py
+++ b/impacket/examples/ntlmrelayx/servers/socksplugins/smb.py
@@ -266,7 +266,7 @@ class SMBSocksRelay(SocksRelay):
                 respSMBCommand['DialectRevision'] = SMB2_DIALECT_WILDCARD
             else:
                 respSMBCommand['DialectRevision'] = self.serverDialect
-                resp['MessageID'] = 1
+                resp['MessageID'] = recvPacket['MessageID']
             respSMBCommand['ServerGuid'] = b(''.join([random.choice(string.ascii_letters) for _ in range(16)]))
             respSMBCommand['Capabilities'] = 0x7
             respSMBCommand['MaxTransactSize'] = 65536


### PR DESCRIPTION
Fix compatibility problems with other SMB clients connecting to the SOCKS proxy created by ntlmrelayx.py
by responding to SMB2 Negotiate Protocol requests with the same MessageID as received in the request.

When using ntlmrelayx.py as a socks server, for example using the following command
`./ntlmrelayx.py -socks -t <target ip> -smb2support --no-http-server --no-wcf-server --no-raw-server`
and connecting with a non-impacket tool that use SMB2 for the initial Negotiate Protocol request,
the client will send a MessageID of 0 and the server will respond with a MessageID of 1 which will
confuse some clients and thereby breaking the connection. This is because the SOCKS smb plugin
always returns a MessageID of 1 when receiving SMB2 Negotiate Protocol requests.

Using impacket's smbclient.py 
`proxychains ./smbclient.py <domain>/<username>@<target ip> -n`
Works because this client begins by sending a SMB1 Negotiate Protocol response which the server
responds to with an SMB2 Negotiate Protocol response with a MessageID of 0. The client then sends
a new Negotiate Protocol request, this time using SMB2, with a MessageID of 1.

Using the Linux tool smbclient with proxychains to connect, this presents a problem as it will begin with SMB2 directly
and encounter a mismatch of MessageID between request and response.
`proxychains smbclient -U "<domain>/<username>" -L \\<target ip>`