### PR TITLE
SMB Server fix filename offsets

### DIFF
--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -502,6 +502,9 @@ def findFirst2(path, fileName, level, searchAttributes, pktFlags=smb.SMB.FLAGS2_
             item['LastAccessTime'] = getSMBTime(atime)
             item['LastWriteDate'] = getSMBDate(mtime)
             item['LastWriteTime'] = getSMBTime(mtime)
+        elif level in [smb.SMB_FIND_FILE_NAMES_INFO, smb2.SMB2_FILE_NAMES_INFO]:
+            padLen = (8 - (len(item) % 8)) % 8
+            item['NextEntryOffset'] = len(item) + padLen
         searchResult.append(item)
 
     # No more files


### PR DESCRIPTION
Correctly set the NextEntryOffset for the SMBFindFileNamesInfo results when querying the names of files. The current logic does not set this value so will be set to 0 making the client believe there are no more entries in the result if going by the MS-SMB2 logic.

The docs for [FileNamesInformation](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/a289f7a8-83d2-4927-8c88-b2d328dde5a5) state that `NextEntryOffset` should be

> A 32-bit unsigned integer that contains the byte offset from the beginning of this entry, at which the next FILE_NAMES_INFORMATION entry is located, if multiple entries are present in a buffer. This member MUST be zero if no other entries follow this one. An implementation MUST use this value to determine the location of the next entry (if multiple entries are present in a buffer)

Currently you can see that while the reponse buffer contains all the entires, becaue `NextEntryOffset` is 0, consumers of this buffer only see the first entry when going by the MS-FSCC logic (0 is last entry)

<img width="1320" alt="image" src="https://github.com/user-attachments/assets/03e9ae2a-359f-4686-b6c8-d3874377e128">

After this change you can see the payload is correctly dissected by Wireshark

<img width="1320" alt="image" src="https://github.com/user-attachments/assets/ea61b952-a38a-47ed-b6be-315f37d751f0">
