### PR TITLE
fix: Updating deprecated datetime lib

### DIFF
--- a/examples/GetNPUsers.py
+++ b/examples/GetNPUsers.py
@@ -162,7 +162,7 @@ class GetUserNoPreAuth:
 
         reqBody['realm'] = domain
 
-        now = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
         reqBody['till'] = KerberosTime.to_asn1(now)
         reqBody['rtime'] = KerberosTime.to_asn1(now)
         reqBody['nonce'] = random.getrandbits(31)

--- a/examples/addcomputer.py
+++ b/examples/addcomputer.py
@@ -357,7 +357,7 @@ class ADDCOMPUTER:
         authenticator['authenticator-vno'] = 5
         authenticator['crealm'] = domain
         seq_set(authenticator, 'cname', userName.components_to_asn1)
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
 
         authenticator['cusec'] = now.microsecond
         authenticator['ctime'] = KerberosTime.to_asn1(now)

--- a/examples/dacledit.py
+++ b/examples/dacledit.py
@@ -873,7 +873,7 @@ def ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='
     authenticator['authenticator-vno'] = 5
     authenticator['crealm'] = domain
     seq_set(authenticator, 'cname', userName.components_to_asn1)
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
 
     authenticator['cusec'] = now.microsecond
     authenticator['ctime'] = KerberosTime.to_asn1(now)

--- a/examples/getPac.py
+++ b/examples/getPac.py
@@ -148,7 +148,7 @@ class S4U2SELF:
 
         seq_set(authenticator, 'cname', clientName.components_to_asn1)
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         authenticator['cusec'] = now.microsecond
         authenticator['ctime'] = KerberosTime.to_asn1(now)
 
@@ -238,7 +238,7 @@ class S4U2SELF:
         seq_set(reqBody, 'sname', serverName.components_to_asn1)
         reqBody['realm'] = str(decodedTGT['crealm'])
 
-        now = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
 
         reqBody['till'] = KerberosTime.to_asn1(now)
         reqBody['nonce'] = random.getrandbits(31)

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -284,7 +284,7 @@ class GETST:
 
             seq_set(authenticator, 'cname', clientName.components_to_asn1)
 
-            now = datetime.datetime.utcnow()
+            now = datetime.datetime.now(datetime.timezone.utc)
             authenticator['cusec'] = now.microsecond
             authenticator['ctime'] = KerberosTime.to_asn1(now)
 
@@ -336,7 +336,7 @@ class GETST:
             myTicket = ticket.to_asn1(TicketAsn1())
             seq_set_iter(reqBody, 'additional-tickets', (myTicket,))
 
-            now = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+            now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
 
             reqBody['till'] = KerberosTime.to_asn1(now)
             reqBody['nonce'] = random.getrandbits(31)
@@ -377,7 +377,7 @@ class GETST:
 
         seq_set(authenticator, 'cname', clientName.components_to_asn1)
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         authenticator['cusec'] = now.microsecond
         authenticator['ctime'] = KerberosTime.to_asn1(now)
 
@@ -474,7 +474,7 @@ class GETST:
         seq_set(reqBody, 'sname', serverName.components_to_asn1)
         reqBody['realm'] = str(decodedTGT['crealm'])
 
-        now = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
 
         reqBody['till'] = KerberosTime.to_asn1(now)
         reqBody['nonce'] = random.getrandbits(31)
@@ -604,7 +604,7 @@ class GETST:
 
         seq_set(authenticator, 'cname', clientName.components_to_asn1)
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         authenticator['cusec'] = now.microsecond
         authenticator['ctime'] = KerberosTime.to_asn1(now)
 
@@ -656,7 +656,7 @@ class GETST:
         myTicket = ticket.to_asn1(TicketAsn1())
         seq_set_iter(reqBody, 'additional-tickets', (myTicket,))
 
-        now = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
 
         reqBody['till'] = KerberosTime.to_asn1(now)
         reqBody['nonce'] = random.getrandbits(31)

--- a/examples/goldenPac.py
+++ b/examples/goldenPac.py
@@ -720,7 +720,7 @@ class MS14_068:
         seq_set(reqBody, 'sname', serverName.components_to_asn1)
         reqBody['realm'] = decodedTGT['crealm'].prettyPrint()
 
-        now = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
 
         reqBody['till'] = KerberosTime.to_asn1(now)
         reqBody['nonce'] = random.SystemRandom().getrandbits(31)
@@ -746,7 +746,7 @@ class MS14_068:
 
         seq_set(authenticator, 'cname', clientName.components_to_asn1)
 
