### PR TITLE
remove redifination of hexdump() function in two files

### DIFF
--- a/examples/ntfs-read.py
+++ b/examples/ntfs-read.py
@@ -43,29 +43,8 @@ from six import PY2, text_type
 from datetime import datetime
 from impacket.examples import logger
 from impacket import version
-from impacket.structure import Structure
+from impacket.structure import Structure, hexdump
 
-
-def pretty_print(x):
-    visible = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~ '
-    return x if x in visible else '.'
-
-def hexdump(data):
-    x = str(data)
-    strLen = len(x)
-    i = 0
-    while i < strLen:
-        print("%04x  " % i, end=' ')
-        for j in range(16):
-            if i+j < strLen:
-                print("%02X" % ord(x[i+j]), end=' ')
-            else:
-                print("  ", end=' ')
-            if j%16 == 7:
-                print("", end=' ')
-        print(" ", end=' ')
-        print(''.join(pretty_print(x) for x in x[i:i+16] ))
-        i += 16
 
 # Reserved/fixed MFTs
 FIXED_MFTS = 16

--- a/impacket/ese.py
+++ b/impacket/ese.py
@@ -430,30 +430,6 @@ class ESENT_CATALOG_DATA_DEFINITION_ENTRY(Structure):
         Structure.__init__(self,data)
 
 
-#def pretty_print(x):
-#    if x in '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~ ':
-#       return x
-#    else:
-#       return '.'
-#
-#def hexdump(data):
-#    x=str(data)
-#    strLen = len(x)
-#    i = 0
-#    while i < strLen:
-#        print "%04x  " % i,
-#        for j in range(16):
-#            if i+j < strLen:
-#                print "%02X" % ord(x[i+j]),
-#
-#            else:
-#                print "  ",
-#            if j%16 == 7:
-#                print "",
-#        print " ",
-#        print ''.join(pretty_print(x) for x in x[i:i+16] )
-#        i += 16
-
 def getUnixTime(t):
     t -= 116444736000000000
     t //= 10000000


### PR DESCRIPTION
`hexdump()` and `pretty_print(x)` functions are defined multiple times in `ntfs-read.py` and `ese.py` files. This PR removes unnecessary redefinition and import function from one single source in `structure.py`.