### PR TITLE
Fix version parsing in git

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ try:
     if call(["git", "branch"], stderr=STDOUT, stdout=open(os.devnull, 'w')) == 0:
         p = Popen("git log -1 --format=%cd --date=format:%Y%m%d.%H%M%S", shell=True, stdin=PIPE, stderr=PIPE, stdout=PIPE)
         (outstr, __) = p.communicate()
-        (VER_CDATE,VER_CTIME) = outstr.strip().decode("utf-8").split('.')
+        (VER_CDATE,VER_CTIME) = outstr.splitlines()[-1].strip().decode("utf-8").split('.')
 
         p = Popen("git rev-parse --short HEAD", shell=True, stdin=PIPE, stderr=PIPE, stdout=PIPE)
         (outstr, __) = p.communicate()


### PR DESCRIPTION
In `setup.py`, the date and time of the last commit is determined using `git log`, but fails to take into account that users may have enabled `log.showSignature` in their global git config. If this option is true and a commit is signed, it breaks the parsing of the git output. As a result, the package fails to build, because the version number is invalid.

By just using the last line of the git output, we ensure that the signature is ignored.

This fixes #1756.