### PR TITLE
Fix SMB2 compoud response signing

### DIFF
--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -4403,10 +4403,11 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
         packet['SecurityFeatures'] = m.digest()[:8]
         connData['SignSequenceNumber'] += 2
 
-    def signSMBv2(self, packet, signingSessionKey):
+    def signSMBv2(self, packet, signingSessionKey, padLength=0):
         packet['Signature'] = b'\x00' * 16
         packet['Flags'] |= smb2.SMB2_FLAGS_SIGNED
-        signature = hmac.new(signingSessionKey, packet.getData(), hashlib.sha256).digest()
+        packetData = packet.getData() + b'\x00' * padLength
+        signature = hmac.new(signingSessionKey, packetData, hashlib.sha256).digest()
         packet['Signature'] = signature[:16]
         # print "%s" % packet['Signature'].encode('hex')
 
@@ -4624,34 +4625,30 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
                         else:
                             respPacket['Data'] = str(respCommand)
 
-                        if connData['SignatureEnabled']:
-                            self.signSMBv2(respPacket, connData['SigningSessionKey'])
-
                         packetsToSend.append(respPacket)
             else:
                 # The SMBCommand took care of building the packet
                 packetsToSend = respPackets
 
         if isSMB2 is True:
-            # Let's build a compound answer
-            finalData = b''
-            i = 0
-            for i in range(len(packetsToSend) - 1):
-                packet = packetsToSend[i]
-                # Align to 8-bytes
-                padLen = (8 - (len(packet) % 8)) % 8
-                packet['NextCommand'] = len(packet) + padLen
-                if hasattr(packet, 'getData'):
-                    finalData += packet.getData() + padLen * b'\x00'
-                else:
-                    finalData += packet + padLen * b'\x00'
+            # Let's build a compound answer and sign it
+            finalData = []
+            totalPackets = len(packetsToSend)
+            for idx, packet in enumerate(packetsToSend):
+                padLen = 0
+                if idx + 1 < totalPackets:
+                    padLen = -len(packet) % 8
+                    packet['NextCommand'] = len(packet) + padLen
 
-            # Last one
-            if hasattr(packetsToSend[len(packetsToSend) - 1], 'getData'):
-                finalData += packetsToSend[len(packetsToSend) - 1].getData()
-            else:
-                finalData += packetsToSend[len(packetsToSend) - 1]
-            packetsToSend = [finalData]
+                if connData['SignatureEnabled']:
+                    self.signSMBv2(packet, connData['SigningSessionKey'], padLength=padLen)
+
+                if hasattr(packet, 'getData'):
+                    finalData.append(packet.getData() + padLen * b'\x00')
+                else:
+                    finalData.append(packet + padLen * b'\x00')
+
+            packetsToSend = [b"".join(finalData)]
 
         # We clear the compound requests
         connData['LastRequest'] = {}

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -4635,9 +4635,8 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
             finalData = []
             totalPackets = len(packetsToSend)
             for idx, packet in enumerate(packetsToSend):
-                padLen = 0
+                padLen = -len(packet) % 8
                 if idx + 1 < totalPackets:
-                    padLen = -len(packet) % 8
                     packet['NextCommand'] = len(packet) + padLen
 
                 if connData['SignatureEnabled']:


### PR DESCRIPTION
Fix the signing the logic when responding with an SMB2 compount response. The signature will include the padding of each compound element and include the next offset value before signing the data.

The current logic was adding the signature but before it set the `NextCommand` entry and it did not include any of the padding added between each compound entry. By delaying the signing until after the compound entries are build we can ensure that the signatures are generated correctly so the client can verify them.

The padding data must be included in the signature as per MS-SMB2 https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/a3e9ea1e-53c8-4cff-94bd-d98fb20417c0

> If the message is part of a compounded chain, any padding at the end of the message MUST be used in the hash computation