-        now = datetime.datetime.utcnow() 
+        now = datetime.datetime.now(datetime.timezone.utc) 
         authenticator['cusec'] =  now.microsecond
         authenticator['ctime'] = KerberosTime.to_asn1(now)
 

--- a/examples/owneredit.py
+++ b/examples/owneredit.py
@@ -404,7 +404,7 @@ def ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='
     authenticator['authenticator-vno'] = 5
     authenticator['crealm'] = domain
     seq_set(authenticator, 'cname', userName.components_to_asn1)
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
 
     authenticator['cusec'] = now.microsecond
     authenticator['ctime'] = KerberosTime.to_asn1(now)

--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -907,7 +907,7 @@ class RAISECHILD:
         encTicketPart = decoder.decode(plainText, asn1Spec = EncTicketPart())[0]
 
         # Let's extend the ticket's validity a lil bit
-        tenYearsFromNow = datetime.datetime.utcnow() + datetime.timedelta(days=365*10)
+        tenYearsFromNow = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=365*10)
         encTicketPart['endtime'] = KerberosTime.to_asn1(tenYearsFromNow)
         encTicketPart['renew-till'] = KerberosTime.to_asn1(tenYearsFromNow)
         #print encTicketPart.prettyPrint()

--- a/examples/rbcd.py
+++ b/examples/rbcd.py
@@ -142,7 +142,7 @@ def ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='
     authenticator['authenticator-vno'] = 5
     authenticator['crealm'] = domain
     seq_set(authenticator, 'cname', userName.components_to_asn1)
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
 
     authenticator['cusec'] = now.microsecond
     authenticator['ctime'] = KerberosTime.to_asn1(now)

--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -138,7 +138,7 @@ class TICKETER:
         # 1) KERB_VALIDATION_INFO
         kerbdata = KERB_VALIDATION_INFO()
 
-        aTime = timegm(datetime.datetime.utcnow().timetuple())
+        aTime = timegm(datetime.datetime.now(datetime.timezone.utc).timetuple())
         unixTime = self.getFileTime(aTime)
 
         kerbdata['LogonTime']['dwLowDateTime'] = unixTime & 0xffffffff
@@ -487,7 +487,7 @@ class TICKETER:
 
         seq_set(authenticator, 'cname', clientName.components_to_asn1)
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         authenticator['cusec'] = now.microsecond
         authenticator['ctime'] = KerberosTime.to_asn1(now)
 
@@ -576,7 +576,7 @@ class TICKETER:
         seq_set(reqBody, 'sname', serverName.components_to_asn1)
         reqBody['realm'] = str(decodedTGT['crealm'])
 
-        now = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
 
         reqBody['till'] = KerberosTime.to_asn1(now)
         reqBody['nonce'] = random.getrandbits(31)
@@ -597,7 +597,7 @@ class TICKETER:
     def customizeTicket(self, kdcRep, pacInfos):
         logging.info('Customizing ticket for %s/%s' % (self.__domain, self.__target))
 
-        ticketDuration = datetime.datetime.utcnow() + datetime.timedelta(hours=int(self.__options.duration))
+        ticketDuration = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=int(self.__options.duration))
 
         if self.__options.impersonate:
             # Doing Sapphire Ticket
@@ -715,8 +715,8 @@ class TICKETER:
             encTicketPart['transited'] = noValue
             encTicketPart['transited']['tr-type'] = 0
             encTicketPart['transited']['contents'] = ''
-            encTicketPart['authtime'] = KerberosTime.to_asn1(datetime.datetime.utcnow())
-            encTicketPart['starttime'] = KerberosTime.to_asn1(datetime.datetime.utcnow())
+            encTicketPart['authtime'] = KerberosTime.to_asn1(datetime.datetime.now(datetime.timezone.utc))
+            encTicketPart['starttime'] = KerberosTime.to_asn1(datetime.datetime.now(datetime.timezone.utc))
             # Let's extend the ticket's validity a lil bit
             encTicketPart['endtime'] = KerberosTime.to_asn1(ticketDuration)
             encTicketPart['renew-till'] = KerberosTime.to_asn1(ticketDuration)
@@ -840,7 +840,7 @@ class TICKETER:
         encRepPart['last-req'] = noValue
         encRepPart['last-req'][0] = noValue
         encRepPart['last-req'][0]['lr-type'] = 0
