### PR TITLE
Print message when connections are received in relay servers

### DIFF
--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -180,6 +180,9 @@ class HTTPRelayServer(Thread):
             return
 
         def do_PROPFIND(self):
+
+            LOG.info('HTTPD(%s): Client requested path: %s' % (self.server.server_address[1], self.path.lower()))
+
             proxy = False
             if (".jpg" in self.path) or (".JPG" in self.path):
                 content = b"""<?xml version="1.0"?><D:multistatus xmlns:D="DAV:"><D:response><D:href>http://webdavrelay/file/image.JPG/</D:href><D:propstat><D:prop><D:creationdate>2016-11-12T22:00:22Z</D:creationdate><D:displayname>image.JPG</D:displayname><D:getcontentlength>4456</D:getcontentlength><D:getcontenttype>image/jpeg</D:getcontenttype><D:getetag>4ebabfcee4364434dacb043986abfffe</D:getetag><D:getlastmodified>Mon, 20 Mar 2017 00:00:22 GMT</D:getlastmodified><D:resourcetype></D:resourcetype><D:supportedlock></D:supportedlock><D:ishidden>0</D:ishidden></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response></D:multistatus>"""

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -923,6 +923,6 @@ class SMBRelayServer(Thread):
         self.server.server_close()
 
     def run(self):
-        LOG.info("Setting up SMB Server")
+        LOG.info("Setting up SMB Server on port %s" % self.server.server_address[1])
         self._start()
 

--- a/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
@@ -348,12 +348,12 @@ class WCFRelayServer(Thread):
         self.server = None
 
     def run(self):
-        LOG.info("Setting up WCF Server")
-
         if self.config.listeningPort:
             wcfport = self.config.listeningPort
         else:
             wcfport = 9389  # ADWS
+
+        LOG.info("Setting up WCF Server on port %s" % wcfport)
 
         # changed to read from the interfaceIP set in the configuration
         self.server = self.WCFServer((self.config.interfaceIp, wcfport), self.WCFHandler, self.config)


### PR DESCRIPTION
This PR fixes #1651

A message should be logged when receiving a new connection in any relay server, despite if it could be relayed afterwards or not.