### PR TITLE
Logging multirelay status on ntlmrelayx.py

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -500,12 +500,7 @@ if __name__ == '__main__':
     if options.no_multirelay:
         logging.info("Multirelay disabled")
     else:
-        if not options.no_smb_server and not options.no_http_server:
-            logging.info("Multirelay enabled for HTTP and SMB servers")
-        elif not options.no_smb_server:
-            logging.info("Multirelay enabled for SMB server")
-        elif not options.no_http_server:
-            logging.info("Multirelay enabled for HTTP server")
+        logging.info("Multirelay enabled")
 
     print("")
     logging.info("Servers started, waiting for connections")

--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -496,6 +496,17 @@ if __name__ == '__main__':
 
     c = start_servers(options, threads)
 
+    # Log multirelay flag status
+    if options.no_multirelay:
+        logging.info("Multirelay disabled")
+    else:
+        if not options.no_smb_server and not options.no_http_server:
+            logging.info("Multirelay enabled for HTTP and SMB servers")
+        elif not options.no_smb_server:
+            logging.info("Multirelay enabled for SMB server")
+        elif not options.no_http_server:
+            logging.info("Multirelay enabled for HTTP server")
+
     print("")
     logging.info("Servers started, waiting for connections")
     try:


### PR DESCRIPTION
In order to better clarify the `multirelay` flag status, this PR adds a logging message stating so (triggered after #1676)

For example
```
┌──(xxx㉿XXXX)-[~/impacket/examples]
└─$ python ntlmrelayx.py -tf targets -smb2support -w --no-smb-server --no-wcf-server --no-raw-server
Impacket v0.12.0.dev1+20240807.21946.829239e3 - Copyright 2023 Fortra

[...]
[*] Setting up HTTP Server on port 80
[*] Multirelay enabled for HTTP server
```
or
```
┌──(xxx㉿XXXX)-[~/impacket/examples]
└─$ python ntlmrelayx.py -tf targets
Impacket v0.12.0.dev1+20240807.21946.829239e3 - Copyright 2023 Fortra

[...]
[*] Setting up HTTP Server on port 80
[*] Multirelay enabled for HTTP and SMB servers
```
or
```
┌──(xxx㉿XXXX)-[~/impacket/examples]
└─$ python ntlmrelayx.py -t 10.10.10.10
Impacket v0.12.0.dev1+20240807.21946.829239e3 - Copyright 2023 Fortra

[...]
[*] Multirelay disabled
```
