### PR TITLE
Title: Enhance Command-Line Argument Handling for Mimikatz RPC Script…

### DIFF
--- a/examples/mimikatz.py
+++ b/examples/mimikatz.py
@@ -122,6 +122,8 @@ def main():
     parser.add_argument('target', action='store', help='[[domain/]username[:password]@]<targetName or address>')
     parser.add_argument('-file', type=argparse.FileType('r'), help='input file with commands to execute in the mini shell')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-guid', help='Custom GUID for RPC interface. This GUID should be same as mimikatz '
+                                                        'rpc::server GUID, if omitted, the default UUID will be used')
 
     group = parser.add_argument_group('authentication')
 
@@ -176,6 +178,14 @@ def main():
     else:
         lmhash = ''
         nthash = ''
+
+    # Use the provided GUID or fall back to the default
+    if options.guid:
+        print(f"Custom GUID provided: {options.guid}")
+        mimilib.set_msrpc_uuid(options.guid)
+    else:
+        print("No custom GUID provided, using default UUID.")
+        mimilib.set_msrpc_uuid()
 
     bound = False
  

--- a/impacket/dcerpc/v5/mimilib.py
+++ b/impacket/dcerpc/v5/mimilib.py
@@ -35,7 +35,17 @@ from impacket.dcerpc.v5.rpcrt import DCERPCException
 from impacket.uuid import uuidtup_to_bin
 from impacket.structure import Structure
 
-MSRPC_UUID_MIMIKATZ   = uuidtup_to_bin(('17FC11E9-C258-4B8D-8D07-2F4125156244', '1.0'))
+
+# Define the default RPC server interface used by mimikatz
+DEFAULT_UUID = uuidtup_to_bin(('17FC11E9-C258-4B8D-8D07-2F4125156244', '1.0'))
+
+# function to set msrpc uuid
+def set_msrpc_uuid(custom_guid=None):
+    global MSRPC_UUID_MIMIKATZ
+    if custom_guid is not None:
+        MSRPC_UUID_MIMIKATZ = uuidtup_to_bin((custom_guid, '1.0'))
+    else:
+        MSRPC_UUID_MIMIKATZ = DEFAULT_UUID
 
 class DCERPCSessionError(DCERPCException):
     def __init__(self, error_string=None, error_code=None, packet=None):


### PR DESCRIPTION
… with Custom GUID Option

**Summary:**
While working on gentilkiwi's Mimikatz, I noticed that the tool accepts a command-line argument for a custom GUID in the _**RPC::Server**_ interface. Inspired by this functionality, this pull request enhances the Mimikatz RPC script by adding support for an optional **_-guid_** command-line argument, allowing users to specify a custom GUID for the RPC interface. If no custom GUID is provided, the script will default to the pre-defined UUID. This update also ensures that other command-line arguments continue to function seamlessly while maintaining backward compatibility.

**Changes Made:**
Added **_-guid_** Argument: Introduced a new optional _**-guid**_ argument to the script. If provided, this argument allows users to specify a custom GUID for the Mimikatz RPC interface. The script defaults to the hardcoded UUID if the -guid argument is omitted.

**Updated mimilib.py:**
Implemented a **_set_msrpc_uuid()_** function to manage the global **_MSRPC_UUID_MIMIKATZ_** variable based on the presence of a custom GUID. Centralized the UUID logic for easier maintenance and updates.

**Main Script Modifications:**
Integrated the **_-guid_** handling logic into the main() function to ensure that the correct UUID is set based on user input. Included checks and debug print statements to enhance runtime visibility and troubleshooting.

**Testing:**
The changes have been thoroughly tested to confirm that:

1. The script correctly defaults to the pre-defined UUID when the -guid argument is not provided. 
![mimi_default_RPC_UUID](https://github.com/user-attachments/assets/2bde59c6-7bb4-4b79-beb7-388598f8f02d)

![impacket-mimi-_default_UUID](https://github.com/user-attachments/assets/eb191a61-b93c-47df-b03e-b05fe543c5bf)

2. The custom GUID is correctly applied when the -guid argument is specified.
![mimi_custom_RPC_UUID](https://github.com/user-attachments/assets/4e97c5d8-9cb6-4912-9d24-62552ba1fc28)

![impacket-mimi-custom_UUID](https://github.com/user-attachments/assets/8971153a-1350-40c0-a9c5-24181537c256)

3. All other command-line arguments continue to work as intended without any regressions.

Notes:
This update maintains full backward compatibility, introducing no breaking changes. It simply adds flexibility to the Mimikatz RPC script by supporting dynamic configuration through the new -guid option.