### PR TITLE
ntlmrelayx: support upn format + oem encoding

### DIFF
--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -360,13 +360,7 @@ class HTTPRelayServer(Thread):
             elif messageType == 3:
                 authenticateMessage = ntlm.NTLMAuthChallengeResponse()
                 authenticateMessage.fromString(token)
-
-                if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
-                    self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('utf-16le'),
-                                                authenticateMessage['user_name'].decode('utf-16le'))).upper()
-                else:
-                    self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('ascii'),
-                                                authenticateMessage['user_name'].decode('ascii'))).upper()
+                self.authUser = authenticateMessage.getUserString()
 
                 self.target = self.server.config.target.getTarget(identity = self.authUser)
                 if self.target is None:
@@ -441,13 +435,7 @@ class HTTPRelayServer(Thread):
                 authenticateMessage.fromString(token)
 
                 if self.server.config.disableMulti:
-                    if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
-                        self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('utf-16le'),
-                                                    authenticateMessage['user_name'].decode('utf-16le'))).upper()
-                    else:
-                        self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('ascii'),
-                                                    authenticateMessage['user_name'].decode('ascii'))).upper()
-
+                    self.authUser = authenticateMessage.getUserString()
                     target = '%s://%s@%s' % (self.target.scheme, self.authUser.replace("/", '\\'), self.target.netloc)
 
                 if not self.do_ntlm_auth(token, authenticateMessage):

--- a/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
@@ -165,14 +165,8 @@ class RAWRelayServer(Thread):
             return True
 
         def do_ntlm_auth(self, token, authenticateMessage):
-
             # For some attacks it is important to know the authenticated username, so we store it
-            if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
-                self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('utf-16le'),
-                                            authenticateMessage['user_name'].decode('utf-16le'))).upper()
-            else:
-                self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('ascii'),
-                                            authenticateMessage['user_name'].decode('ascii'))).upper()
+            self.authUser = authenticateMessage.getUserString()
 
             if authenticateMessage['user_name'] != '' or self.target.hostname == '127.0.0.1':
                 clientResponse, errorCode = self.client.sendAuth(token)

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -340,8 +340,7 @@ class SMBRelayServer(Thread):
             client = connData['SMBClient']
             authenticateMessage = ntlm.NTLMAuthChallengeResponse()
             authenticateMessage.fromString(token)
-            self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('utf-16le'),
-                                        authenticateMessage['user_name'].decode('utf-16le'))).upper()
+            self.authUser = authenticateMessage.getUserString()
 
             if rawNTLM is True:
                 respToken2 = SPNEGO_NegTokenResp()
@@ -409,11 +408,8 @@ class SMBRelayServer(Thread):
 
     def smb2TreeConnect(self, connId, smbServer, recvPacket):
         connData = smbServer.getConnectionData(connId)
-
         authenticateMessage = connData['AUTHENTICATE_MESSAGE']
-
-        self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode ('utf-16le'),
-                                    authenticateMessage['user_name'].decode ('utf-16le'))).upper ()
+        self.authUser = authenticateMessage.getUserString()
 
         if self.config.disableMulti:
             return self.origsmb2TreeConnect(connId, smbServer, recvPacket)
@@ -631,8 +627,7 @@ class SMBRelayServer(Thread):
                 client = connData['SMBClient']
                 authenticateMessage = ntlm.NTLMAuthChallengeResponse()
                 authenticateMessage.fromString(token)
-                self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('utf-16le'),
-                                            authenticateMessage['user_name'].decode('utf-16le'))).upper()
+                self.authUser = authenticateMessage.getUserString()
 
                 clientResponse, errorCode = self.do_ntlm_auth(client,sessionSetupData['SecurityBlob'],
                                                               connData['CHALLENGE_MESSAGE']['challenge'])
@@ -773,8 +768,7 @@ class SMBRelayServer(Thread):
         connData = smbServer.getConnectionData(connId)
 
         authenticateMessage = connData['AUTHENTICATE_MESSAGE']
-        self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode ('utf-16le'),
-                                    authenticateMessage['user_name'].decode ('utf-16le'))).upper ()
+        self.authUser = authenticateMessage.getUserString()
 
         if self.config.disableMulti:
             return self.smbComTreeConnectAndX(connId, smbServer, SMBCommand, recvPacket)

--- a/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
@@ -306,12 +306,7 @@ class WCFRelayServer(Thread):
 
         def do_ntlm_auth(self, token, authenticateMessage):
             # For some attacks it is important to know the authenticated username, so we store it
-            if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
-                self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('utf-16le'),
-                                            authenticateMessage['user_name'].decode('utf-16le'))).upper()
-            else:
-                self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('ascii'),
-                                            authenticateMessage['user_name'].decode('ascii'))).upper()
+            self.authUser = authenticateMessage.getUserString()
 
             if authenticateMessage['user_name'] != '' or self.target.hostname == '127.0.0.1':
                 clientResponse, errorCode = self.client.sendAuth(token)

--- a/impacket/ntlm.py
+++ b/impacket/ntlm.py
@@ -503,6 +503,20 @@ class NTLMAuthChallengeResponse(Structure):
         lanman_end    = self['lanman_len'] + lanman_offset
         self['lanman'] = data[ lanman_offset : lanman_end]
 
+    def getUserString(self):
+        if self['flags'] & NTLMSSP_NEGOTIATE_UNICODE:
+            user = self['user_name'].decode('utf-16le')
+            domain = self['domain_name'].decode('utf-16le')
+        else:
+            user = self['user_name'].decode('cp437')
+            domain = self['domain_name'].decode('cp437')
+
+        # user is in UPN format
+        if not domain and '@' in user:
+            user, _, domain = user.rpartition("@")
+
+        return ('%s/%s' % (domain, user)).upper()
+
 class ImpacketStructure(Structure):
     def set_parent(self, other):
         self.parent = other


### PR DESCRIPTION
This is a followup PR for https://github.com/fortra/impacket/pull/1316 (since @rtpt-lucasvater leaves the company) and I'm taking over for him. Original text:

As described in https://github.com/fortra/impacket/issues/1315, `ntlmrelayx.py` in SOCKS-mode currently does not work together with usernames in UPN format.

This pull request converts usernames in UPN formats (`user1@domain`) to a format compatible with Impacket (`domain/user1`), before they are added to the active SOCKS connections.

While implementing this, I noticed that if NTLM is negotiated using OEM encoding instead of Unicode (`NTLMSSP_NEGOTIATE_OEM`), the username is currently encoded wrongfully using ASCII-encoding. This fails when certain characters are used in usernames (umlauts like ä,ü,ö for example). I changed the encoding to use the most used Windows codepage in this case.

Fixes https://github.com/fortra/impacket/issues/1315