### PR TITLE
Display created ProcessId using wmiexec.py

### DIFF
--- a/examples/wmiexec.py
+++ b/examples/wmiexec.py
@@ -292,8 +292,11 @@ class RemoteShell(cmd.Cmd):
 
         if self.__noOutput is False:
             command += ' 1> ' + '\\\\127.0.0.1\\%s' % self.__share + self.__output + ' 2>&1'
-        self.__win32Process.Create(command, self.__pwd, None)
-        self.get_output()
+        response = self.__win32Process.Create(command, self.__pwd, None)
+        if self.__noOutput is False:
+            self.get_output()
+        else:
+            response.printInformation() # print ProcessId and ReturnValue
 
     def send_data(self, data):
         self.execute_remote(data, self.__shell_type)

--- a/examples/wmiexec.py
+++ b/examples/wmiexec.py
@@ -43,7 +43,6 @@ from impacket.dcerpc.v5.dcomrt import DCOMConnection, COMVERSION
 from impacket.dcerpc.v5.dcom import wmi
 from impacket.dcerpc.v5.dtypes import NULL
 from impacket.krb5.keytab import Keytab
-from six import PY2
 
 OUTPUT_FILENAME = '__' + str(time.time())
 CODEC = sys.stdout.encoding
@@ -226,10 +225,7 @@ class RemoteShell(cmd.Cmd):
             print(self.__outputBuffer)
             self.__outputBuffer = ''
         else:
-            if PY2:
-                self.__pwd = ntpath.normpath(ntpath.join(self.__pwd, s.decode(sys.stdin.encoding)))
-            else:
-                self.__pwd = ntpath.normpath(ntpath.join(self.__pwd, s))
+            self.__pwd = ntpath.normpath(ntpath.join(self.__pwd, s))
             self.execute_remote('cd ')
             self.__pwd = self.__outputBuffer.strip('\r\n')
             self.prompt = (self.__pwd + '>')
@@ -296,10 +292,7 @@ class RemoteShell(cmd.Cmd):
 
         if self.__noOutput is False:
             command += ' 1> ' + '\\\\127.0.0.1\\%s' % self.__share + self.__output + ' 2>&1'
-        if PY2:
-            self.__win32Process.Create(command.decode(sys.stdin.encoding), self.__pwd, None)
-        else:
-            self.__win32Process.Create(command, self.__pwd, None)
+        self.__win32Process.Create(command, self.__pwd, None)
         self.get_output()
 
     def send_data(self, data):


### PR DESCRIPTION
This PR contains two changes in `wmiexec.py`:

1. drops python2 support due to recent changes in Impacket.
2. display ProcessId and ReturnValue for created process using wmi, if `-nooutput` was specified.

Sample:
```
┌──(kali㉿kali)-[~/Dev/impacket]
└─$ python examples/wmiexec.py -nooutput Administrator:SecretPass123@192.168.1.78 notepad
Impacket v0.12.0 - Copyright Fortra, LLC and its affiliated companies

[abstract]
class __PARAMETERS
{
        [Out(True)]
        [MappingStrings(['Win32API|Process and Thread Functions|CreateProcess|lpProcessInformation|dwProcessId'])]
        [ID(3)]
        uint32 ProcessId = 6560

        [out(True)]
        uint32 ReturnValue = 0


}
```