### PR TITLE
Adding parameter "-outputfile" to set smbserver log file.

### DIFF
--- a/examples/smbserver.py
+++ b/examples/smbserver.py
@@ -43,6 +43,7 @@ if __name__ == '__main__':
     parser.add_argument('-ip', '--interface-address', action='store', default='0.0.0.0', help='ip address of listening interface')
     parser.add_argument('-port', action='store', default='445', help='TCP port for listening incoming connections (default 445)')
     parser.add_argument('-smb2support', action='store_true', default=False, help='SMB2 Support (experimental!)')
+    parser.add_argument('-outputfile', action='store', default=None, help='Output file to log smbserver output messages')
 
     if len(sys.argv)==1:
         parser.print_help()
@@ -70,6 +71,10 @@ if __name__ == '__main__':
 
     server = smbserver.SimpleSMBServer(listenAddress=options.interface_address, listenPort=int(options.port))
 
+    if options.outputfile:
+        server.log('Switching output to file %s' % options.outputfile)
+        server.setLogFile(options.outputfile)
+
     server.addShare(options.shareName.upper(), options.sharePath, comment)
     server.setSMB2Support(options.smb2support)
 
@@ -96,10 +101,6 @@ if __name__ == '__main__':
     # (remember: must be 16 hex bytes long)
     # e.g. server.setSMBChallenge('12345678abcdef00')
     server.setSMBChallenge('')
-
-    # If you don't want log to stdout, comment the following line
-    # If you want log dumped to a file, enter the filename
-    server.setLogFile('')
 
     # Rock and roll
     server.start()

--- a/examples/smbserver.py
+++ b/examples/smbserver.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
     server = smbserver.SimpleSMBServer(listenAddress=options.interface_address, listenPort=int(options.port))
 
     if options.outputfile:
-        server.log('Switching output to file %s' % options.outputfile)
+        logging.info('Switching output to file %s' % options.outputfile)
         server.setLogFile(options.outputfile)
 
     server.addShare(options.shareName.upper(), options.sharePath, comment)

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -4671,7 +4671,8 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
             logging.basicConfig(filename=self.__logFile,
                                 level=logging.DEBUG,
                                 format="%(asctime)s: %(levelname)s: %(message)s",
-                                datefmt='%m/%d/%Y %I:%M:%S %p')
+                                datefmt='%m/%d/%Y %I:%M:%S %p',
+                                force=True)
         self.__log = LOG
 
         # Process the credentials


### PR DESCRIPTION
This PR fixes #1771

It allows configuring a log file from the `smbserver` parameters and before switching to the file prints a message in the stdout informing that.

For example:
```
┌──(xxx㉿XXXX)-[~/impacket/examples]
└─$ python smbserver.py TEMP /tmp -outputfile /tmp/smbservertest.log

Impacket v0.12.0.dev1+20240801.132541.6eae6598 - Copyright 2023 Fortra

[*] Config file parsed
[*] Switching output to file /tmp/smbservertest.log
```