### PR TITLE
feat in net.py: add functionality to enable and disable user accounts

### DIFF
--- a/examples/net.py
+++ b/examples/net.py
@@ -216,26 +216,27 @@ class User(SamrObject):
         finally:
             self._close_domain()
 
-    def _hEnableAccount(self, user_handle):
+    def _hEnableAccount(self, user_handle, user_account_control):
         buffer = samr.SAMPR_USER_INFO_BUFFER()
         buffer['tag'] = samr.USER_INFORMATION_CLASS.UserControlInformation
-        buffer['Control']['UserAccountControl'] = samr.USER_ALL_ADMINCOMMENT
+        buffer['Control']['UserAccountControl'] = user_account_control ^ samr.USER_ACCOUNT_DISABLED
         samr.hSamrSetInformationUser2(self._dce, user_handle, buffer)
 
-    def _hDisableAccount(self, user_handle):
+    def _hDisableAccount(self, user_handle, user_account_control):
         buffer = samr.SAMPR_USER_INFO_BUFFER()
         buffer['tag'] = samr.USER_INFORMATION_CLASS.UserControlInformation
-        buffer['Control']['UserAccountControl'] = samr.USER_ACCOUNT_DISABLED | samr.USER_NORMAL_ACCOUNT
+        buffer['Control']['UserAccountControl'] = samr.USER_ACCOUNT_DISABLED | user_account_control
         samr.hSamrSetInformationUser2(self._dce, user_handle, buffer)
 
     def SetUserAccountControl(self, name, action):
+        info = self.Query(name)
         domain_handle = self._open_domain()
         try:
             user_handle = self._get_user_handle(domain_handle, name)
             if action == 'enable':
-                self._hEnableAccount(user_handle)
+                self._hEnableAccount(user_handle, info['UserAccountControl'])
             else:
-                self._hDisableAccount(user_handle)
+                self._hDisableAccount(user_handle, info['UserAccountControl'])
         finally:
             self._close_domain()
 
@@ -504,6 +505,8 @@ if __name__ == '__main__':
     computer_parser.add_argument('-create', action="store", metavar = "NAME", help='Add new computer account to domain.')
     computer_parser.add_argument('-remove', action="store", metavar = "NAME", help='Remove existing computer account from domain.')
     computer_parser.add_argument('-newPasswd', action="store", metavar = "PASSWORD", help='New password to set for creating account.')
+    computer_parser.add_argument('-enable', action="store", metavar = "NAME", help='Enables account.')
+    computer_parser.add_argument('-disable', action="store", metavar = "NAME", help='Disables account.')
 
     localgroup_parser = subparsers.add_parser('localgroup', help='Enumerate local groups (aliases) of local computer')
     localgroup_parser.add_argument('-name', action="store", metavar = "NAME", help='Operate on single specific domain group account.')

--- a/examples/net.py
+++ b/examples/net.py
@@ -204,7 +204,7 @@ class User(SamrObject):
             samr.hSamrDeleteUser(self._dce, user_handle)
             raise
         else:
-            self._hEnableAccount(user_handle)
+            self._hEnableAccount(user_handle, self._create_account_type | samr.USER_ACCOUNT_DISABLED)
         finally:
             self._close_domain()
 


### PR DESCRIPTION
Hi,
this PR adds functionality to net.py to enable or disable user accounts
![image](https://github.com/user-attachments/assets/cbc6f182-66e4-4a47-ac37-574a48da7392)

![image](https://github.com/user-attachments/assets/dda1674c-5592-4b26-9114-9667a244a082)

![image](https://github.com/user-attachments/assets/3b34b50c-9038-4269-bd39-5b316330eee3)

![image](https://github.com/user-attachments/assets/8d9c41e6-1bb1-4a43-9c6a-13f01203f891)
