### PR TITLE
Fix: undo untested breaking changes from #1311 that change getErrorString

### DIFF
--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -712,7 +712,7 @@ class KerberosError(SessionError):
         return self.packet
 
     def getErrorString( self ):
-        return str(self)
+        return constants.ERROR_MESSAGES[self.error]
 
     def __str__( self ):
         retString = 'Kerberos SessionError: %s(%s)' % (constants.ERROR_MESSAGES[self.error])

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -712,7 +712,7 @@ class KerberosError(SessionError):
         return self.packet
 
     def getErrorString( self ):
-        return constants.ERROR_MESSAGES[self.error]
+        return nt_errors.ERROR_MESSAGES[self.error]
 
     def __str__( self ):
         retString = 'Kerberos SessionError: %s(%s)' % (constants.ERROR_MESSAGES[self.error])

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -712,7 +712,7 @@ class KerberosError(SessionError):
         return self.packet
 
     def getErrorString( self ):
-        return nt_errors.ERROR_MESSAGES[self.error]
+        return constants.ERROR_MESSAGES[self.error]
 
     def __str__( self ):
         retString = 'Kerberos SessionError: %s(%s)' % (constants.ERROR_MESSAGES[self.error])

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -986,7 +986,7 @@ class SessionError(Exception):
         return self.packet
 
     def getErrorString( self ):
-        return str(self)
+        return constants.ERROR_MESSAGES[self.error]
 
     def __str__( self ):
         key = self.error

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -986,7 +986,7 @@ class SessionError(Exception):
         return self.packet
 
     def getErrorString( self ):
-        return constants.ERROR_MESSAGES[self.error]
+        return nt_errors.ERROR_MESSAGES[self.error]
 
     def __str__( self ):
         key = self.error


### PR DESCRIPTION
#1311 was untested and broke how NetExec (previously crackmapexec) handle errors. Ironically, the PR was intended to fix something for CME, but instead it broke how all nt_status errors were handled via getErrorString.

This PR reverts the changes to the getErrorString function, which is required for NetExec to be able to use Fortra's Impacket upstream. We need to use Fortra's Impacket to have NetExec packaged on Kali Linux, so please consider testing and merging this ASAP. Thank you!