### PR TITLE
winregistry.Registry: handle destruction of uninitialized instance

### DIFF
--- a/impacket/winregistry.py
+++ b/impacket/winregistry.py
@@ -176,7 +176,8 @@ class Registry:
             LOG.warning("Unsupported version (%d.%d) - things might not work!" % (self.__regf['MajorVersion'], self.__regf['MinorVersion']))
 
     def close(self):
-        self.fd.close()
+        if hasattr(self, 'fd'):
+            self.fd.close()
 
     def __del__(self):
         self.close()


### PR DESCRIPTION
If `Registry()` is called and initialization fails (for instance, the given file does not exist), the not initialized instanced will be destroyed, and `__del__()` calls close() which calls `self.fd.close()`, raising an AttributeError.
This fixes this situation.

## Sample code to reproduce
```python
from impacket.winregistry import Registry

try:
	reg = Registry('This file does not exist', isRemote = False)
except FileNotFoundError:
	pass
```
### expected result
nothing
### Actual result
```
Exception ignored in: <function Registry.__del__ at 0x7706ebe50a40>
Traceback (most recent call last):
  File "/home/didier/Tools/impacket/impacket/winregistry.py", line 183, in __del__
    self.close()
  File "/home/didier/Tools/impacket/impacket/winregistry.py", line 180, in close
    self.fd.close()
    ^^^^^^^
AttributeError: 'Registry' object has no attribute 'fd'
```
### Actual result after fix
nothing
