### PR TITLE
Implement Kerberos encryption types from RFC8009 (AES HMAC-SHA2 familly)

### DIFF
--- a/examples/getST.py
+++ b/examples/getST.py
@@ -57,7 +57,7 @@ from impacket.krb5 import constants
 from impacket.krb5.asn1 import AP_REQ, AS_REP, TGS_REQ, Authenticator, TGS_REP, seq_set, seq_set_iter, PA_FOR_USER_ENC, \
     Ticket as TicketAsn1, EncTGSRepPart, PA_PAC_OPTIONS, EncTicketPart
 from impacket.krb5.ccache import CCache
-from impacket.krb5.crypto import Key, _enctype_table, _HMACMD5, _AES256CTS, Enctype
+from impacket.krb5.crypto import Key, _enctype_table, _HMACMD5, _AES256_SHA1_CTS, Enctype
 from impacket.krb5.constants import TicketFlags, encodeFlags
 from impacket.krb5.kerberosv5 import getKerberosTGS, getKerberosTGT, sendReceive
 from impacket.krb5.types import Principal, KerberosTime, Ticket
@@ -128,7 +128,7 @@ class GETST:
                             print(hexlify(nthash).decode())
                     if not aesKey:
                         salt = self.__domain.upper() + self.__user
-                        aesKey = _AES256CTS.string_to_key(self.__password, salt, params=None).contents
+                        aesKey = _AES256_SHA1_CTS.string_to_key(self.__password, salt, params=None).contents
                         if logging.getLogger().level == logging.DEBUG:
                             logging.debug('AESKey')
                             print(hexlify(aesKey).decode())
@@ -449,7 +449,7 @@ class GETST:
                         print(hexlify(nthash).decode())
                 if not aesKey:
                     salt = self.__domain.upper() + self.__user
-                    aesKey = _AES256CTS.string_to_key(self.__password, salt, params=None).contents
+                    aesKey = _AES256_SHA1_CTS.string_to_key(self.__password, salt, params=None).contents
                     if logging.getLogger().level == logging.DEBUG:
                         logging.debug('AESKey')
                         print(hexlify(aesKey).decode())

--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -82,7 +82,7 @@ from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGS
 
 from impacket.krb5 import constants, pac
 from impacket.krb5.asn1 import AP_REQ, TGS_REQ, Authenticator, seq_set, seq_set_iter, PA_FOR_USER_ENC, Ticket as TicketAsn1
-from impacket.krb5.crypto import _HMACMD5, _AES256CTS, string_to_key
+from impacket.krb5.crypto import _HMACMD5, string_to_key
 from impacket.krb5.kerberosv5 import sendReceive
 from impacket.krb5.types import Ticket
 from impacket.winregistry import hexdump
@@ -125,7 +125,7 @@ class TICKETER:
         keytab = Keytab.loadFile(filename)
         keyblock = keytab.getKey("%s@%s" % (options.spn, self.__domain))
         if keyblock:
-            if keyblock["keytype"] == Enctype.AES256 or keyblock["keytype"] == Enctype.AES128:
+            if keyblock["keytype"] == Enctype.AES256_SHA1 or keyblock["keytype"] == Enctype.AES128_SHA1:
                 options.aesKey = keyblock.hexlifiedValue()
             elif keyblock["keytype"] == Enctype.RC4:
                 options.nthash = keyblock.hexlifiedValue()
@@ -988,9 +988,9 @@ class TICKETER:
 
         checkSumFunctionServer = _checksum_table[serverChecksum['SignatureType']]
         if serverChecksum['SignatureType'] == ChecksumTypes.hmac_sha1_96_aes256.value:
-            keyServer = Key(Enctype.AES256, unhexlify(self.__options.aesKey))
+            keyServer = Key(Enctype.AES256_SHA1, unhexlify(self.__options.aesKey))
         elif serverChecksum['SignatureType'] == ChecksumTypes.hmac_sha1_96_aes128.value:
-            keyServer = Key(Enctype.AES128, unhexlify(self.__options.aesKey))
+            keyServer = Key(Enctype.AES128_SHA1, unhexlify(self.__options.aesKey))
         elif serverChecksum['SignatureType'] == ChecksumTypes.hmac_md5.value:
             keyServer = Key(Enctype.RC4, unhexlify(self.__options.nthash))
         else:
@@ -998,9 +998,9 @@ class TICKETER:
 
         checkSumFunctionPriv = _checksum_table[privSvrChecksum['SignatureType']]
         if privSvrChecksum['SignatureType'] == ChecksumTypes.hmac_sha1_96_aes256.value:
-            keyPriv = Key(Enctype.AES256, unhexlify(self.__options.aesKey))
+            keyPriv = Key(Enctype.AES256_SHA1, unhexlify(self.__options.aesKey))
         elif privSvrChecksum['SignatureType'] == ChecksumTypes.hmac_sha1_96_aes128.value:
-            keyPriv = Key(Enctype.AES128, unhexlify(self.__options.aesKey))
+            keyPriv = Key(Enctype.AES128_SHA1, unhexlify(self.__options.aesKey))
         elif privSvrChecksum['SignatureType'] == ChecksumTypes.hmac_md5.value:
             keyPriv = Key(Enctype.RC4, unhexlify(self.__options.nthash))
         else:

--- a/impacket/examples/utils.py
+++ b/impacket/examples/utils.py
@@ -19,9 +19,11 @@ import re
 target_regex = re.compile(r"(?:(?:([^/@:]*)/)?([^@:]*)(?::([^@]*))?@)?(.*)")
 
 
