### PR TITLE
add more requests to even6 protocol

### DIFF
--- a/impacket/dcerpc/v5/even6.py
+++ b/impacket/dcerpc/v5/even6.py
@@ -57,10 +57,16 @@ def checkNullString(string):
 ################################################################################
 
 # Evt Path Flags
-EvtQueryChannelName = 0x00000001
-EvtQueryFilePath = 0x00000002
+EvtQueryChannelName   = 0x00000001
+EvtQueryFilePath      = 0x00000002
+
+# EvtRpcExportLog
+EvtQueryTolerateQueryErrors = 0x00001000
+
+# EvtRpcRegisterLogQuery
 EvtReadOldestToNewest = 0x00000100
 EvtReadNewestToOldest = 0x00000200
+
 
 ################################################################################
 # STRUCTURES
@@ -244,6 +250,21 @@ class EvtRpcClearLogResponse(NDRCALL):
         ('Error', RPC_INFO),
     )
 
+class EvtRpcExportLog(NDRCALL):
+    opnum = 7
+    structure = (
+        ('Handle', CONTEXT_HANDLE_OPERATION_CONTROL),
+        ('ChannelPath', WSTR),
+        ('Query', WSTR),
+        ('BackupPath', WSTR),
+        ('Flags', DWORD),
+    )
+
+class EvtRpcExportLogResponse(NDRCALL):
+    structure = (
+        ('Error', RPC_INFO),
+    )
+
 class EvtRpcQueryNext(NDRCALL):
     opnum = 11
     structure = (
@@ -323,6 +344,7 @@ OPNUMS = {
     4   : (EvtRpcRegisterControllableOperation, EvtRpcRegisterControllableOperationResponse),
     5   : (EvtRpcRegisterLogQuery, EvtRpcRegisterLogQueryResponse),
     6   : (EvtRpcClearLog, EvtRpcClearLogResponse),
+    7   : (EvtRpcExportLog, EvtRpcExportLogResponse),
     11  : (EvtRpcQueryNext,  EvtRpcQueryNextResponse),
     12  : (EvtRpcQuerySeek, EvtRpcQuerySeekResponse),
     13  : (EvtRpcClose, EvtRpcCloseResponse),
@@ -347,11 +369,21 @@ def hEvtRpcRegisterLogQuery(dce, path, flags, query='*\x00'):
     resp = dce.request(request)
     return resp
 
-def hEvtRpcClearLog(dce, handle, path):
+def hEvtRpcClearLog(dce, handle, path, backupPath=NULL):
     request = EvtRpcClearLog()
     request['Handle'] = handle
     request['ChannelPath'] = checkNullString(path)
-    request['BackupPath'] = NULL
+    request['BackupPath'] = checkNullString(backupPath)
+    request['Flags'] = 0
+    resp = dce.request(request)
+    return resp
+
+def hEvtRpcExportLog(dce, handle, channelPath, query, backupPath):
+    request = EvtRpcExportLog()
+    request['Handle'] = handle
+    request['ChannelPath'] = checkNullString(channelPath)
+    request['Query'] = checkNullString(query)
+    request['BackupPath'] = checkNullString(backupPath)
     request['Flags'] = 0
     resp = dce.request(request)
     return resp

--- a/impacket/dcerpc/v5/even6.py
+++ b/impacket/dcerpc/v5/even6.py
@@ -364,7 +364,7 @@ def hEvtRpcRegisterControllableOperation(dce):
 def hEvtRpcRegisterLogQuery(dce, path, flags, query='*\x00'):
     request = EvtRpcRegisterLogQuery()
     request['Path'] = checkNullString(path)
-    request['Query'] = query
+    request['Query'] = checkNullString(query)
     request['Flags'] = flags
     resp = dce.request(request)
     return resp

--- a/tests/dcerpc/test_even6.py
+++ b/tests/dcerpc/test_even6.py
@@ -35,7 +35,7 @@ class EVEN6Tests(DCERPCTests):
     authn = True
     authn_level = RPC_C_AUTHN_LEVEL_PKT_PRIVACY
 
-    def test_EvtRpcClearLog(self):
+    def test_hEvtRpcClearLog(self):
         dce, rpctransport = self.connect()
 
         resp = even6.hEvtRpcRegisterControllableOperation(dce)
@@ -49,7 +49,7 @@ class EVEN6Tests(DCERPCTests):
         resp = even6.hEvtRpcClose(dce, control_handle)
         resp.dump()
 
-    def test_EvtRpcExportLog(self):
+    def test_hEvtRpcExportLog(self):
         dce, rpctransport = self.connect()
 
         resp = even6.hEvtRpcRegisterControllableOperation(dce)

--- a/tests/dcerpc/test_even6.py
+++ b/tests/dcerpc/test_even6.py
@@ -35,6 +35,34 @@ class EVEN6Tests(DCERPCTests):
     authn = True
     authn_level = RPC_C_AUTHN_LEVEL_PKT_PRIVACY
 
+    def test_EvtRpcClearLog(self):
+        dce, rpctransport = self.connect()
+
+        resp = even6.hEvtRpcRegisterControllableOperation(dce)
+        resp.dump()
+
+        control_handle = resp['Handle']
+
+        resp = even6.hEvtRpcClearLog(dce, control_handle, 'Security\x00')
+        resp.dump()
+
+        resp = even6.hEvtRpcClose(dce, control_handle)
+        resp.dump()
+
+    def test_EvtRpcExportLog(self):
+        dce, rpctransport = self.connect()
+
+        resp = even6.hEvtRpcRegisterControllableOperation(dce)
+        resp.dump()
+
+        control_handle = resp['Handle']
+
+        resp = even6.hEvtRpcExportLog(dce, control_handle, 'Security\x00', '*\x00', 'C:\\Security_Log_Exported.evtx\x00')
+        resp.dump()
+
+        resp = even6.hEvtRpcClose(dce, control_handle)
+        resp.dump()
+
     def test_EvtRpcRegisterLogQuery_EvtRpcQueryNext(self):
         dce, rpctransport = self.connect()
 


### PR DESCRIPTION
This PR adds 2 operations to Windows Eventlog Protocol (**EVEN6**) implementation:

1. `EvtRpcRegisterControllableOperation` (opnum 4)
2. `EvtRpcClearLog` (opnum 6)

by these two, Impacket is able to clear eventlogs on remote computer.

This PR also contains a 2 minor changes:

1. Checking string parameters for null termination (required by protocol specifications). The associated function is `checkNullString()`.
2. Parse rpc context handles in structured and more accurate way (`handle_t()`) instead of treating them as string (`20s=""`)