### PR TITLE
[secretsdump] Filter foreign users when parsing NTDS.dit

### DIFF
--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -1969,6 +1969,7 @@ class NTDSHashes:
         'pekList':b'ATTk590689',
         'supplementalCredentials':b'ATTk589949',
         'pwdLastSet':b'ATTq589920',
+        'instanceType':b'ATTj131073',
     }
 
     NAME_TO_ATTRTYP = {
@@ -2106,6 +2107,7 @@ class NTDSHashes:
             self.NAME_TO_INTERNAL['userAccountControl'] : 1,
             self.NAME_TO_INTERNAL['supplementalCredentials'] : 1,
             self.NAME_TO_INTERNAL['pekList'] : 1,
+            self.NAME_TO_INTERNAL['instanceType'] : 1,
 
         }
 
@@ -2127,7 +2129,7 @@ class NTDSHashes:
             elif record[self.NAME_TO_INTERNAL['pekList']] is not None:
                 peklist =  unhexlify(record[self.NAME_TO_INTERNAL['pekList']])
                 break
-            elif record[self.NAME_TO_INTERNAL['sAMAccountType']] in self.ACCOUNT_TYPES:
+            elif record[self.NAME_TO_INTERNAL['sAMAccountType']] in self.ACCOUNT_TYPES and record[self.NAME_TO_INTERNAL['instanceType']] & 4:    # "The object is writable on this directory":
                 # Okey.. we found some users, but we're not yet ready to process them.
                 # Let's just store them in a temp list
                 self.__tmpUsers.append(record)
@@ -2654,7 +2656,7 @@ class NTDSHashes:
                         if record is None:
                             break
                         try:
-                            if record[self.NAME_TO_INTERNAL['sAMAccountType']] in self.ACCOUNT_TYPES:
+                            if record[self.NAME_TO_INTERNAL['sAMAccountType']] in self.ACCOUNT_TYPES and record[self.NAME_TO_INTERNAL['instanceType']] & 4:    # "The object is writable on this directory"
                                 self.__decryptHash(record, outputFile=hashesOutputFile)
                                 if self.__justNTLM is False:
                                     self.__decryptSupplementalInfo(record, None, keysOutputFile, clearTextOutputFile)


### PR DESCRIPTION
Hi!

### Problem

NTDS.dit files can contain entries relative to principals belonging to other trusted domains (intra- or extra-forest). Naturally, foreign principals passwords are not stored in the local domain's NTDS.dit.

When parsing these files, secretsdump outputs those principals anyway, with an empty password as their NT hash. It would be better to filter them out from the output to not mislead the user (many times I have been surprised at first to see an enabled T0 user with an empty password).

### Solution

