### PR TITLE
[DCOM] Fix kerberos with remoteHost & add '-target-ip' for wmiexec.py

### DIFF
--- a/examples/wmiexec.py
+++ b/examples/wmiexec.py
@@ -49,7 +49,7 @@ CODEC = sys.stdout.encoding
 
 class WMIEXEC:
     def __init__(self, command='', username='', password='', domain='', hashes=None, aesKey=None, share=None,
-                 noOutput=False, doKerberos=False, kdcHost=None, shell_type=None):
+                 noOutput=False, doKerberos=False, kdcHost=None, remoteHost="", shell_type=None):
         self.__command = command
         self.__username = username
         self.__password = password
@@ -61,6 +61,7 @@ class WMIEXEC:
         self.__noOutput = noOutput
         self.__doKerberos = doKerberos
         self.__kdcHost = kdcHost
+        self.__remoteHost = remoteHost
         self.__shell_type = shell_type
         self.shell = None
         if hashes is not None:
@@ -68,7 +69,7 @@ class WMIEXEC:
 
     def run(self, addr, silentCommand=False):
         if self.__noOutput is False and silentCommand is False:
-            smbConnection = SMBConnection(addr, addr)
+            smbConnection = SMBConnection(addr, self.__remoteHost)
             if self.__doKerberos is False:
                 smbConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
             else:
@@ -88,7 +89,7 @@ class WMIEXEC:
             smbConnection = None
 
         dcom = DCOMConnection(addr, self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
-                              self.__aesKey, oxidResolver=True, doKerberos=self.__doKerberos, kdcHost=self.__kdcHost)
+                              self.__aesKey, oxidResolver=True, doKerberos=self.__doKerberos, kdcHost=self.__kdcHost, remoteHost=self.__remoteHost)
         try:
             iInterface = dcom.CoCreateInstanceEx(wmi.CLSID_WbemLevel1Login, wmi.IID_IWbemLevel1Login)
             iWbemLevel1Login = wmi.IWbemLevel1Login(iInterface)
@@ -393,6 +394,9 @@ if __name__ == '__main__':
                                                                           '(128 or 256 bits)')
     group.add_argument('-dc-ip', action='store', metavar="ip address", help='IP Address of the domain controller. If '
                                                                             'ommited it use the domain part (FQDN) specified in the target parameter')
+    group.add_argument('-target-ip', action='store', metavar="ip address",
+                       help='IP Address of the target machine. If omitted it will use whatever was specified as target. '
+                            'This is useful when target is the NetBIOS name and you cannot resolve it')
     group.add_argument('-A', action="store", metavar="authfile", help="smbclient/mount.cifs-style authentication file. "
                                                                       "See smbclient man page's -A option.")
     group.add_argument('-keytab', action="store", help='Read keys for SPN from keytab file')
@@ -442,6 +446,9 @@ if __name__ == '__main__':
             logging.debug('loaded smbclient auth file: domain=%s, username=%s, password=%s' % (
             repr(domain), repr(username), repr(password)))
 
+        if options.target_ip is None:
+            options.target_ip = address
+
         if domain is None:
             domain = ''
 
@@ -458,7 +465,7 @@ if __name__ == '__main__':
             options.k = True
 
         executer = WMIEXEC(' '.join(options.command), username, password, domain, options.hashes, options.aesKey,
-                           options.share, options.nooutput, options.k, options.dc_ip, options.shell_type)
+                           options.share, options.nooutput, options.k, options.dc_ip, options.target_ip, options.shell_type)
         executer.run(address, options.silentcommand)
     except KeyboardInterrupt as e:
         logging.error(str(e))

--- a/impacket/dcerpc/v5/dcomrt.py
+++ b/impacket/dcerpc/v5/dcomrt.py
@@ -964,7 +964,7 @@ class DCOMConnection:
     PORTMAPS = {}
 
     def __init__(self, target, username='', password='', domain='', lmhash='', nthash='', aesKey='', TGT=None, TGS=None,
-                 authLevel=RPC_C_AUTHN_LEVEL_PKT_PRIVACY, oxidResolver=False, doKerberos=False, kdcHost=None):
+                 authLevel=RPC_C_AUTHN_LEVEL_PKT_PRIVACY, oxidResolver=False, doKerberos=False, kdcHost=None, remoteHost=None):
         self.__target = target
         self.__userName = username
         self.__password = password
