### PR TITLE
Fix packet padding concatenation error (#1819)

### DIFF
--- a/impacket/ImpactPacket.py
+++ b/impacket/ImpactPacket.py
@@ -432,7 +432,7 @@ class Header(PacketBuffer,ProtocolLayer):
         if(len(aBuffer) < hdr_len):         #we must do something like this
             diff = hdr_len - len(aBuffer)
             for i in range(0, diff):
-                aBuffer += '\x00'
+                aBuffer += b'\x00'
         self.set_bytes_from_string(aBuffer[:hdr_len])
 
     def get_header_size(self):


### PR DESCRIPTION
- This happens when trying to parse packets headers from raw data, if the available data is less than the expected header length the library will try to pad zeroes to it: https://github.com/fortra/impacket/blob/3ce41be452dfe578f7edea16bc816e4f7fabe04d/impacket/ImpactPacket.py#L432-L435

- The padding worked fine in python 2, the buffer and `'\x00'` are considered bytes. 

- In python 3 `'\x00'` is considered a string so we get an error when trying to append it to a `bytes` buffer: `TypeError: can't concat str to bytes`

Affected classes so far are:

1. IP6
2. ICMP6
3. LINUXSLL
4. UDP
5. ARP
6. ICMP
7. IGMP
