### PR TITLE
Add domain and username to interactive Ldap shell message

### DIFF
--- a/impacket/examples/ntlmrelayx/attacks/__init__.py
+++ b/impacket/examples/ntlmrelayx/attacks/__init__.py
@@ -39,6 +39,8 @@ class ProtocolAttack(Thread):
         self.client = client
         # By default we only use the username and remove the domain
         self.username = username.split('/')[1]
+        # But we also store the domain for later use
+        self.domain = username.split('/')[0]
 
     def run(self):
         raise RuntimeError('Virtual Function')

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -920,7 +920,7 @@ class LDAPAttack(ProtocolAttack):
 
         if self.config.interactive:
             if self.tcp_shell is not None:
-                LOG.info('Started interactive Ldap shell via TCP on 127.0.0.1:%d' % self.tcp_shell.port)
+                LOG.info('Started interactive Ldap shell via TCP on 127.0.0.1:%d as %s/%s' % (self.tcp_shell.port, self.domain, self.username))
                 # Start listening and launch interactive shell.
                 self.tcp_shell.listen()
                 ldap_shell = LdapShell(self.tcp_shell, domainDumper, self.client)


### PR DESCRIPTION
When running an ldap attack on a domain, one can encounter a large number of ldap shells being created. It is not always easy to tell which shell is using which relayed account when there are 100 shells.

I made extremely minor tweaks to:

1. Add the ability to reference the domain from `__init__` 
2. Add the domain and username to the interactive shell info log