### PR TITLE
Update reg.py - Add a missing Null byte for REG_SZ values

### DIFF
--- a/examples/reg.py
+++ b/examples/reg.py
@@ -301,7 +301,7 @@ class RegHandler:
                 bin_value_len += (bin_value_len & 1)
                 valueData = binascii.a2b_hex(self.__options.vd.ljust(bin_value_len, '0'))
             else:
-                valueData = self.__options.vd
+                valueData = self.__options.vd + "\0" # Add a NULL Byte as terminator for Non Binary values
 
             ans3 = rrp.hBaseRegSetValue(
                 dce, ans2['phkResult'], self.__options.v, dwType, valueData
@@ -554,7 +554,7 @@ if __name__ == '__main__':
                                    'keyName must include a valid root key. Valid root keys for the local computer are: HKLM,'
                                    ' HKU, HKCU, HKCR.')
     add_parser.add_argument('-v', action='store', metavar="VALUENAME", required=False, help='Specifies the registry '
-                           'value name that is to be set.')
+                           'value name that is to be set. Set to "" to write the (Defualt) value')
     add_parser.add_argument('-vt', action='store', metavar="VALUETYPE", required=False, help='Specifies the registry '
                            'type name that is to be set. Default is REG_SZ. Valid types are: REG_NONE, REG_SZ, REG_EXPAND_SZ, '
                            'REG_BINARY, REG_DWORD, REG_DWORD_BIG_ENDIAN, REG_LINK, REG_MULTI_SZ, REG_QWORD',


### PR DESCRIPTION
When adding a value to the registry REG_SZ Values are missing an NULL Byte terminator.
This results sometimes in a broken key. The InProcServer32 was set via `regedit`,  the InProcServer322 via `reg.py`.
The snippet was manually redacted.

```
user@localhost ~> reg.py <creds> add -keyName "HKU\\S-1-5-21-1000\\SOFTWARE\\Classes\\CLSID\\{XYZ}\\InProcServer322" -v "" -vd "C:\tmp\some.dll"
Impacket v0.12.0.dev1+20240523.75507.15eff880 - Copyright 2023 Fortra

Successfully set key HKU\S-1-5-21-1000\SOFTWARE\Classes\CLSID\{XYZ}\InProcServer322\ of type REG_SZ to value C:\tmp\some.dll

user@localhost ~> reg.py <creds> query -keyName "HKU\\S-1-5-21-1000\\SOFTWARE\\Classes\\CLSID\\{XYZ}" -s
Impacket v0.12.0.dev1+20240523.75507.15eff880 - Copyright 2023 Fortra

S-1-5-21-1000\SOFTWARE\Classes\CLSID\{XYZ}\InProcServer32\
	(Default)	REG_SZ	 C:\tmp\some.dll
S-1-5-21-1000\SOFTWARE\Classes\CLSID\{XYZ}\InProcServer322\
	(Default)	REG_SZ	 C:\tmp\some.dl

```
When comparing those two keys, via regedit and their binary data it is getting clear that there is a missing `00` byte at the end.

Additional this PR will add a small hint, how to write the `(Default)` value of a key, which requires the -v parameter to be empty.