### PR TITLE
ADCS PKCS#12 clarification and formatting

### DIFF
--- a/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
@@ -16,6 +16,7 @@
 import re
 import base64
 from OpenSSL import crypto
+from textwrap import wrap
 
 from impacket import LOG
 
@@ -25,7 +26,7 @@ ELEVATED = []
 
 class ADCSAttack:
 
-    def _run(self):
+    def _run(self,text_width=80):
         key = crypto.PKey()
         key.generate_key(crypto.TYPE_RSA, 4096)
 
@@ -76,7 +77,13 @@ class ADCSAttack:
         certificate = response.read().decode()
 
         certificate_store = self.generate_pfx(key, certificate)
-        LOG.info("Base64 certificate of user %s: \n%s" % (self.username, base64.b64encode(certificate_store).decode()))
+        LOG.info("Base64-encoded PKCS#12 of user %s:" % (self.username))
+
+        pkcs_dump = base64.b64encode(certificate_store).decode()
+
+        for i in wrap(pkcs_dump,text_width):
+            print(i)
+
 
         if self.config.altName:
             LOG.info("This certificate can also be used for user : {}".format(self.config.altName))


### PR DESCRIPTION
Slight clarification of what data is being returned on ADCS attack 
Patch ADCS attack to limit line length on PKCS#12 data returned (to prevent clipboard problems w/overly long lines)