### PR TITLE
allow to pass commands to mssqlclient.py via command line

### DIFF
--- a/examples/mssqlclient.py
+++ b/examples/mssqlclient.py
@@ -110,8 +110,8 @@ if __name__ == '__main__':
             for line in options.file.readlines():
                 print("SQL> %s" % line, end=' ')
                 shell.onecmd(line)
-        elif options.cmd:
-            for c in options.cmd:
+        elif options.command:
+            for c in options.command:
                 print("SQL> %s" % c)
                 shell.onecmd(c)
         else:

--- a/examples/mssqlclient.py
+++ b/examples/mssqlclient.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
                                                                                   'Authentication (default False)')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
     parser.add_argument('-show', action='store_true', help='show the queries')
-    parser.add_argument('-cmd', action='extend', nargs='+', help='Commands to execute in the SQL shell. Multiple commands can be passed.')
+    parser.add_argument('-command', action='extend', nargs='*', help='Commands to execute in the SQL shell. Multiple commands can be passed.')
     parser.add_argument('-file', type=argparse.FileType('r'), help='input file with commands to execute in the SQL shell')
 
     group = parser.add_argument_group('authentication')

--- a/examples/mssqlclient.py
+++ b/examples/mssqlclient.py
@@ -40,6 +40,7 @@ if __name__ == '__main__':
                                                                                   'Authentication (default False)')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
     parser.add_argument('-show', action='store_true', help='show the queries')
+    parser.add_argument('-cmd', action='extend', nargs='+', help='Commands to execute in the SQL shell. Multiple commands can be passed.')
     parser.add_argument('-file', type=argparse.FileType('r'), help='input file with commands to execute in the SQL shell')
 
     group = parser.add_argument_group('authentication')
@@ -105,10 +106,14 @@ if __name__ == '__main__':
         res = False
     if res is True:
         shell = SQLSHELL(ms_sql, options.show)
-        if options.file is None:
-            shell.cmdloop()
-        else:
+        if options.file:
             for line in options.file.readlines():
                 print("SQL> %s" % line, end=' ')
                 shell.onecmd(line)
+        elif options.cmd:
+            for c in options.cmd:
+                print("SQL> %s" % c)
+                shell.onecmd(c)
+        else:
+            shell.cmdloop()
     ms_sql.disconnect()


### PR DESCRIPTION
allow to pass commands to mssqlclient.py via the command line directly instead of only using a input file