### PR TITLE
Fix SOCKS Target Parsing

### DIFF
--- a/impacket/examples/ntlmrelayx/servers/socksserver.py
+++ b/impacket/examples/ntlmrelayx/servers/socksserver.py
@@ -325,7 +325,7 @@ class SocksRequestHandler(socketserver.BaseRequestHandler):
                 self.targetHost = socket.inet_ntoa(request['PAYLOAD'][:4])
                 self.targetPort = unpack('>H',request['PAYLOAD'][4:])[0]
             elif request['ATYP'] == ATYP.DOMAINNAME.value:
-                hostLength = unpack('!B',request['PAYLOAD'][0])[0]
+                hostLength = unpack('!B',request['PAYLOAD'][:1])[0]
                 self.targetHost = request['PAYLOAD'][1:hostLength+1]
                 self.targetPort = unpack('>H',request['PAYLOAD'][hostLength+1:])[0]
             else:


### PR DESCRIPTION
Fixes https://github.com/fortra/impacket/issues/1575 by parsing the target hostname correctly from commands run through ntlmrelayx's socks5 proxy.