### PR TITLE
bug fix issue #1675

### DIFF
--- a/impacket/structure.py
+++ b/impacket/structure.py
@@ -11,6 +11,10 @@ from __future__ import division
 from __future__ import print_function
 from struct import pack, unpack, calcsize
 from six import b, PY3
+from sys import stdout
+
+
+encoding = stdout.encoding
 
 class Structure:
     """ sublcasses can define commonHdr and/or structure.
@@ -172,7 +176,7 @@ class Structure:
         del self.fields[key]
         
     def __str__(self):
-        return self.getData()
+        return self.getData().decode(encoding)
 
     def __len__(self):
         # XXX: improve

--- a/impacket/structure.py
+++ b/impacket/structure.py
@@ -11,10 +11,8 @@ from __future__ import division
 from __future__ import print_function
 from struct import pack, unpack, calcsize
 from six import b, PY3
-from sys import stdout
+from binascii import hexlify
 
-
-encoding = stdout.encoding
 
 class Structure:
     """ sublcasses can define commonHdr and/or structure.
@@ -164,7 +162,7 @@ class Structure:
             data = data[size:]
 
         return self
-        
+
     def __setitem__(self, key, value):
         self.fields[key] = value
         self.data = None        # force recompute
@@ -174,9 +172,9 @@ class Structure:
 
     def __delitem__(self, key):
         del self.fields[key]
-        
+
     def __str__(self):
-        return self.getData().decode(encoding)
+        return hexlify(self.getData())
 
     def __len__(self):
         # XXX: improve


### PR DESCRIPTION
This PR fixes issue reported on #1675. The patch decodes bytes returned from `getData()` by default `sys.stdout` encoding. The root cause of the bug is drop Python2 supporting.

