### PR TITLE
smbserver examples log to console

### DIFF
--- a/examples/karmaSMB.py
+++ b/examples/karmaSMB.py
@@ -87,7 +87,7 @@ class KarmaSMBServer(Thread):
         smbConfig.set('global','server_name','server_name')
         smbConfig.set('global','server_os','UNIX')
         smbConfig.set('global','server_domain','WORKGROUP')
-        smbConfig.set('global','log_file','smb.log')
+        smbConfig.set('global','log_file','None')
         smbConfig.set('global','credentials_file','')
 
         # IPC always needed

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -66,10 +66,6 @@ class SMBServer(Thread):
 
     def cleanup_server(self):
         logging.info('Cleaning up..')
-        try:
-            os.unlink(SMBSERVER_DIR + '/smb.log')
-        except OSError:
-            pass
         os.rmdir(SMBSERVER_DIR)
 
     def run(self):
@@ -79,7 +75,7 @@ class SMBServer(Thread):
         smbConfig.set('global','server_name','server_name')
         smbConfig.set('global','server_os','UNIX')
         smbConfig.set('global','server_domain','WORKGROUP')
-        smbConfig.set('global','log_file',SMBSERVER_DIR + '/smb.log')
+        smbConfig.set('global','log_file','None')
         smbConfig.set('global','credentials_file','')
 
         # Let's add a dummy share

--- a/examples/smbrelayx.py
+++ b/examples/smbrelayx.py
@@ -692,7 +692,7 @@ class SMBRelayServer(Thread):
         smbConfig.set('global','server_name','server_name')
         smbConfig.set('global','server_os','UNIX')
         smbConfig.set('global','server_domain','WORKGROUP')
-        smbConfig.set('global','log_file','smb.log')
+        smbConfig.set('global','log_file','None')
         smbConfig.set('global','credentials_file','')
 
         if outputFile is not None:

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -76,7 +76,7 @@ class SMBRelayServer(Thread):
         smbConfig.set('global','server_name','server_name')
         smbConfig.set('global','server_os','UNIX')
         smbConfig.set('global','server_domain','WORKGROUP')
-        smbConfig.set('global','log_file','smb.log')
+        smbConfig.set('global','log_file','None')
         smbConfig.set('global','credentials_file','')
 
         if self.config.smb2support is True:


### PR DESCRIPTION
In the context of #1784, smbserver logging configuration started to be forced-applied.

This change made some examples to avoid logging to console (as they were doing) and start logging to the configured file _smb.log_.

This PR configures those examples to continue logging to console as they were doing before aforementioned changes.