### PR TITLE
Add NTLM SIGN flag for SMB Server

### DIFF
--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -2908,6 +2908,8 @@ class SMB2Commands:
                 ansFlags |= ntlm.NTLMSSP_NEGOTIATE_UNICODE
             if negotiateMessage['flags'] & ntlm.NTLM_NEGOTIATE_OEM:
                 ansFlags |= ntlm.NTLM_NEGOTIATE_OEM
+            if negotiateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_SIGN:
+                ansFlags |= ntlm.NTLMSSP_NEGOTIATE_SIGN
 
             ansFlags |= ntlm.NTLMSSP_NEGOTIATE_VERSION | ntlm.NTLMSSP_NEGOTIATE_TARGET_INFO | ntlm.NTLMSSP_TARGET_TYPE_SERVER | ntlm.NTLMSSP_NEGOTIATE_NTLM | ntlm.NTLMSSP_REQUEST_TARGET
 


### PR DESCRIPTION
Adds the NTLMSSP_NEGOTIATE_SIGN flag to the NTLM CHALLENGE message returned by the SMB server. This is needeed for clients that generate a SPNEGO mechListMIC which require signing to be enabled on the NTLM context.

Some background information, a client that sends an NTLM token wrapped in a SPNEGO payload can set the [mechListMIC](https://www.rfc-editor.org/rfc/rfc4178.html#section-5) but the MS-NLMP docs are unclear what the signature behaviour is without the `NTLMSSP_NEGOTIATE_SIGN` or `NTLMSSP_NEGOTIATE_ALWAYS_SIGN` flags. I've interpreted it as signing isn't supported and thus the `mechListMIC` field cannot be computed. What should happen is if the client itself specified the `NTLMSSP_NEGOTIATE_SIGN` flag then the challenge should also respond with it which this change does. This is backed up by the protocol docs for [CHALLENGE_MESSAGE](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/801a4681-8809-4be9-ab0d-61dcfe762786)

> If the client has set the NTLMSSP_NEGOTIATE_SIGN in the NEGOTIATE_MESSAGE the
Server MUST return it.