### PR TITLE
update requirements.txt in order to drop of python2 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ pyOpenSSL>=21.0.0
 ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6
 ldapdomaindump>=0.9.0
 flask>=1.0
-pyreadline;sys_platform == 'win32'
+pyreadline3;platform_system == 'Windows'
 dsinternals


### PR DESCRIPTION
**This PR is fully about windows environment.**

`pyreadline` module is not supporting new versions of python 3.x, as specified in documentation [here](https://pypi.org/project/pyreadline/):
`Version 2.1 of pyreadline has been verfied for Python 2.7, and 3.4, 3.5.`

Since Impacket continues growing by Python3, we need to update dependencies (requirements.txt). `pyreadline3` is the new version of its previous version and supports more recent versions of python3, as specifications in [document](https://pypi.org/project/pyreadline3/).