### PR TITLE
[Ntlmrelayx] keep relaying target to SMB protocol

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -182,6 +182,7 @@ def start_servers(options, threads):
         c.setCommand(options.c)
         c.setEnumLocalAdmins(options.enum_local_admins)
         c.setDisableMulti(options.no_multirelay)
+        c.setKeepRelay(options.keep_relay)
         c.setEncoding(codec)
         c.setMode(mode)
         c.setAttacks(PROTOCOL_ATTACKS)
@@ -290,6 +291,7 @@ if __name__ == '__main__':
     parser.add_argument('--raw-port', type=int, help='Port to listen on raw server', default=6666)
 
     parser.add_argument('--no-multirelay', action="store_true", required=False, help='If set, disable multi-host relay (SMB and HTTP servers)')
+    parser.add_argument('--keep-relay', action="store_true", required=False, help='If set, keeps relaying to a target even after a successful connection on it')
     parser.add_argument('-ra','--random', action='store_true', help='Randomize target selection')
     parser.add_argument('-r', action='store', metavar = 'SMBSERVER', help='Redirect HTTP requests to a file:// path on SMBSERVER')
     parser.add_argument('-l','--lootdir', action='store', type=str, required=False, metavar = 'LOOTDIR',default='.', help='Loot '

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -144,7 +144,7 @@ class SMBRelayServer(Thread):
             if self.config.mode.upper() == 'REFLECTION':
                 self.targetprocessor = TargetsProcessor(singleTarget='SMB://%s:445/' % connData['ClientIP'])
 
-            self.target = self.targetprocessor.getTarget(multiRelay=False)
+            self.target = self.targetprocessor.getTarget(multiRelay=self.config.keepRelay)
             if self.target is None:
                 LOG.info('SMBD-%s: Connection from %s controlled, but there are no more targets left!' %
                          (connId, connData['ClientIP']))
@@ -417,7 +417,7 @@ class SMBRelayServer(Thread):
         #    return self.origsmb2TreeConnect(connId, smbServer, recvPacket)
 
         try:
-            if self.config.mode.upper () == 'REFLECTION':
+            if self.config.mode.upper() == 'REFLECTION':
                 self.targetprocessor = TargetsProcessor (singleTarget='SMB://%s:445/' % connData['ClientIP'])
 
             self.target = self.targetprocessor.getTarget(identity = self.authUser)
@@ -493,7 +493,7 @@ class SMBRelayServer(Thread):
             if self.config.mode.upper() == 'REFLECTION':
                 self.targetprocessor = TargetsProcessor(singleTarget='SMB://%s:445/' % connData['ClientIP'])
 
-            self.target = self.targetprocessor.getTarget(multiRelay=False)
+            self.target = self.targetprocessor.getTarget(multiRelay=self.config.keepRelay)
             if self.target is None:
                 LOG.info('SMBD-%s: Connection from %s controlled, but there are no more targets left!' %
                          (connId, connData['ClientIP']))
@@ -772,7 +772,7 @@ class SMBRelayServer(Thread):
         #    return self.smbComTreeConnectAndX(connId, smbServer, SMBCommand, recvPacket)
 
         try:
-            if self.config.mode.upper () == 'REFLECTION':
+            if self.config.mode.upper() == 'REFLECTION':
                 self.targetprocessor = TargetsProcessor (singleTarget='SMB://%s:445/' % connData['ClientIP'])
 
             self.target = self.targetprocessor.getTarget(identity = self.authUser)

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -137,6 +137,9 @@ class NTLMRelayxConfig:
     def setDisableMulti(self, disableMulti):
         self.disableMulti = disableMulti
 
+    def setKeepRelay(self, keepRelay):
+        self.keepRelay = keepRelay
+
     def setEncoding(self, encoding):
         self.encoding = encoding
 


### PR DESCRIPTION
Add new option `--keep-relay` to keep relaying user to specific targets on SMB protocol even if the a session has already been obtained to the target