### PR TITLE
[BUG] Bad format for SMB ShadowCopy access

### DIFF
--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -1697,7 +1697,7 @@ class SMB3:
         timestamp = path[path.index("@GMT-"):path.index("@GMT-")+24]
         path = path.replace(timestamp, '')
         from datetime import datetime
-        fTime = int((datetime.strptime(timestamp, '@GMT-%Y.%m.%d-%H.%M.%S') - datetime(1970,1,1)).total_seconds())
+        fTime = int((datetime.strptime(timestamp, '@GMT-%Y.%d.%m-%H.%M.%S') - datetime(1970,1,1)).total_seconds())
         fTime *= 10000000
         fTime += 116444736000000000
 


### PR DESCRIPTION
When accessing Shadow Copies via the SMB protocol, the following format is typically utilized: '@GMT-%Y.%d.%m-%H.%M.%S'.

Impacket incorrectly implements this format by using %Y.%m.%d instead of %Y.%d.%m (noting the day before the month).

Here's a simple example:

Take note of the date in this example Shadow Snapshot:

![image](https://github.com/fortra/impacket/assets/34518201/c20c1fac-9ac1-46f5-be97-a3e4f4d1f43e)

Now, access it via SMB using the correct format:

![image](https://github.com/fortra/impacket/assets/34518201/e425d11c-b2d6-4235-9509-c46045446c14)

Reference: [https://www.4n6k.com/2017/02/forensics-quickie-accessing-copying.html](https://www.4n6k.com/2017/02/forensics-quickie-accessing-copying.html)
