### PR TITLE
winregistry.py: handle value name containting backslash character

### DIFF
--- a/examples/registry-read.py
+++ b/examples/registry-read.py
@@ -87,7 +87,7 @@ def enumValues(reg, searchKey):
 
     for value in values:
         print("  %-30s: " % value, end=' ')
-        data = reg.getValue(key,value.decode('utf-8'))
+        data = reg.getValue(searchKey, value.decode('utf-8'))
         # Special case for binary string.. so it looks better formatted
         if data[0] == winregistry.REG_BINARY:
             print('')

--- a/examples/registry-read.py
+++ b/examples/registry-read.py
@@ -87,7 +87,7 @@ def enumValues(reg, searchKey):
 
     for value in values:
         print("  %-30s: " % value, end=' ')
-        data = reg.getValue('%s\\%s'%(searchKey,value.decode('utf-8')))
+        data = reg.getValue(key,value.decode('utf-8'))
         # Special case for binary string.. so it looks better formatted
         if data[0] == winregistry.REG_BINARY:
             print('')

--- a/impacket/winregistry.py
+++ b/impacket/winregistry.py
@@ -454,9 +454,7 @@ class Registry:
         """ returns a tuple with (ValueType, ValueData) for the requested keyValue
             valueName is the name of the value (which can contain '\\')
             if valueName is not  given, keyValue must be a string containing the full path to the value
-            if valueName is given, keyValue can be:
-                either a string containting the path to the key conaitning valueName,
-                or a instance of REG_NK containing the key itself (as returned by findKey())
+            if valueName is given, keyValue should be the string containing the path to the key containing valueName
         """
         key = None
         if valueName is None:

--- a/impacket/winregistry.py
+++ b/impacket/winregistry.py
@@ -461,10 +461,7 @@ class Registry:
             regKey   = ntpath.dirname(keyValue)
             regValue = ntpath.basename(keyValue)
         else:
-            if isinstance(keyValue, REG_NK):
-                key = keyValue
-            else:
-                regKey = keyValue
+            regKey = keyValue
             regValue = valueName
 
         if key is None:

--- a/impacket/winregistry.py
+++ b/impacket/winregistry.py
@@ -463,8 +463,7 @@ class Registry:
             regKey = keyValue
             regValue = valueName
 
-        if key is None:
-            key = self.findKey(regKey)
+        key = self.findKey(regKey)
 
         if key is None:
             return None

--- a/impacket/winregistry.py
+++ b/impacket/winregistry.py
@@ -456,7 +456,6 @@ class Registry:
             if valueName is not  given, keyValue must be a string containing the full path to the value
             if valueName is given, keyValue should be the string containing the path to the key containing valueName
         """
-        key = None
         if valueName is None:
             regKey   = ntpath.dirname(keyValue)
             regValue = ntpath.basename(keyValue)

--- a/impacket/winregistry.py
+++ b/impacket/winregistry.py
@@ -450,12 +450,27 @@ class Registry:
 
         return resp
 
-    def getValue(self, keyValue):
-        # returns a tuple with (ValueType, ValueData) for the requested keyValue
-        regKey = ntpath.dirname(keyValue)
-        regValue = ntpath.basename(keyValue)
+    def getValue(self, keyValue, valueName=None):
+        """ returns a tuple with (ValueType, ValueData) for the requested keyValue
+            valueName is the name of the value (which can contain '\\')
+            if valueName is not  given, keyValue must be a string containing the full path to the value
+            if valueName is given, keyValue can be:
+                either a string containting the path to the key conaitning valueName,
+                or a instance of REG_NK containing the key itself (as returned by findKey())
+        """
+        key = None
+        if valueName is None:
+            regKey   = ntpath.dirname(keyValue)
+            regValue = ntpath.basename(keyValue)
+        else:
+            if isinstance(keyValue, REG_NK):
+                key = keyValue
+            else:
+                regKey = keyValue
+            regValue = valueName
 
-        key = self.findKey(regKey)
+        if key is None:
+            key = self.findKey(regKey)
 
         if key is None:
             return None


### PR DESCRIPTION
`winregistry.Registry.getValue()` splits keyValue on backslash to separate key and value. But  value names can contain backslash, and calling getValue on such a value will cause a ValueError exception.

This commit corrects this bug while keeping compatibility with old code. 