@@ -979,6 +979,7 @@ class DCOMConnection:
         self.__oxidResolver = oxidResolver
         self.__doKerberos = doKerberos
         self.__kdcHost = kdcHost
+        self.__remoteHost = remoteHost
         self.initConnection()
 
     @classmethod
@@ -1058,6 +1059,10 @@ class DCOMConnection:
     def initConnection(self):
         stringBinding = r'ncacn_ip_tcp:%s' % self.__target
         rpctransport = transport.DCERPCTransportFactory(stringBinding)
+
+        if self.__remoteHost:
+            rpctransport.setRemoteHost(self.__remoteHost)
+            rpctransport.setRemoteName(self.__target)
 
         if hasattr(rpctransport, 'set_credentials') and len(self.__userName) >=0:
             # This method exists only for selected protocol sequences.
@@ -1286,6 +1291,11 @@ class INTERFACE:
                     raise Exception('Can\'t find a valid stringBinding to connect')
 
                 dcomInterface = transport.DCERPCTransportFactory(stringBinding)
+
+                if DCOMConnection.PORTMAPS[self.__target].get_rpc_transport().get_kerberos():
+                    dcomInterface.setRemoteHost(DCOMConnection.PORTMAPS[self.__target].get_rpc_transport().getRemoteHost())
+                    dcomInterface.setRemoteName(DCOMConnection.PORTMAPS[self.__target].get_rpc_transport().getRemoteName())
+
                 if hasattr(dcomInterface, 'set_credentials'):
                     # This method exists only for selected protocol sequences.
                     dcomInterface.set_credentials(*DCOMConnection.PORTMAPS[self.__target].get_credentials())
@@ -1584,7 +1594,7 @@ class IActivation:
 
         classInstance = CLASS_INSTANCE(ORPCthis, stringBindings)
         return IRemUnknown2(INTERFACE(classInstance, b''.join(resp['ppInterfaceData'][0]['abData']), ipidRemUnknown,
-                                      target=self.__portmap.get_rpc_transport().getRemoteHost()))
+                                      target=self.__portmap.get_rpc_transport().getRemoteName()))
 
 
 # 3.1.2.5.2.2 IRemoteSCMActivator Methods
@@ -1750,7 +1760,7 @@ class IRemoteSCMActivator:
         classInstance.set_auth_level(scmr['remoteReply']['authnHint'])
         classInstance.set_auth_type(self.__portmap.get_auth_type())
         return IRemUnknown2(INTERFACE(classInstance, b''.join(propsOut['ppIntfData'][0]['abData']), ipidRemUnknown,
-                                      target=self.__portmap.get_rpc_transport().getRemoteHost()))
+                                      target=self.__portmap.get_rpc_transport().getRemoteName()))
 
     def RemoteCreateInstance(self, clsId, iid):
         # Only supports one interface at a time
@@ -1914,4 +1924,4 @@ class IRemoteSCMActivator:
         classInstance.set_auth_level(scmr['remoteReply']['authnHint'])
         classInstance.set_auth_type(self.__portmap.get_auth_type())
         return IRemUnknown2(INTERFACE(classInstance, b''.join(propsOut['ppIntfData'][0]['abData']), ipidRemUnknown,
-                                      target=self.__portmap.get_rpc_transport().getRemoteHost()))
+                                      target=self.__portmap.get_rpc_transport().getRemoteName()))


### PR DESCRIPTION
Fix some logic error in `dcomrt.py`, now `wmiexec.py` can work with `-target-ip` & `-k` even without add hosts attribute into `/etc/hosts` or DNS resolution

Before: (use `-silentcommand` to avoid create smb connection)
![image](https://github.com/fortra/impacket/assets/30458572/fee1f9c0-8ba9-42cd-98f1-e93f3a009a5d)

After:
![image](https://github.com/fortra/impacket/assets/30458572/d184de48-5e10-4c07-b6c3-89ac7fb7e412)

Semi-interactive:
![image](https://github.com/fortra/impacket/assets/30458572/ea9292a8-6d20-43d4-99d0-70f6e852ac87)