-        encRepPart['last-req'][0]['lr-value'] = KerberosTime.to_asn1(datetime.datetime.utcnow())
+        encRepPart['last-req'][0]['lr-value'] = KerberosTime.to_asn1(datetime.datetime.now(datetime.timezone.utc))
         encRepPart['nonce'] = 123456789
         encRepPart['key-expiration'] = KerberosTime.to_asn1(ticketDuration)
         flags = []

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -155,7 +155,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
 
     reqBody['realm'] = domain
 
-    now = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+    now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
     reqBody['till'] = KerberosTime.to_asn1(now)
     reqBody['rtime'] = KerberosTime.to_asn1(now)
     reqBody['nonce'] =  rand.getrandbits(31)
@@ -266,7 +266,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
         # Let's build the timestamp
         timeStamp = PA_ENC_TS_ENC()
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         timeStamp['patimestamp'] = KerberosTime.to_asn1(now)
         timeStamp['pausec'] = now.microsecond
 
@@ -312,7 +312,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
 
         reqBody['realm'] =  domain
 
-        now = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
         reqBody['till'] = KerberosTime.to_asn1(now)
         reqBody['rtime'] =  KerberosTime.to_asn1(now)
         reqBody['nonce'] = rand.getrandbits(31)
@@ -396,7 +396,7 @@ def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey, renew =
 
     seq_set(authenticator, 'cname', clientName.components_to_asn1)
 
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     authenticator['cusec'] =  now.microsecond
     authenticator['ctime'] = KerberosTime.to_asn1(now)
 
@@ -438,7 +438,7 @@ def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey, renew =
     seq_set(reqBody, 'sname', serverName.components_to_asn1)
     reqBody['realm'] = domain
 
-    now = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+    now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
 
     reqBody['till'] = KerberosTime.to_asn1(now)
     reqBody['nonce'] = rand.getrandbits(31)
@@ -519,7 +519,7 @@ def getKerberosType3(cipher, sessionKey, auth_data):
     encAPRepPart['subkey'].clear()
     encAPRepPart = encAPRepPart.clone()
 
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     encAPRepPart['cusec'] = now.microsecond
     encAPRepPart['ctime'] = KerberosTime.to_asn1(now)
     encAPRepPart['seq-number'] = sequenceNumber
@@ -645,7 +645,7 @@ def getKerberosType1(username, password, domain, lmhash, nthash, aesKey='', TGT 
     authenticator['authenticator-vno'] = 5
     authenticator['crealm'] = domain
     seq_set(authenticator, 'cname', userName.components_to_asn1)
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
 
     authenticator['cusec'] = now.microsecond
     authenticator['ctime'] = KerberosTime.to_asn1(now)

--- a/impacket/krb5/kpasswd.py
+++ b/impacket/krb5/kpasswd.py
@@ -129,7 +129,7 @@ def createKPasswdRequest(principal, domain, newPasswd, tgs, cipher, sessionKey, 
         sequenceNumber = int.from_bytes(get_random_bytes(4), "big")
 
     if now is None:
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
 
     if not isinstance(newPasswd, bytes):
         newPasswd = newPasswd.encode("utf-8")

--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -215,7 +215,7 @@ class LDAPConnection:
         authenticator['authenticator-vno'] = 5
         authenticator['crealm'] = domain
         seq_set(authenticator, 'cname', userName.components_to_asn1)
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
 
         authenticator['cusec'] = now.microsecond
         authenticator['ctime'] = KerberosTime.to_asn1(now)

--- a/impacket/smb.py
+++ b/impacket/smb.py
@@ -3251,7 +3251,7 @@ class SMB(object):
         authenticator['authenticator-vno'] = 5
         authenticator['crealm'] = domain
         seq_set(authenticator, 'cname', userName.components_to_asn1)
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
 
         authenticator['cusec'] = now.microsecond
         authenticator['ctime'] = KerberosTime.to_asn1(now)

--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -797,7 +797,7 @@ class SMB3:
         authenticator['authenticator-vno'] = 5
         authenticator['crealm'] = domain
         seq_set(authenticator, 'cname', userName.components_to_asn1)
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
 
         authenticator['cusec'] = now.microsecond
         authenticator['ctime'] = KerberosTime.to_asn1(now)

--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -818,7 +818,7 @@ class MSSQL:
         authenticator['authenticator-vno'] = 5
         authenticator['crealm'] = domain
         seq_set(authenticator, 'cname', userName.components_to_asn1)
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
 
         authenticator['cusec'] = now.microsecond
         authenticator['ctime'] = KerberosTime.to_asn1(now)


### PR DESCRIPTION
Updating the use of datetime.datetime.utcnow() to datetime.datetime.now(datetime.timezone.utc) since the former is deprecated