### PR TITLE
fix smbv1 unicode name in waitNamedPipe when flags2_unicode is true.

### DIFF
--- a/impacket/smb.py
+++ b/impacket/smb.py
@@ -3607,6 +3607,15 @@ class SMB(object):
 
         setup = '\x53\x00\x00\x00'
         name = '\\PIPE%s\x00' % pipe
+        if self.__flags2 & SMB.FLAGS2_UNICODE:
+            start_of_name = 32+3+28+len(setup)#32 is smb_header,28 is parameter,3 is wordcount and bytecount
+            start_pad = 2-(start_of_name%2)
+            name = start_pad*b'\x00' + name.encode('utf-16le')
+            end_of_name = start_of_name+len(name) 
+            pad_len = 4-(end_of_name%4)
+            name += pad_len*b'\x00'
+        else:
+            name = name.encode('utf-8')
         transCommand['Parameters']['Setup'] = setup
         transCommand['Parameters']['TotalParameterCount'] = 0
         transCommand['Parameters']['TotalDataCount'] = 0


### PR DESCRIPTION
According to [MS-CIFS-SMB_COM_TRANSACTION Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/57bfc115-fe29-4482-a0fe-a935757e0a4f),If SMB_FLAGS2_UNICODE is set in the Flags2 field of the SMB Header (section 2.2.3.1) of the request, this field MUST be a null-terminated array of **16-bit Unicode characters** which MUST be aligned to **start on a 2-byte boundary** from the start of the SMB header.Pad should be used as an array of padding bytes to align the following field to a 4-byte boundary. relative to the start of the SMB Header. 