### PR TITLE
removed pyreadline dependency

### DIFF
--- a/examples/mimikatz.py
+++ b/examples/mimikatz.py
@@ -38,12 +38,6 @@ except Exception:
     logging.critical("Warning: You don't have any crypto installed. You need pycryptodomex")
     logging.critical("See https://pypi.org/project/pycryptodomex/")
 
-# If you wanna have readline like functionality in Windows, install pyreadline
-try:
-  import pyreadline as readline
-except ImportError:
-  import readline
-
 
 mimikatz_intro = r"""Type help for list of commands"""
 

--- a/examples/ntfs-read.py
+++ b/examples/ntfs-read.py
@@ -34,11 +34,6 @@ import struct
 import argparse
 import cmd
 import ntpath
-# If you wanna have readline like functionality in Windows, install pyreadline
-try:
-  import pyreadline as readline
-except ImportError:
-  import readline
 from six import PY2, text_type
 from datetime import datetime
 from impacket.examples import logger

--- a/impacket/examples/smbclient.py
+++ b/impacket/examples/smbclient.py
@@ -35,12 +35,6 @@ from impacket.smb3structs import FILE_DIRECTORY_FILE, FILE_LIST_DIRECTORY
 import charset_normalizer as chardet
 
 
-# If you wanna have readline like functionality in Windows, install pyreadline
-try:
-  import pyreadline as readline
-except ImportError:
-  import readline
-
 class MiniImpacketShell(cmd.Cmd):
     def __init__(self, smbClient, tcpShell=None, outputfile=None):
         #If the tcpShell parameter is passed (used in ntlmrelayx),

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pyOpenSSL==24.0.0
 ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6
 ldapdomaindump>=0.9.0
 flask>=1.0
+pyreadline3;sys_platform == 'win32'

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ pyOpenSSL==24.0.0
 ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6
 ldapdomaindump>=0.9.0
 flask>=1.0
-pyreadline;sys_platform == 'win32'

--- a/setup.py
+++ b/setup.py
@@ -70,8 +70,6 @@ setup(
 
     install_requires=['pyasn1>=0.2.3', 'pyasn1_modules', 'pycryptodomex', 'pyOpenSSL==24.0.0', 'six', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6',
                       'ldapdomaindump>=0.9.0', 'flask>=1.0', 'setuptools', 'charset_normalizer'],
-    extras_require={'pyreadline:sys_platform=="win32"': [],
-                    },
     classifiers=[
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.11",

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,8 @@ setup(
 
     install_requires=['pyasn1>=0.2.3', 'pyasn1_modules', 'pycryptodomex', 'pyOpenSSL==24.0.0', 'six', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6',
                       'ldapdomaindump>=0.9.0', 'flask>=1.0', 'setuptools', 'charset_normalizer'],
+    extras_require={'pyreadline3:sys_platform=="win32"': [],
+                    },
     classifiers=[
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.11",

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
 
     install_requires=['pyasn1>=0.2.3', 'pyasn1_modules', 'pycryptodomex', 'pyOpenSSL==24.0.0', 'six', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6',
                       'ldapdomaindump>=0.9.0', 'flask>=1.0', 'setuptools', 'charset_normalizer'],
-    extras_require={'pyreadline3:sys_platform=="win32"': [],
+    extras_require={':sys_platform=="win32"': ['pyreadline3'],
                     },
     classifiers=[
         "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Removed pyreadline dependency as it's currently deprecated.
Also it was not being used in the correct way. Support of autocomplete in shell on windows platforms never worked as expected.