### PR TITLE
bugfix in net.py: show user account enabled or not enabled

### DIFF
--- a/examples/net.py
+++ b/examples/net.py
@@ -379,7 +379,7 @@ class Net:
                 print("Comment".ljust(30), info['AdminComment'])
                 print("User's comment".ljust(30), info['UserComment'])
                 print("Country/region code".ljust(30), "000 (System Default)" if info['CountryCode'] == 0 else info['CountryCode'])
-                print("Account active".ljust(30), self.__b2s(info['WhichFields'] & samr.USER_ACCOUNT_DISABLED == samr.USER_ACCOUNT_DISABLED))
+                print("Account active".ljust(30), self.__b2s(info['UserAccountControl'] & samr.USER_ACCOUNT_DISABLED != samr.USER_ACCOUNT_DISABLED))
                 print("Account expires".ljust(30), self.__get_time_string(info['AccountExpires']))
                 print('')
                 print("Password last set".ljust(30), self.__get_time_string(info['PasswordLastSet']))


### PR DESCRIPTION
Hi,
current net.py has a bug where the line `account active` always displays 'Yes'
this is due to checking the `WhichFields ` field instead of the `UserAccountControl ` field of `info ` object

Before:
![account disabled](https://github.com/user-attachments/assets/d543d9ab-ee0d-4262-b407-e5507af62c01)
![BEFORE net user with account disabled](https://github.com/user-attachments/assets/0cc345d2-ead2-47f6-8e26-7b077f42bdc9)

After:
![AFTER net user with account disabled](https://github.com/user-attachments/assets/f467ea69-f55d-4e02-9cc0-4bbb121ea53d)

