### PR TITLE
Fix netlogon implementation

### DIFF
--- a/impacket/dcerpc/v5/nrpc.py
+++ b/impacket/dcerpc/v5/nrpc.py
@@ -1623,9 +1623,10 @@ class NL_AUTH_SHA2_SIGNATURE(Structure):
         ('Pad','<H=0xffff'),
         ('Flags','<H=0'),
         ('SequenceNumber','8s=""'),
-        ('Checksum','32s=""'),
+        ('Checksum','8s=""'),
         ('_Confounder','_-Confounder','8'),
         ('Confounder',':'),
+        ('Reserved','24s=""'),
     )
     def __init__(self, data = None, alignment = 0):
         Structure.__init__(self, data, alignment)
@@ -1698,7 +1699,7 @@ def ComputeNetlogonSignatureAES(authSignature, message, confounder, sessionKey):
     # If no confidentiality requested, it should be ''
     hm.update(confounder)
     hm.update(bytes(message))
-    return hm.digest()[:8]+'\x00'*24
+    return hm.digest()[:8]
 
 def ComputeNetlogonSignatureMD5(authSignature, message, confounder, sessionKey):
     # [MS-NRPC] Section 3.3.4.2.1, point 7
@@ -1712,6 +1713,21 @@ def ComputeNetlogonSignatureMD5(authSignature, message, confounder, sessionKey):
     hm = hmac.new(sessionKey, digestmod=hashlib.md5)
     hm.update(finalMD5)
     return hm.digest()[:8]
+
+def ComputeNetlogonAuthenticatorAES(clientStoredCredential, sessionKey):
+    # [MS-NRPC] Section 3.1.4.5
+    timestamp = int(time.time())
+
+    authenticator = NETLOGON_AUTHENTICATOR()
+    authenticator['Timestamp'] = timestamp
+
+    credential = unpack('<I', clientStoredCredential[:4])[0] + timestamp
+    if credential > 0xffffffff:
+        credential &= 0xffffffff
+    credential = pack('<I', credential)
+
+    authenticator['Credential'] = ComputeNetlogonCredentialAES(credential + clientStoredCredential[4:], sessionKey)
+    return authenticator
 
 def ComputeNetlogonAuthenticator(clientStoredCredential, sessionKey):
     # [MS-NRPC] Section 3.1.4.5
@@ -1761,7 +1777,7 @@ def SIGN(data, confounder, sequenceNum, key, aes = False):
     if aes is False:
         signature = NL_AUTH_SIGNATURE()
         signature['SignatureAlgorithm'] = NL_SIGNATURE_HMAC_MD5
-        if confounder == '':
+        if confounder == b'':
             signature['SealAlgorithm'] = NL_SEAL_NOT_ENCRYPTED
         else:
             signature['SealAlgorithm'] = NL_SEAL_RC4
@@ -1769,14 +1785,16 @@ def SIGN(data, confounder, sequenceNum, key, aes = False):
         signature['SequenceNumber'] = encryptSequenceNumberRC4(deriveSequenceNumber(sequenceNum), signature['Checksum'], key)
         return signature
     else:
-        signature = NL_AUTH_SIGNATURE()
+        signature = NL_AUTH_SHA2_SIGNATURE()
         signature['SignatureAlgorithm'] = NL_SIGNATURE_HMAC_SHA256
-        if confounder == '':
+        if confounder == b'':
             signature['SealAlgorithm'] = NL_SEAL_NOT_ENCRYPTED
         else:
             signature['SealAlgorithm'] = NL_SEAL_AES128
         signature['Checksum'] = ComputeNetlogonSignatureAES(signature, data, confounder, key)
         signature['SequenceNumber'] = encryptSequenceNumberAES(deriveSequenceNumber(sequenceNum), signature['Checksum'], key)
+        # 2.2.1.3.3 : Reserved: The sender SHOULD set these bytes to zero, and the receiver MUST ignore them.
+        signature['Reserved'] = b'\x00'*24
         return signature
 
 def SEAL(data, confounder, sequenceNum, key, aes = False):

--- a/impacket/dcerpc/v5/rpcrt.py
+++ b/impacket/dcerpc/v5/rpcrt.py
@@ -903,7 +903,8 @@ class DCERPC_v5(DCERPC):
         self.__aesKey = ''
         self.__TGT    = None
         self.__TGS    = None
-        
+
+        self.__aesNegociated = False
         self.__clientSigningKey = b''
         self.__serverSigningKey = b''
         self.__clientSealingKey = b''
@@ -921,6 +922,9 @@ class DCERPC_v5(DCERPC):
         self.__cipher = None
         self.__confounder = b''
         self.__gss = None
+
+    def set_aes(self, is_aes):
+        self.__aesNegociated = is_aes
 
     def set_session_key(self, session_key):
         self.__sessionKey = session_key
@@ -1200,7 +1204,7 @@ class DCERPC_v5(DCERPC):
                                self.__clientSealingHandle)
                 elif self.__auth_type == RPC_C_AUTHN_NETLOGON:
                     from impacket.dcerpc.v5 import nrpc
-                    sealedMessage, signature = nrpc.SEAL(plain_data, self.__confounder, self.__sequence, self.__sessionKey, False)
+                    sealedMessage, signature = nrpc.SEAL(plain_data, self.__confounder, self.__sequence, self.__sessionKey, self.__aesNegociated)
                 elif self.__auth_type == RPC_C_AUTHN_GSS_NEGOTIATE:
                     sealedMessage, signature = self.__gss.GSS_Wrap(self.__sessionKey, plain_data, self.__sequence)
 
@@ -1227,7 +1231,7 @@ class DCERPC_v5(DCERPC):
                            self.__confounder, 
                            self.__sequence, 
                            self.__sessionKey, 
-                           False)
+                           self.__aesNegociated)
                 elif self.__auth_type == RPC_C_AUTHN_GSS_NEGOTIATE:
                     signature = self.__gss.GSS_GetMIC(self.__sessionKey, plain_data, self.__sequence)
 
@@ -1374,7 +1378,7 @@ class DCERPC_v5(DCERPC):
                         answer, cfounder = nrpc.UNSEAL(answer, 
                                auth_data[len(sec_trailer):],
                                self.__sessionKey, 
-                               False)
+                               self.__aesNegociated)
                         self.__sequence += 1
                     elif self.__auth_type == RPC_C_AUTHN_GSS_NEGOTIATE:
                         if self.__sequence > 0:
@@ -1406,7 +1410,7 @@ class DCERPC_v5(DCERPC):
                                self.__confounder, 
                                self.__sequence, 
                                self.__sessionKey, 
-                               False)
+                               self.__aesNegociated)
                         self.__sequence += 1
                     elif self.__auth_type == RPC_C_AUTHN_GSS_NEGOTIATE:
                         # Do NOT increment the sequence number when Signing Kerberos


### PR DESCRIPTION
Hi.

Minor fixes within NETLOGON implementation:
- If AES is set for signing, function uses the right structure: `NL_AUTH_SHA2_SIGNATURE`
- `NL_AUTH_SHA2_SIGNATURE` is now more MS-NRPC "compliant": Reserved bytes are no longer part of the signature (see [2.2.1.3.3](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/fc77c8aa-6c21-446b-a822-4da26cc8a9a8))
- New function `ComputeNetlogonAuthenticatorAES`: compute a AES authenticator, based on `ComputeNetlogonAuthenticator`
- Fix bug when INTEGRITY is set: `confounder` is `b''` but it is compared with `''` (which returns `False`). This PR fixes it.

:sunflower: 

