### PR TITLE
Target Domain Flags for GetNPUsers & GetADUser

### DIFF
--- a/examples/GetADUsers.py
+++ b/examples/GetADUsers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 # Impacket - Collection of Python classes for working with network protocols.
 #
 # Copyright (C) 2023 Fortra. All rights reserved.

--- a/examples/GetADUsers.py
+++ b/examples/GetADUsers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 # Impacket - Collection of Python classes for working with network protocols.
 #
 # Copyright (C) 2023 Fortra. All rights reserved.
@@ -54,16 +54,25 @@ class GetADUsers:
         self.__kdcHost = cmdLineOptions.dc_host
         self.__requestUser = cmdLineOptions.user
         self.__all = cmdLineOptions.all
+        self.__targetdomain = cmdLineOptions.targetdomain
         if cmdLineOptions.hashes is not None:
             self.__lmhash, self.__nthash = cmdLineOptions.hashes.split(':')
 
         # Create the baseDN
-        domainParts = self.__domain.split('.')
-        self.baseDN = ''
-        for i in domainParts:
-            self.baseDN += 'dc=%s,' % i
-        # Remove last ','
-        self.baseDN = self.baseDN[:-1]
+        if(self.__targetdomain == None):
+            domainParts = self.__domain.split('.')
+            self.baseDN = ''
+            for i in domainParts:
+                self.baseDN += 'dc=%s,' % i
+            # Remove last ','
+            self.baseDN = self.baseDN[:-1]
+        else:
+            domainParts = self.__targetdomain.split('.')
+            self.baseDN = ''
+            for i in domainParts:
+                self.baseDN += 'dc=%s,' % i
+            # Remove last ','
+            self.baseDN = self.baseDN[:-1]
 
         # Let's calculate the header and format
         self.__header = ["Name", "Email", "PasswordLastSet", "LastLogon"]
@@ -230,7 +239,8 @@ if __name__ == '__main__':
     group.add_argument('-dc-host', action='store', metavar='hostname', help='Hostname of the domain controller to use. '
                                                                               'If ommited, the domain part (FQDN) '
                                                                               'specified in the account parameter will be used')
-
+    group.add_argument('-targetdomain', action='store',metavar='targetdomain', help='The domain you would like to target in case'
+                                                                               'of a domain trust.')
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)

--- a/examples/GetNPUsers.py
+++ b/examples/GetNPUsers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 # Impacket - Collection of Python classes for working with network protocols.
 #
 # Copyright (C) 2023 Fortra. All rights reserved.

--- a/examples/GetNPUsers.py
+++ b/examples/GetNPUsers.py
@@ -425,7 +425,8 @@ if __name__ == '__main__':
     group.add_argument('-dc-host', action='store', metavar='hostname', help='Hostname of the domain controller to use. '
                                                                               'If ommited, the domain part (FQDN) '
                                                                               'specified in the account parameter will be used')
-    group.add_argument('-targetdomain', action='store',metavar='targetdomain', help='The domain you would like to query in case of a bidirectional-trust.')
+    group.add_argument('-targetdomain', action='store',metavar='targetdomain', help='The domain you would like to target in case'
+                                                                               'of a domain trust.')
 
     if len(sys.argv)==1:
         parser.print_help()


### PR DESCRIPTION
Hello Impacket team!
### Overview
Recently our team identified a small oddity in GetNPUsers.py && GetADUsers.py where you couldn't ASREP-Roast or query users in other domains. To remedy this, I modified the logic that both scripts use to create the LDAP search scope 
### Changes
The original code is something like so:
```python3
            domainParts = self.__domain.split('.')
            self.baseDN = ''
            for i in domainParts:
                self.baseDN += 'dc=%s,' % i
            # Remove last ','
            self.baseDN = self.baseDN[:-1]
```
Which essentially retrieves the LDAP search scope from self.__domain (which is directly passed into the init function from the main function's provided credentials). It now checks and sees if the user provided a target domain flag:
```python3
    group.add_argument('-targetdomain', action='store',metavar='targetdomain', help='The domain you would like to target in case of a domain trust.')
``
The full change in the init function now checks if the supplied value is None/Null, if so, it'll then parse from the domain. If not, it'll first prefer the users set target domain through a simple if statement:
```python3
        if(self.__targetdomain == None):
            domainParts = self.__domain.split('.')
            self.baseDN = ''
            for i in domainParts:
                self.baseDN += 'dc=%s,' % i
            # Remove last ','
            self.baseDN = self.baseDN[:-1]
        else:
            domainParts = self.__targetdomain.split('.')
            self.baseDN = ''
            for i in domainParts:
                self.baseDN += 'dc=%s,' % i
            # Remove last ','
            self.baseDN = self.baseDN[:-1]
```

Both of the code is shared within GetNPUsers.py && GetADUsers.py. The only other code change is within GetNPUsers.py within the getTGT function where a similar check (if target domain != None, set this, else, that):
```python3
        if self.__targetdomain != None:
            domain = self.__targetdomain.upper()
        else:
            domain = self.__domain.upper()
```
### Testing
This was tested in both a lab environment as well as a production active directory domain to ensure functionality wasn't broken. An example screenshot can be found here:
![image](https://github.com/fortra/impacket/assets/44957111/aedd0836-7133-4aab-b47c-33a6c5b8efdb)
In the above example, the Administrator lives in the NANAISU domain, which has a bidirectional trust with the MSP domain as seen in the following screenshot:
![image](https://github.com/fortra/impacket/assets/44957111/6348201c-6527-4267-83e0-68615b859804)
Within the MSP domain there is two users, sqlUser and Ronnie. sqlUser has "Do not require Kerberos Pre-Auth" checked to allow for GetNPUsers.py testing. 
Testing the inverse also works. Users on the MSP domain can query the NANAISU domain:
![image](https://github.com/fortra/impacket/assets/44957111/8371b8c8-3c66-4c27-b17c-7ec9f6e373dd)

If there's any questions or concerns, please let me know!
I hope this helps!