### PR TITLE
Update rbcd.py

### DIFF
--- a/examples/rbcd.py
+++ b/examples/rbcd.py
@@ -459,6 +459,8 @@ def parse_identity(args):
 
     if args.hashes is not None:
         lmhash, nthash = args.hashes.split(':')
+        if lmhash == '':
+            lmhash = 'aad3b435b51404eeaad3b435b51404ee'
     else:
         lmhash = ''
         nthash = ''


### PR DESCRIPTION
Identified that rbcd failed with a "constrained violation" error when only using the NT hash. The solution was including the LM hash too, despite the fact that it was "blank".  Added a line that'll set the LM hash to "aad3b435b51404eeaad3b435b51404ee" if one isn't provided.