### PR TITLE
minor change in ntfs-read.py to make it more human-readable

### DIFF
--- a/examples/ntfs-read.py
+++ b/examples/ntfs-read.py
@@ -1020,7 +1020,7 @@ class MiniShell(cmd.Cmd):
         cmd.Cmd.__init__(self)
         self.volumePath = volume
         self.volume = NTFS(volume)
-        self.rootINode = self.volume.getINode(5)
+        self.rootINode = self.volume.getINode(FILE_Root)
         self.prompt = '\\>'
         self.intro = 'Type help for list of commands'
         self.currentINode = self.rootINode


### PR DESCRIPTION
This PR makes a single line in `ntfs-read.py` more human-readable by replacing hard-coded `5` with `FILE_Root` variable.