### PR TITLE
Add error checking for an unknown samaccountname

### DIFF
--- a/examples/rbcd.py
+++ b/examples/rbcd.py
@@ -371,8 +371,12 @@ class RBCD(object):
                 logging.info('Accounts allowed to act on behalf of other identity:')
                 for ace in sd['Dacl'].aces:
                     SID = ace['Ace']['Sid'].formatCanonical()
-                    SamAccountName = self.get_sid_info(ace['Ace']['Sid'].formatCanonical())[1]
-                    logging.info('    %-10s   (%s)' % (SamAccountName, SID))
+                    try:
+                        SamAccountName = self.get_sid_info(ace['Ace']['Sid'].formatCanonical())[1]
+                    except:
+                        logging.error('SamAccountName could not be found SID: %s' % SID)
+                        SamAccountName = 'Unknown'
+                    logging.info('    %-10s   (%s)' % (SamAccountName, SID))  
             else:
                 logging.info('Attribute msDS-AllowedToActOnBehalfOfOtherIdentity is empty')
         except IndexError:


### PR DESCRIPTION
When rbcd.py cannot determine the SamAccountName of a SID, the tool would simply fail. By adding this error checking and adding 'Unknown' for the SamAccountName, when it cannot be determined, the tool will still perform the as intended. 