### PR TITLE
Support for adding REG_MULTI_SZ values through reg.py

### DIFF
--- a/examples/reg.py
+++ b/examples/reg.py
@@ -294,6 +294,7 @@ class RegHandler:
             if dwType == rrp.REG_MULTI_SZ:
                 vd = '\0'.join(self.__options.vd)
                 valueData = vd + 2 * '\0' # REG_MULTI_SZ ends with 2 null-bytes
+                valueDataToPrint = vd.replace('\0', '\n')
             else:
                 vd = self.__options.vd[0] if len(self.__options.vd) > 0 else ''
                 if dwType in (
@@ -307,6 +308,7 @@ class RegHandler:
                     valueData = binascii.a2b_hex(vd.ljust(bin_value_len, '0'))
                 else:
                     valueData = vd + "\0" # Add a NULL Byte as terminator for Non Binary values
+                valueDataToPrint = valueData
 
             ans3 = rrp.hBaseRegSetValue(
                 dce, ans2['phkResult'], self.__options.v, dwType, valueData
@@ -314,11 +316,11 @@ class RegHandler:
 
             if ans3['ErrorCode'] == 0:
                 print('Successfully set key %s\\%s of type %s to value %s' % (
-                    keyName, self.__options.v, self.__options.vt, valueData
+                    keyName, self.__options.v, self.__options.vt, valueDataToPrint
                 ))
             else:
                 print('Error 0x%08x while setting key %s\\%s of type %s to value %s' % (
-                    ans3['ErrorCode'], keyName, self.__options.v, self.__options.vt, valueData
+                    ans3['ErrorCode'], keyName, self.__options.v, self.__options.vt, valueDataToPrint
                 ))
 
     def delete(self, dce, keyName):
@@ -512,7 +514,7 @@ class RegHandler:
                 except:
                     print(" NULL")
             elif valueType == rrp.REG_MULTI_SZ:
-                print("%s" % (valueData.decode('utf-16le')[:-2]))
+                print("%s" % (valueData.decode('utf-16le')[:-2].replace('\0', '\n')))
             else:
                 print("Unknown Type 0x%x!" % valueType)
                 hexdump(valueData)

--- a/examples/reg.py
+++ b/examples/reg.py
@@ -295,7 +295,7 @@ class RegHandler:
                 vd = '\0'.join(self.__options.vd)
                 valueData = vd + 2 * '\0' # REG_MULTI_SZ ends with 2 null-bytes
             else:
-                vd = self.__options.vd[0]
+                vd = self.__options.vd[0] if len(self.__options.vd) > 0 else ''
                 if dwType in (
                     rrp.REG_DWORD, rrp.REG_DWORD_BIG_ENDIAN, rrp.REG_DWORD_LITTLE_ENDIAN,
                     rrp.REG_QWORD, rrp.REG_QWORD_LITTLE_ENDIAN
@@ -566,7 +566,7 @@ if __name__ == '__main__':
                             default='REG_SZ')
     add_parser.add_argument('-vd', action='append', metavar="VALUEDATA", required=False, help='Specifies the registry '
                            'value data that is to be set. In case of adding a REG_MULTI_SZ value, set this option once for each '
-                           'line you want to add.', default=[''])
+                           'line you want to add.', default=[])
 
     # An delete command
     delete_parser = subparsers.add_parser('delete', help='Deletes a subkey or entries from the registry')

--- a/examples/reg.py
+++ b/examples/reg.py
@@ -294,7 +294,7 @@ class RegHandler:
             if dwType == rrp.REG_MULTI_SZ:
                 vd = '\0'.join(self.__options.vd)
                 valueData = vd + 2 * '\0' # REG_MULTI_SZ ends with 2 null-bytes
-                valueDataToPrint = vd.replace('\0', '\n')
+                valueDataToPrint = vd.replace('\0', '\n\t\t')
             else:
                 vd = self.__options.vd[0] if len(self.__options.vd) > 0 else ''
                 if dwType in (
@@ -315,11 +315,11 @@ class RegHandler:
             )
 
             if ans3['ErrorCode'] == 0:
-                print('Successfully set key %s\\%s of type %s to value %s' % (
+                print('Successfully set\n\tkey\t%s\\%s\n\ttype\t%s\n\tvalue\t%s' % (
                     keyName, self.__options.v, self.__options.vt, valueDataToPrint
                 ))
             else:
-                print('Error 0x%08x while setting key %s\\%s of type %s to value %s' % (
+                print('Error 0x%08x while setting\n\tkey\t%s\\%s\n\ttype\t%s\n\tvalue\t%s' % (
                     ans3['ErrorCode'], keyName, self.__options.v, self.__options.vt, valueDataToPrint
                 ))
 
@@ -514,7 +514,7 @@ class RegHandler:
                 except:
                     print(" NULL")
             elif valueType == rrp.REG_MULTI_SZ:
-                print("%s" % (valueData.decode('utf-16le')[:-2].replace('\0', '\n')))
+                print("%s" % (valueData.decode('utf-16le')[:-2]))
             else:
                 print("Unknown Type 0x%x!" % valueType)
                 hexdump(valueData)

--- a/impacket/dcerpc/v5/rrp.py
+++ b/impacket/dcerpc/v5/rrp.py
@@ -702,9 +702,9 @@ def packValue(valueType, value):
             retData = value.decode(sys.getfilesystemencoding()).encode('utf-16le')
     elif valueType == REG_MULTI_SZ:
         try:
-            # REG_MULTI_SZ must end with 2 null-bytes
             v = checkNullString(value)
-            if v[-2:] != '\x00':
+            # REG_MULTI_SZ must end with 2 null-bytes
+            if v[-2:-1] != '\x00':
                 v = v + '\x00'
             retData = v.encode('utf-16le')
         except UnicodeDecodeError:

--- a/impacket/dcerpc/v5/rrp.py
+++ b/impacket/dcerpc/v5/rrp.py
@@ -702,7 +702,11 @@ def packValue(valueType, value):
             retData = value.decode(sys.getfilesystemencoding()).encode('utf-16le')
     elif valueType == REG_MULTI_SZ:
         try:
-            retData = (checkNullString(value)+'\x00').encode('utf-16le')
+            # REG_MULTI_SZ must end with 2 null-bytes
+            v = checkNullString(value)
+            if v[-2:] != '\x00':
+                v = v + '\x00'
+            retData = v.encode('utf-16le')
         except UnicodeDecodeError:
             import sys
             retData = value.decode(sys.getfilesystemencoding()).encode('utf-16le')


### PR DESCRIPTION
This PR implements #1720

Changing `-vd` argument to `append`

```
add_parser.add_argument('-vd', action='append', metavar="VALUEDATA", required=False, help='Specifies the registry '
                           'value data that is to be set. In case of adding a REG_MULTI_SZ value, set this option once for each '
                           'line you want to add.', default=[''])
```

Running the example with a command like this, ie:
```
┌──(xxx㉿XXX)-[~/impacket/examples]
└─$ python reg.py <domain>/<user>@<ip> add -v multistring -vt REG_MULTI_SZ -keyName "HKLM\SOFTWARE\test" -vd first -vd the_second -vd "with whitespaces"
```