-# Regular expression to parse credentials information
-credential_regex = re.compile(r"(?:(?:([^/:]*)/)?([^:]*)(?::(.*))?)?")
+# Regular expression to parse Active Directory credentials information
+ad_credential_regex = re.compile(r"(?:(?:([^/:]*)/)?([^:]*)(?::(.*))?)?")
 
+# Regular expression to parse standard Kerberos credentials information
+krb5_credential_regex = re.compile(r"([^@:]*)@([^/@:]*)(?::(.*))?")
 
 def parse_target(target):
     """ Helper function to parse target information. The expected format is:
@@ -47,6 +49,8 @@ def parse_target(target):
 def parse_credentials(credentials):
     """ Helper function to parse credentials information. The expected format is:
 
+    <USERNAME@><DOMAIN><:PASSWORD>
+    OR
     <DOMAIN></USERNAME><:PASSWORD>
 
     :param credentials: credentials to parse
@@ -55,6 +59,10 @@ def parse_credentials(credentials):
     :return: tuple of domain, username and password
     :rtype: (string, string, string)
     """
-    domain, username, password = credential_regex.match(credentials).groups('')
+    res = krb5_credential_regex.match(credentials)
+    if res:
+        username, domain, password = res.groups('')
+    else:
+        domain, username, password = ad_credential_regex.match(credentials).groups('')
 
     return domain, username, password

--- a/impacket/krb5/asn1.py
+++ b/impacket/krb5/asn1.py
@@ -502,6 +502,19 @@ class PA_FOR_USER_ENC(univ.Sequence):
         _sequence_optional_component('cksum', 2, Checksum()),
         _sequence_optional_component('auth-package', 3, KerberosString()))
 
+class S4UUserID(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        _sequence_component('nonce', 0, UInt32()),
+        _sequence_optional_component("cname", 1, PrincipalName()),
+        _sequence_component("crealm", 2, Realm()),
+        _sequence_optional_component("subject-certificate", 3, univ.OctetString()),
+        _sequence_optional_component('options', 4, univ.BitString()))
+
+class PA_S4U_X509_USER(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        _sequence_component('user-id', 0, S4UUserID()),
+        _sequence_component('checksum', 1, Checksum()))
+
 class KERB_ERROR_DATA(univ.Sequence):
     componentType = namedtype.NamedTypes(
         _sequence_component('data-type', 1, Int32()),

--- a/impacket/krb5/constants.py
+++ b/impacket/krb5/constants.py
@@ -102,6 +102,7 @@ class PreAuthenticationDataTypes(Enum):
     TD_REQ_SEQ                 = 108
     PA_PAC_REQUEST             = 128
     PA_FOR_USER                = 129
+    PA_S4U_X509_USER           = 130
     PA_FX_COOKIE               = 133 
     PA_FX_FAST                 = 136
     PA_FX_ERROR                = 137

--- a/impacket/krb5/constants.py
+++ b/impacket/krb5/constants.py
@@ -461,6 +461,8 @@ class EncryptionTypes(Enum):
     des3_cbc_sha1_kd             = 16
     aes128_cts_hmac_sha1_96      = 17
     aes256_cts_hmac_sha1_96      = 18
+    aes128_cts_hmac_sha256_128   = 19
+    aes256_cts_hmac_sha384_192   = 20
     rc4_hmac                     = 23
     rc4_hmac_exp                 = 24
     subkey_keymaterial           = 65
@@ -473,3 +475,5 @@ class ChecksumTypes(Enum):
     hmac_sha1_des3_kd = 12
     hmac_sha1_96_aes128 = 15
     hmac_sha1_96_aes256 = 16
+    hmac_sha256_128_aes128 = 19
+    hmac_sha384_192_aes256 = 20

--- a/impacket/krb5/gssapi.py
+++ b/impacket/krb5/gssapi.py
@@ -68,6 +68,10 @@ def GSSAPI(cipher):
         return GSSAPI_AES256_SHA1()
     if cipher.enctype == constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value:
         return GSSAPI_AES128_SHA1()
+    if cipher.enctype == constants.EncryptionTypes.aes256_cts_hmac_sha384_192.value:
+        return GSSAPI_AES256_SHA2()
+    if cipher.enctype == constants.EncryptionTypes.aes128_cts_hmac_sha256_128.value:
+        return GSSAPI_AES128_SHA2()
     elif cipher.enctype == constants.EncryptionTypes.rc4_hmac.value:
         return GSSAPI_RC4()
     else:
@@ -289,10 +293,22 @@ class GSSAPI_AES_SHA1():
 
         return plainText[:-(token['EC']+len(self.WRAP()))], None
 
-class GSSAPI_AES256_SHA1(GSSAPI_AES):
+class GSSAPI_AES256_SHA1(GSSAPI_AES_SHA1):
     checkSumProfile = crypto._SHA1AES256
     cipherType = crypto._AES256_SHA1_CTS
 
-class GSSAPI_AES128_SHA1(GSSAPI_AES):
+class GSSAPI_AES128_SHA1(GSSAPI_AES_SHA1):
     checkSumProfile = crypto._SHA1AES128
     cipherType = crypto._AES128_SHA1_CTS
+
+class GSSAPI_AES_SHA2():
+    checkSumProfile = None
+    cipherType = None
+
+class GSSAPI_AES128_SHA256(GSSAPI_AES_SHA2):
+    checkSumProfile = crypto._SHA256AES128
+    cipherType = crypto._AES128_SHA256_CTS
+
+class GSSAPI_AES256_SHA384(GSSAPI_AES_SHA2):
+    checkSumProfile = crypto._SHA384AES256
+    cipherType = crypto._AES256_SHA384_CTS

--- a/impacket/krb5/gssapi.py
+++ b/impacket/krb5/gssapi.py
@@ -65,9 +65,9 @@ class CheckSumField(Structure):
 
 def GSSAPI(cipher):
     if cipher.enctype == constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value:
-        return GSSAPI_AES256()
+        return GSSAPI_AES256_SHA1()
     if cipher.enctype == constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value:
-        return GSSAPI_AES128()
+        return GSSAPI_AES128_SHA1()
     elif cipher.enctype == constants.EncryptionTypes.rc4_hmac.value:
         return GSSAPI_RC4()
     else:
@@ -194,7 +194,7 @@ class GSSAPI_RC4:
     def GSS_Unwrap(self, sessionKey, data, sequenceNumber, direction = 'init', encrypt=True, authData=None):
         return self.GSS_Wrap(sessionKey, data, sequenceNumber, direction, encrypt, authData)
 
-class GSSAPI_AES():
+class GSSAPI_AES_SHA1():
     checkSumProfile = None
     cipherType = None
 
@@ -289,10 +289,10 @@ class GSSAPI_AES():
 
         return plainText[:-(token['EC']+len(self.WRAP()))], None
 
-class GSSAPI_AES256(GSSAPI_AES):
+class GSSAPI_AES256_SHA1(GSSAPI_AES):
     checkSumProfile = crypto._SHA1AES256
-    cipherType = crypto._AES256CTS
+    cipherType = crypto._AES256_SHA1_CTS
 
-class GSSAPI_AES128(GSSAPI_AES):
+class GSSAPI_AES128_SHA1(GSSAPI_AES):
     checkSumProfile = crypto._SHA1AES128
-    cipherType = crypto._AES128CTS
+    cipherType = crypto._AES128_SHA1_CTS

--- a/tests/misc/test_krb5_crypto.py
+++ b/tests/misc/test_krb5_crypto.py
@@ -21,92 +21,92 @@ def h(hexstr):
 
 
 class AESTests(unittest.TestCase):
-    def test_AES128(self):
-        # AES128 encrypt and decrypt
+    def test_AES128_SHA1(self):
+        # AES128 HMAC-SHA1 encrypt and decrypt
         kb = h('9062430C8CDA3388922E6D6A509F5B7A')
         conf = h('94B491F481485B9A0678CD3C4EA386AD')
         keyusage = 2
         plain = b'9 bytesss'
         ctxt = h('68FB9679601F45C78857B2BF820FD6E53ECA8D42FD4B1D7024A09205ABB7CD2E'
                  'C26C355D2F')
-        k = Key(Enctype.AES128, kb)
+        k = Key(Enctype.AES128_SHA1, kb)
         self.assertEqual(encrypt(k, keyusage, plain, conf), ctxt)
         self.assertEqual(decrypt(k, keyusage, ctxt), plain)
 
-    def test_AES256(self):
-        # AES256 encrypt and decrypt
+    def test_AES256_SHA1(self):
+        # AES256 HMAC-SHA1 encrypt and decrypt
         kb = h('F1C795E9248A09338D82C3F8D5B567040B0110736845041347235B1404231398')
         conf = h('E45CA518B42E266AD98E165E706FFB60')
         keyusage = 4
         plain = b'30 bytes bytes bytes bytes byt'
         ctxt = h('D1137A4D634CFECE924DBC3BF6790648BD5CFF7DE0E7B99460211D0DAEF3D79A'
                  '295C688858F3B34B9CBD6EEBAE81DAF6B734D4D498B6714F1C1D')
-        k = Key(Enctype.AES256, kb)
+        k = Key(Enctype.AES256_SHA1, kb)
         self.assertEqual(encrypt(k, keyusage, plain, conf), ctxt)
         self.assertEqual(decrypt(k, keyusage, ctxt), plain)
 
-    def test_AES128_checksum(self):
-        # AES128 checksum
+    def test_AES128_SHA1_checksum(self):
+        # AES128 HMAC-SHA1 checksum
         kb = h('9062430C8CDA3388922E6D6A509F5B7A')
         keyusage = 3
         plain = b'eight nine ten eleven twelve thirteen'
         cksum = h('01A4B088D45628F6946614E3')
-        k = Key(Enctype.AES128, kb)
+        k = Key(Enctype.AES128_SHA1, kb)
         verify_checksum(Cksumtype.SHA1_AES128, k, keyusage, plain, cksum)
 
-    def test_AES256_checksum(self):
-        # AES256 checksum
+    def test_AES256_SHA1_checksum(self):
+        # AES256 HMAC-SHA1 checksum
         kb = h('B1AE4CD8462AFF1677053CC9279AAC30B796FB81CE21474DD3DDBCFEA4EC76D7')
         keyusage = 4
         plain = b'fourteen'
         cksum = h('E08739E3279E2903EC8E3836')
-        k = Key(Enctype.AES256, kb)
+        k = Key(Enctype.AES256_SHA1, kb)
         verify_checksum(Cksumtype.SHA1_AES256, k, keyusage, plain, cksum)
 
-    def test_AES128_string_to_key(self):
-        # AES128 string-to-key
+    def test_AES128_SHA1_string_to_key(self):
+        # AES128 HMAC-SHA1 string-to-key
         string = 'password'
         salt = b'ATHENA.MIT.EDUraeburn'
         params = h('00000002')
         kb = h('C651BF29E2300AC27FA469D693BDDA13')
-        k = string_to_key(Enctype.AES128, string, salt, params)
+        k = string_to_key(Enctype.AES128_SHA1, string, salt, params)
         self.assertEqual(k.contents, kb)
 
-    def test_AES256_string_to_key(self):
-        # AES256 string-to-key
+    def test_AES256_SHA1_string_to_key(self):
+        # AES256 HMAC-SHA1 string-to-key
         string = 'X' * 64
         salt = b'pass phrase equals block size'
         params = h('000004B0')
         kb = h('89ADEE3608DB8BC71F1BFBFE459486B05618B70CBAE22092534E56C553BA4B34')
-        k = string_to_key(Enctype.AES256, string, salt, params)
+        k = string_to_key(Enctype.AES256_SHA1, string, salt, params)
         self.assertEqual(k.contents, kb)
 
-    def test_AES128_prf(self):
-        # AES128 prf
+    def test_AES128_SHA1_prf(self):
+        # AES128 HMAC-SHA1 prf
         kb = h('77B39A37A868920F2A51F9DD150C5717')
-        k = string_to_key(Enctype.AES128, b'key1', b'key1')
+        k = string_to_key(Enctype.AES128_SHA1, b'key1', b'key1')
         self.assertEqual(prf(k, b'\x01\x61'), kb)
 
-    def test_AES256_prf(self):
-        # AES256 prf
+    def test_AES256_SHA1_prf(self):
+        # AES256 HMAC-SHA1 prf
         kb = h('0D674DD0F9A6806525A4D92E828BD15A')
-        k = string_to_key(Enctype.AES256, b'key2', b'key2')
+        k = string_to_key(Enctype.AES256_SHA1, b'key2', b'key2')
         self.assertEqual(prf(k, b'\x02\x62'), kb)
 
-    def test_AES128_cf2(self):
-        # AES128 cf2
+    def test_AES128_SHA1_cf2(self):
+        # AES128 HMAC-SHA1 cf2
         kb = h('97DF97E4B798B29EB31ED7280287A92A')
-        k1 = string_to_key(Enctype.AES128, b'key1', b'key1')
-        k2 = string_to_key(Enctype.AES128, b'key2', b'key2')
-        k = cf2(Enctype.AES128, k1, k2, b'a', b'b')
+        k1 = string_to_key(Enctype.AES128_SHA1, b'key1', b'key1')
+        k2 = string_to_key(Enctype.AES128_SHA1, b'key2', b'key2')
+        k = cf2(Enctype.AES128_SHA1, k1, k2, b'a', b'b')
         self.assertEqual(k.contents, kb)
 
-    def test_AES256_cf2(self):
-        # AES256 cf2
+    def test_AES256_SHA1_cf2(self):
+        # AES256 HMAC-SHA1 cf2
         kb = h('4D6CA4E629785C1F01BAF55E2E548566B9617AE3A96868C337CB93B5E72B1C7B')
-        k1 = string_to_key(Enctype.AES256, b'key1', b'key1')
-        k2 = string_to_key(Enctype.AES256, b'key2', b'key2')
-        k = cf2(Enctype.AES256, k1, k2, b'a', b'b')
+        k1 = string_to_key(Enctype.AES256_SHA1, b'key1', b'key1')
+        k2 = string_to_key(Enctype.AES256_SHA1, b'key2', b'key2')
+        k = cf2(Enctype.AES256_SHA1, k1, k2, b'a', b'b')
         self.assertEqual(k.contents, kb)
 
     def test_DES3(self):

--- a/tests/misc/test_krb5_rfc8009.py
+++ b/tests/misc/test_krb5_rfc8009.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright (C) 2023 Red Hat, Inc. All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+#
+# This test file implements test vectors from the appendix A of RFC8009
+# https://datatracker.ietf.org/doc/html/rfc8009#appendix-A
+#
+from impacket.krb5.crypto import _AES128_SHA256_CTS, _AES256_SHA384_CTS, _SHA256AES128, _SHA384AES256
+from Cryptodome.Hash import HMAC
+from struct import pack
+import unittest
+
+
+def encrypt_empty_plaintext(tcase, confounder, ke, ki, exp_ciphertext):
+    plaintext = b''
+    key = tcase.etype.random_to_key(ke)
+    c = tcase.etype.basic_encrypt(key, confounder + plaintext, bytes(tcase.etype.blocksize))
+    h = HMAC.new(ki, bytes(tcase.etype.blocksize) + c, tcase.etype.hashmod).digest()[:tcase.etype.macsize]
+    ciphertext = c + h
+    tcase.assertEqual(ciphertext, exp_ciphertext)
+    c = ciphertext[:-tcase.etype.macsize]
+    h = ciphertext[-tcase.etype.macsize:]
+    dec_plaintext = tcase.etype.basic_decrypt(key, c, bytes(tcase.etype.blocksize))[len(confounder):]
+    tcase.assertEqual(plaintext, dec_plaintext)
+    tcase.assertEqual(h, HMAC.new(ki, bytes(tcase.etype.blocksize) + c, tcase.etype.hashmod).digest()[:tcase.etype.macsize])
+
+    ciphertext = tcase.etype.encrypt(key, 2, plaintext, confounder)
+    dec_plaintext = tcase.etype.decrypt(key, 2, ciphertext)
+    tcase.assertEqual(plaintext, dec_plaintext)
+
+def encrypt_less_than_block_size(tcase, plaintext, confounder, ke, ki, exp_ciphertext):
+    key = tcase.etype.random_to_key(ke)
+    c = tcase.etype.basic_encrypt(key, confounder + plaintext, bytes(tcase.etype.blocksize))
+    h = HMAC.new(ki, bytes(tcase.etype.blocksize) + c, tcase.etype.hashmod).digest()[:tcase.etype.macsize]
+    ciphertext = c + h
+    tcase.assertEqual(ciphertext, exp_ciphertext)
+    c = ciphertext[:-tcase.etype.macsize]
+    h = ciphertext[-tcase.etype.macsize:]
+    dec_plaintext = tcase.etype.basic_decrypt(key, c, bytes(tcase.etype.blocksize))[len(confounder):]
+    tcase.assertEqual(plaintext, dec_plaintext)
+    tcase.assertEqual(h, HMAC.new(ki, bytes(tcase.etype.blocksize) + c, tcase.etype.hashmod).digest()[:tcase.etype.macsize])
+
+    ciphertext = tcase.etype.encrypt(key, 2, plaintext, confounder)
+    dec_plaintext = tcase.etype.decrypt(key, 2, ciphertext)
+    tcase.assertEqual(plaintext, dec_plaintext)
+
+def encrypt_equals_block_size(tcase, plaintext, confounder, ke, ki, exp_ciphertext):
+    key = tcase.etype.random_to_key(ke)
+    c = tcase.etype.basic_encrypt(key, confounder + plaintext, bytes(tcase.etype.blocksize))
+    h = HMAC.new(ki, bytes(tcase.etype.blocksize) + c, tcase.etype.hashmod).digest()[:tcase.etype.macsize]
+    ciphertext = c + h
+    tcase.assertEqual(ciphertext, exp_ciphertext)
+    c = ciphertext[:-tcase.etype.macsize]
+    h = ciphertext[-tcase.etype.macsize:]
+    dec_plaintext = tcase.etype.basic_decrypt(key, c, bytes(tcase.etype.blocksize))[len(confounder):]
+    tcase.assertEqual(plaintext, dec_plaintext)
+    tcase.assertEqual(h, HMAC.new(ki, bytes(tcase.etype.blocksize) + c, tcase.etype.hashmod).digest()[:tcase.etype.macsize])
+
+    ciphertext = tcase.etype.encrypt(key, 2, plaintext, confounder)
+    dec_plaintext = tcase.etype.decrypt(key, 2, ciphertext)
+    tcase.assertEqual(plaintext, dec_plaintext)
+
+def encrypt_greater_than_block_size(tcase, plaintext, confounder, ke, ki, exp_ciphertext):
+    key = tcase.etype.random_to_key(ke)
+    c = tcase.etype.basic_encrypt(key, confounder + plaintext, bytes(tcase.etype.blocksize))
+    h = HMAC.new(ki, bytes(tcase.etype.blocksize) + c, tcase.etype.hashmod).digest()[:tcase.etype.macsize]
+    ciphertext = c + h
+    tcase.assertEqual(ciphertext, exp_ciphertext)
+    c = ciphertext[:-tcase.etype.macsize]
+    h = ciphertext[-tcase.etype.macsize:]
+    dec_plaintext = tcase.etype.basic_decrypt(key, c, bytes(tcase.etype.blocksize))[len(confounder):]
+    tcase.assertEqual(plaintext, dec_plaintext)
+    tcase.assertEqual(h, HMAC.new(ki, bytes(tcase.etype.blocksize) + c, tcase.etype.hashmod).digest()[:tcase.etype.macsize])
+
+    ciphertext = tcase.etype.encrypt(key, 2, plaintext, None)
+    dec_plaintext = tcase.etype.decrypt(key, 2, ciphertext)
+    tcase.assertEqual(plaintext, dec_plaintext)
+
+def prf(tcase, inpt, exp_output, key, message):
+    output = tcase.etype.prf(tcase.etype.random_to_key(key), inpt)
+    tcase.assertEqual(output, exp_output)
+
+def string_to_key(tcase, iter_count, pw, salt, exp_key):
+    key = tcase.etype.string_to_key(pw, salt, None)
+    tcase.assertEqual(key.contents, exp_key)
+
+def key_derivation(tcase, keyusage, base_key, exp_ke, exp_ki, exp_kc):
+    key = tcase.etype.random_to_key(base_key)
+    ke = tcase.etype.random_to_key(tcase.etype.kdf_hmac_sha2(key.contents, pack('>IB', keyusage, 0xAA), tcase.etype.keysize))
+    ki = tcase.etype.random_to_key(tcase.etype.kdf_hmac_sha2(key.contents, pack('>IB', keyusage, 0x55), tcase.etype.macsize))
+    kc = tcase.etype.derive(key, pack('>IB', keyusage, 0x99))
+    tcase.assertEqual(exp_ke, ke.contents)
+    tcase.assertEqual(exp_ki, ki.contents)
+    tcase.assertEqual(exp_kc, kc.contents)
+
+def checksum(tcase, kc, plaintext, exp_checksum):
+    checksum = HMAC.new(kc, plaintext, tcase.digest.enc.hashmod).digest()[:tcase.digest.enc.macsize]
+    tcase.assertEqual(checksum, exp_checksum)
+
+
+class Aes128HmacSha256Tests(unittest.TestCase):
+    etype = _AES128_SHA256_CTS
+    digest = _SHA256AES128
+
+    def test_encrypt_empty_plaintext(self):
+        confounder = bytes.fromhex('7E 58 95 EA F2 67 24 35 BA D8 17 F5 45 A3 71 48')
+        ke = bytes.fromhex('9B 19 7D D1 E8 C5 60 9D 6E 67 C3 E3 7C 62 C7 2E')
+        ki = bytes.fromhex('9F DA 0E 56 AB 2D 85 E1 56 9A 68 86 96 C2 6A 6C')
+        exp_ciphertext = bytes.fromhex('EF 85 FB 89 0B B8 47 2F 4D AB 20 39 4D CA 78 1D AD 87 7E DA 39 D5 0C 87 0C 0D 5A 0A 8E 48 C7 18')
+        encrypt_empty_plaintext(self, confounder, ke, ki, exp_ciphertext)
+
+    def test_encrypt_less_than_block_size(self):
+        plaintext = bytes.fromhex('00 01 02 03 04 05')
+        confounder = bytes.fromhex('7B CA 28 5E 2F D4 13 0F B5 5B 1A 5C 83 BC 5B 24')
+        ke = bytes.fromhex('9B 19 7D D1 E8 C5 60 9D 6E 67 C3 E3 7C 62 C7 2E')
+        ki = bytes.fromhex('9F DA 0E 56 AB 2D 85 E1 56 9A 68 86 96 C2 6A 6C')
+        exp_ciphertext = bytes.fromhex('84 D7 F3 07 54 ED 98 7B AB 0B F3 50 6B EB 09 CF B5 54 02 CE F7 E6 87 7C E9 9E 24 7E 52 D1 6E D4 42 1D FD F8 97 6C')
+        encrypt_less_than_block_size(self, plaintext, confounder, ke, ki, exp_ciphertext)
+
+    def test_encrypt_equals_block_size(self):
+        plaintext = bytes.fromhex('00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F')
+        confounder = bytes.fromhex('56 AB 21 71 3F F6 2C 0A 14 57 20 0F 6F A9 94 8F')
+        ke = bytes.fromhex('9B 19 7D D1 E8 C5 60 9D 6E 67 C3 E3 7C 62 C7 2E')
+        ki = bytes.fromhex('9F DA 0E 56 AB 2D 85 E1 56 9A 68 86 96 C2 6A 6C')
+        exp_ciphertext = bytes.fromhex('35 17 D6 40 F5 0D DC 8A D3 62 87 22 B3 56 9D 2A E0 74 93 FA 82 63 25 40 80 EA 65 C1 00 8E 8F C2 95 FB 48 52 E7 D8 3E 1E 7C 48 C3 7E EB E6 B0 D3')
+        encrypt_equals_block_size(self, plaintext, confounder, ke, ki, exp_ciphertext)
+
+    def test_encrypt_greater_than_block_size(self):
+        plaintext = bytes.fromhex('00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14')
+        confounder = bytes.fromhex('A7 A4 E2 9A 47 28 CE 10 66 4F B6 4E 49 AD 3F AC')
+        ke = bytes.fromhex('9B 19 7D D1 E8 C5 60 9D 6E 67 C3 E3 7C 62 C7 2E')
+        ki = bytes.fromhex('9F DA 0E 56 AB 2D 85 E1 56 9A 68 86 96 C2 6A 6C')
+        exp_ciphertext = bytes.fromhex('72 0F 73 B1 8D 98 59 CD 6C CB 43 46 11 5C D3 36 C7 0F 58 ED C0 C4 43 7C 55 73 54 4C 31 C8 13 BC E1 E6 D0 72 C1 86 B3 9A 41 3C 2F 92 CA 9B 83 34 A2 87 FF CB FC')
+        encrypt_greater_than_block_size(self, plaintext, confounder, ke, ki, exp_ciphertext)
+
+    def test_prf(self):
+        inpt = b'test'
+        exp_output = bytes.fromhex('9D 18 86 16 F6 38 52 FE 86 91 5B B8 40 B4 A8 86 FF 3E 6B B0 F8 19 B4 9B 89 33 93 D3 93 85 42 95')
+        key = bytes.fromhex('37 05 D9 60 80 C1 77 28 A0 E8 00 EA B6 E0 D2 3C')
+        message = bytes.fromhex('00 00 00 01 70 72 66 00 74 65 73 74 00 00 01 00')
+        prf(self, inpt, exp_output, key, message)
+
+    def test_string_to_key(self):
+        iter_count = 32768
+        pw = b'password'
+        salt = bytes.fromhex('10 DF 9D D7 83 E5 BC 8A CE A1 73 0E 74 35 5F 61') + b'ATHENA.MIT.EDUraeburn'
+        exp_key = bytes.fromhex('08 9B CA 48 B1 05 EA 6E A7 7C A5 D2 F3 9D C5 E7')
+        string_to_key(self, iter_count, pw, salt, exp_key)
+
+    def test_key_derivation(self):
+        keyusage = 2
+        base_key = bytes.fromhex('37 05 D9 60 80 C1 77 28 A0 E8 00 EA B6 E0 D2 3C')
+        exp_ke = bytes.fromhex('9B 19 7D D1 E8 C5 60 9D 6E 67 C3 E3 7C 62 C7 2E')
+        exp_ki = bytes.fromhex('9F DA 0E 56 AB 2D 85 E1 56 9A 68 86 96 C2 6A 6C')
+        exp_kc = bytes.fromhex('B3 1A 01 8A 48 F5 47 76 F4 03 E9 A3 96 32 5D C3')
+        key_derivation(self, keyusage, base_key, exp_ke, exp_ki, exp_kc)
+
+    def test_checksum(self):
+        kc = bytes.fromhex('B3 1A 01 8A 48 F5 47 76 F4 03 E9 A3 96 32 5D C3')
+        plaintext = bytes.fromhex('00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14')
+        exp_checksum = bytes.fromhex('D7 83 67 18 66 43 D6 7B 41 1C BA 91 39 FC 1D EE')
+        checksum(self, kc, plaintext, exp_checksum)
+
+
+class Aes256HmacSha384Tests(unittest.TestCase):
+    etype = _AES256_SHA384_CTS
+    digest = _SHA384AES256
+
+    def test_encrypt_empty_plaintext(self):
+        confounder = bytes.fromhex('F7 64 E9 FA 15 C2 76 47 8B 2C 7D 0C 4E 5F 58 E4')
+        ke = bytes.fromhex('56 AB 22 BE E6 3D 82 D7 BC 52 27 F6 77 3F 8E A7 A5 EB 1C 82 51 60 C3 83 12 98 0C 44 2E 5C 7E 49')
+        ki = bytes.fromhex('69 B1 65 14 E3 CD 8E 56 B8 20 10 D5 C7 30 12 B6 22 C4 D0 0F FC 23 ED 1F')
+        exp_ciphertext = bytes.fromhex('41 F5 3F A5 BF E7 02 6D 91 FA F9 BE 95 91 95 A0 58 70 72 73 A9 6A 40 F0 A0 19 60 62 1A C6 12 74 8B 9B BF BE 7E B4 CE 3C')
+        encrypt_empty_plaintext(self, confounder, ke, ki, exp_ciphertext)
+
+    def test_encrypt_less_than_block_size(self):
+        plaintext = bytes.fromhex('00 01 02 03 04 05')
+        confounder = bytes.fromhex('B8 0D 32 51 C1 F6 47 14 94 25 6F FE 71 2D 0B 9A')
+        ke = bytes.fromhex('56 AB 22 BE E6 3D 82 D7 BC 52 27 F6 77 3F 8E A7 A5 EB 1C 82 51 60 C3 83 12 98 0C 44 2E 5C 7E 49')
+        ki = bytes.fromhex('69 B1 65 14 E3 CD 8E 56 B8 20 10 D5 C7 30 12 B6 22 C4 D0 0F FC 23 ED 1F')
+        exp_ciphertext = bytes.fromhex('4E D7 B3 7C 2B CA C8 F7 4F 23 C1 CF 07 E6 2B C7 B7 5F B3 F6 37 B9 F5 59 C7 F6 64 F6 9E AB 7B 60 92 23 75 26 EA 0D 1F 61 CB 20 D6 9D 10 F2')
+        encrypt_less_than_block_size(self, plaintext, confounder, ke, ki, exp_ciphertext)
+
+    def test_encrypt_equals_block_size(self):
+        plaintext = bytes.fromhex('00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F')
+        confounder = bytes.fromhex('53 BF 8A 0D 10 52 65 D4 E2 76 42 86 24 CE 5E 63')
+        ke = bytes.fromhex('56 AB 22 BE E6 3D 82 D7 BC 52 27 F6 77 3F 8E A7 A5 EB 1C 82 51 60 C3 83 12 98 0C 44 2E 5C 7E 49')
+        ki = bytes.fromhex('69 B1 65 14 E3 CD 8E 56 B8 20 10 D5 C7 30 12 B6 22 C4 D0 0F FC 23 ED 1F')
+        exp_ciphertext = bytes.fromhex('BC 47 FF EC 79 98 EB 91 E8 11 5C F8 D1 9D AC 4B BB E2 E1 63 E8 7D D3 7F 49 BE CA 92 02 77 64 F6 8C F5 1F 14 D7 98 C2 27 3F 35 DF 57 4D 1F 93 2E 40 C4 FF 25 5B 36 A2 66')
+        encrypt_equals_block_size(self, plaintext, confounder, ke, ki, exp_ciphertext)
+
+    def test_encrypt_greater_than_block_size(self):
+        plaintext = bytes.fromhex('00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14')
+        confounder = bytes.fromhex('76 3E 65 36 7E 86 4F 02 F5 51 53 C7 E3 B5 8A F1')
+        ke = bytes.fromhex('56 AB 22 BE E6 3D 82 D7 BC 52 27 F6 77 3F 8E A7 A5 EB 1C 82 51 60 C3 83 12 98 0C 44 2E 5C 7E 49')
+        ki = bytes.fromhex('69 B1 65 14 E3 CD 8E 56 B8 20 10 D5 C7 30 12 B6 22 C4 D0 0F FC 23 ED 1F')
+        exp_ciphertext = bytes.fromhex('40 01 3E 2D F5 8E 87 51 95 7D 28 78 BC D2 D6 FE 10 1C CF D5 56 CB 1E AE 79 DB 3C 3E E8 64 29 F2 B2 A6 02 AC 86 FE F6 EC B6 47 D6 29 5F AE 07 7A 1F EB 51 75 08 D2 C1 6B 41 92 E0 1F 62')
+        encrypt_greater_than_block_size(self, plaintext, confounder, ke, ki, exp_ciphertext)
+
+    def test_prf(self):
+        inpt = b'test'
+        exp_output = bytes.fromhex('98 01 F6 9A 36 8C 2B F6 75 E5 95 21 E1 77 D9 A0 7F 67 EF E1 CF DE 8D 3C 8D 6F 6A 02 56 E3 B1 7D B3 C1 B6 2A D1 B8 55 33 60 D1 73 67 EB 15 14 D2')
+        key = bytes.fromhex('6D 40 4D 37 FA F7 9F 9D F0 D3 35 68 D3 20 66 98 00 EB 48 36 47 2E A8 A0 26 D1 6B 71 82 46 0C 52')
+        message = bytes.fromhex('00 00 00 01 70 72 66 00 74 65 73 74 00 00 01 80')
+        prf(self, inpt, exp_output, key, message)
+
+    def test_string_to_key(self):
+        iter_count = 32768
+        pw = b'password'
+        salt = bytes.fromhex('10 DF 9D D7 83 E5 BC 8A CE A1 73 0E 74 35 5F 61') + b'ATHENA.MIT.EDUraeburn'
+        exp_key = bytes.fromhex('45 BD 80 6D BF 6A 83 3A 9C FF C1 C9 45 89 A2 22 36 7A 79 BC 21 C4 13 71 89 06 E9 F5 78 A7 84 67')
+        string_to_key(self, iter_count, pw, salt, exp_key)
+
+    def test_key_derivation(self):
+        keyusage = 2
+        base_key = bytes.fromhex('6D 40 4D 37 FA F7 9F 9D F0 D3 35 68 D3 20 66 98 00 EB 48 36 47 2E A8 A0 26 D1 6B 71 82 46 0C 52')
+        exp_ke = bytes.fromhex('56 AB 22 BE E6 3D 82 D7 BC 52 27 F6 77 3F 8E A7 A5 EB 1C 82 51 60 C3 83 12 98 0C 44 2E 5C 7E 49')
+        exp_ki = bytes.fromhex('69 B1 65 14 E3 CD 8E 56 B8 20 10 D5 C7 30 12 B6 22 C4 D0 0F FC 23 ED 1F')
+        exp_kc = bytes.fromhex('EF 57 18 BE 86 CC 84 96 3D 8B BB 50 31 E9 F5 C4 BA 41 F2 8F AF 69 E7 3D')
+        key_derivation(self, keyusage, base_key, exp_ke, exp_ki, exp_kc)
+
+    def test_checksum(self):
+        kc = bytes.fromhex('EF 57 18 BE 86 CC 84 96 3D 8B BB 50 31 E9 F5 C4 BA 41 F2 8F AF 69 E7 3D')
+        plaintext = bytes.fromhex('00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14')
+        exp_checksum = bytes.fromhex('45 EE 79 15 67 EE FC A3 7F 4A C1 E0 22 2D E8 0D 43 C3 BF A0 66 99 67 2A')
+        checksum(self, kc, plaintext, exp_checksum)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=1)


### PR DESCRIPTION
This pull request implements the following features in the Impacket library:
* Encryption types from [RFC8009](https://datatracker.ietf.org/doc/html/rfc8009)
* [`PA_S4U_X509_USER` ASN.1 sequence](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-sfu/cd9d5ca7-ce20-4693-872b-2f5dd41cbff6)
* Support for [standard Kerberos principal format](https://datatracker.ietf.org/doc/html/rfc4120#section-5.2.2)

It also modifies the `getST.py` script:
* Add support for AES HMAC-SHA2 encryption types (`-aesSha2Key` option)
* Add the [`KDC-REQ-BODY` checksum](https://datatracker.ietf.org/doc/html/rfc4120#section-5.2.7.1) to S4U2Self and S4U2Proxy TGS-REQs
* Replace the [`PA-FOR-USER` sequence](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-sfu/aceb70de-40f0-4409-87fa-df00ca145f5a) by the `PA_S4U_X509_USER` one

The motivation for these changes is to test the Bronze-Bit exploit (CVE-2020-17049) against [FreeIPA](https://www.freeipa.org/). It cannot be done with the current implementation because `getST.py` is designed to work against Active Directory only. FreeIPA differs on the following points:

* Supports and priorities AES HMAC-SHA2 encryption types
  * These encryption types are not supported by Active Directory yet
* Requires `KDC-REQ-BODY` checksums in TGS-REQ
* By default, does not allow encryption types or checksum types relying on MD5
  * Since the `PA-FOR-USER` sequence in S4U2Self requests requires HMAC-MD5, it is incompatible with FreeIPA

The `PA_S4U_X509_USER` sequence basically serves the same purpose as `PA-FOR-USER`, but it uses the checksum type associated with the encryption type of the session key. Hence it can be any of the HMAC-MD5, HMAC-SHA1 or HMAC-SHA2 ones.

To be mentioned that FreeIPA does not have the same approach as Active Directory when it comes to service principals. For Active Directory, an SPN has to be owned by a user account, and S4U requests can use this account name rather than the actual proxy service principal. This is why `getST.py` expects an identity with the `domain/username` format as final argument (the actual Active Directory format is `domain\username` format though, with `\`). This is all AD-specific. The standard Kerberos format is `username@realm` for users and `primary/hostname@realm` for services. In addition, FreeIPA service principals are meant to be used directly in S4U requests, since they don't have an "owner" in the AD sense.

As a consequence, the identify to pass to `getST.py` in order for it to work with a FreeIPA-managed service principal was something like `EXAMPLE.COM/HTTP/web.example.com` (`EXAMPLE.COM` as realm, and `HTTP/web.example.com` as service principal). This was quite confusing, so I included a commit to add support for standard Kerberos principals in addition to AD usernames.

**IMPORTANT**: This pull request requires Legrandin/pycryptodome#781 to work. The `SP800_108_Counter()` function in its current form does not allow passing null bytes in label, while this is required by RFC8009.