### PR TITLE
add missing dep: future

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     data_files=data_files,
 
     install_requires=['pyasn1>=0.2.3', 'pyasn1_modules', 'pycryptodomex', 'pyOpenSSL>=21.0.0', 'six', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6',
-                      'ldapdomaindump>=0.9.0', 'flask>=1.0', 'setuptools', 'charset_normalizer'],
+                      'ldapdomaindump>=0.9.0', 'flask>=1.0', 'setuptools', 'charset_normalizer', 'future'],
     extras_require={'pyreadline:sys_platform=="win32"': [],
                     },
     classifiers=[


### PR DESCRIPTION
Future dependency is missing from the requirement

```
  File "/usr/lib/python3.11/site-packages/pkg_resources/__init__.py", line 870, in _resolve_dist
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'future' distribution was not found and is required by impacket
```

Maybe you would like to require 0.18.x or 1.0.0