This PR aims to fix this by filtering out foreign principals based on the value of the [`instanceType` attribute](https://learn.microsoft.com/en-us/windows/win32/adschema/a-instancetype). Through trial and error, I have observed that local principals have the bit `0x4` ("The object is writable on this directory.") enabled in this attribute, while foreign ones do not.

### Example

This issue can be observed on the [GOAD lab](https://github.com/Orange-Cyberdefense/GOAD), for instance when dumping the NTDS.dit file of the `winterfell.north.sevenkingdoms.local` domain controller. Secretsdump's output will be as such. Note the presence of many foreign principals with an empty password as their NT hash, such as a duplicated `Administrator` user.

```bash
$ secretsdump.py -ntds ntds.dit -system system -user-status -just-dc-ntlm LOCAL
Impacket v0.12.0.dev1+20240523.75507.15eff880 - Copyright 2023 Fortra

[*] Target system bootKey: 0x6457f466e87a6ec861b680d31c7a6759
[*] Dumping Domain Credentials (domain\uid:rid:lmhash:nthash)
[*] Searching for pekList, be patient
[*] PEK # 0 found and decrypted: 8b7862def60e442f7425b23f1bc78670
[*] Reading and decrypting hashes from ntds.dit 
KINGSLANDING$:1001:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Enabled)
Administrator:500:aad3b435b51404eeaad3b435b51404ee:dbd13e1c4e338284ac4e9874f7de6ef4::: (status=Enabled)
Guest:501:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Disabled)
vagrant:1000:aad3b435b51404eeaad3b435b51404ee:e02bc503339d51f71d913c245d35b50b::: (status=Enabled)
WINTERFELL$:1001:aad3b435b51404eeaad3b435b51404ee:ffc37752d112b06cfad97941c7ac10fc::: (status=Enabled)
krbtgt:502:aad3b435b51404eeaad3b435b51404ee:44e1f85ccf1935db45f88b71f8f96096::: (status=Disabled)
Guest:501:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Disabled)
krbtgt:502:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Disabled)
vagrant:1000:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Enabled)
Administrator:500:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Enabled)
NORTH$:1104:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Enabled)
CASTELBLACK$:1104:aad3b435b51404eeaad3b435b51404ee:0c793a8a77ad8dda4b647454f93ef3dc::: (status=Enabled)
ESSOS$:1105:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Enabled)
SEVENKINGDOMS$:1105:aad3b435b51404eeaad3b435b51404ee:7bf01d9b9a8d6520689556fbc1af5589::: (status=Enabled)
arya.stark:1110:aad3b435b51404eeaad3b435b51404ee:4f622f4cd4284a887228940e2ff4e709::: (status=Enabled)
tywin.lannister:1113:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Enabled)
eddard.stark:1111:aad3b435b51404eeaad3b435b51404ee:d977b98c6c9282c5c478be1d97b237b8::: (status=Enabled)
catelyn.stark:1112:aad3b435b51404eeaad3b435b51404ee:cba36eccfd9d949c73bc73715364aff5::: (status=Enabled)
jaime.lannister:1114:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Enabled)
cersei.lannister:1115:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Enabled)
robb.stark:1113:aad3b435b51404eeaad3b435b51404ee:831486ac7f26860c9e2f51ac91e1a07a::: (status=Enabled)
tyron.lannister:1116:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Enabled)
sansa.stark:1114:aad3b435b51404eeaad3b435b51404ee:b777555c2e2e3716e075cc255b26c14d::: (status=Enabled)
brandon.stark:1115:aad3b435b51404eeaad3b435b51404ee:84bbaa1c58b7f69d2192560a3f932129::: (status=Enabled)
robert.baratheon:1117:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Enabled)
rickon.stark:1116:aad3b435b51404eeaad3b435b51404ee:7978dc8a66d8e480d9a86041f8409560::: (status=Enabled)
joffrey.baratheon:1118:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Enabled)
renly.baratheon:1119:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Enabled)
hodor:1117:aad3b435b51404eeaad3b435b51404ee:337d2667505c203904bd899c6c95525e::: (status=Enabled)
stannis.baratheon:1120:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Enabled)
jon.snow:1118:aad3b435b51404eeaad3b435b51404ee:b8d76e56e9dac90539aff05e3ccb1755::: (status=Enabled)
samwell.tarly:1119:aad3b435b51404eeaad3b435b51404ee:f5db9e027ef824d029262068ac826843::: (status=Enabled)
petyer.baelish:1121:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Enabled)
jeor.mormont:1120:aad3b435b51404eeaad3b435b51404ee:6dccf1c567c56a40e56691a723a49664::: (status=Enabled)
lord.varys:1122:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Enabled)
maester.pycelle:1123:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Enabled)
sql_svc:1121:aad3b435b51404eeaad3b435b51404ee:84a5092f53390ea48d660be52b93b804::: (status=Enabled)
HBOSERVER$:1124:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Enabled)
sevenkingdoms.local\hboproducer:1125:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Enabled)
[*] Cleaning up...
```

After applying this PR, the result is the following. Note that the foreign principals are not present anymore.

```bash
$ secretsdump.py -ntds ntds.dit -system system -user-status -just-dc-ntlm LOCAL
Impacket v0.12.0.dev1+20240523.75507.15eff880 - Copyright 2023 Fortra

[*] Target system bootKey: 0x6457f466e87a6ec861b680d31c7a6759
[*] Dumping Domain Credentials (domain\uid:rid:lmhash:nthash)
[*] Searching for pekList, be patient
[*] PEK # 0 found and decrypted: 8b7862def60e442f7425b23f1bc78670
[*] Reading and decrypting hashes from ntds.dit 
Administrator:500:aad3b435b51404eeaad3b435b51404ee:dbd13e1c4e338284ac4e9874f7de6ef4::: (status=Enabled)
Guest:501:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Disabled)
vagrant:1000:aad3b435b51404eeaad3b435b51404ee:e02bc503339d51f71d913c245d35b50b::: (status=Enabled)
WINTERFELL$:1001:aad3b435b51404eeaad3b435b51404ee:ffc37752d112b06cfad97941c7ac10fc::: (status=Enabled)
krbtgt:502:aad3b435b51404eeaad3b435b51404ee:44e1f85ccf1935db45f88b71f8f96096::: (status=Disabled)
CASTELBLACK$:1104:aad3b435b51404eeaad3b435b51404ee:0c793a8a77ad8dda4b647454f93ef3dc::: (status=Enabled)
SEVENKINGDOMS$:1105:aad3b435b51404eeaad3b435b51404ee:7bf01d9b9a8d6520689556fbc1af5589::: (status=Enabled)
arya.stark:1110:aad3b435b51404eeaad3b435b51404ee:4f622f4cd4284a887228940e2ff4e709::: (status=Enabled)
eddard.stark:1111:aad3b435b51404eeaad3b435b51404ee:d977b98c6c9282c5c478be1d97b237b8::: (status=Enabled)
catelyn.stark:1112:aad3b435b51404eeaad3b435b51404ee:cba36eccfd9d949c73bc73715364aff5::: (status=Enabled)
robb.stark:1113:aad3b435b51404eeaad3b435b51404ee:831486ac7f26860c9e2f51ac91e1a07a::: (status=Enabled)
sansa.stark:1114:aad3b435b51404eeaad3b435b51404ee:b777555c2e2e3716e075cc255b26c14d::: (status=Enabled)
brandon.stark:1115:aad3b435b51404eeaad3b435b51404ee:84bbaa1c58b7f69d2192560a3f932129::: (status=Enabled)
rickon.stark:1116:aad3b435b51404eeaad3b435b51404ee:7978dc8a66d8e480d9a86041f8409560::: (status=Enabled)
hodor:1117:aad3b435b51404eeaad3b435b51404ee:337d2667505c203904bd899c6c95525e::: (status=Enabled)
jon.snow:1118:aad3b435b51404eeaad3b435b51404ee:b8d76e56e9dac90539aff05e3ccb1755::: (status=Enabled)
samwell.tarly:1119:aad3b435b51404eeaad3b435b51404ee:f5db9e027ef824d029262068ac826843::: (status=Enabled)
jeor.mormont:1120:aad3b435b51404eeaad3b435b51404ee:6dccf1c567c56a40e56691a723a49664::: (status=Enabled)
sql_svc:1121:aad3b435b51404eeaad3b435b51404ee:84a5092f53390ea48d660be52b93b804::: (status=Enabled)
[*] Cleaning up...
```

One thing to be aware of: when looking at the `instanceType` attribute of accounts local to this domain on a live DC, we can observe that some of them have their `instanceType` attribute empty. However, in the NTDS.dit itself, this value is `4` as expected:
![Screenshot from 2024-06-05 17-18-53](https://github.com/fortra/impacket/assets/78735647/1eb4421e-893c-4293-8ee9-f9c164aaad2e)

As such, the filtering works correctly.

Cheers!

PS: thanks to @vletoux for https://github.com/vletoux/ADSecrets, very useful when diving into NTDS internals 🙂