### PR TITLE
Checking for 'value' != None before creating IWbemClass properties

### DIFF
--- a/examples/wmiquery.py
+++ b/examples/wmiquery.py
@@ -101,10 +101,10 @@ if __name__ == '__main__':
                             print('%s |' % record[key]['value'], end=' ')
                     print() 
                 except Exception as e:
-                    if logging.getLogger().level == logging.DEBUG:
-                        import traceback
-                        traceback.print_exc()
                     if str(e).find('S_FALSE') < 0:
+                        if logging.getLogger().level == logging.DEBUG:
+                            import traceback
+                            traceback.print_exc()
                         raise
                     else:
                         break

--- a/impacket/dcerpc/v5/dcom/wmi.py
+++ b/impacket/dcerpc/v5/dcom/wmi.py
@@ -2613,7 +2613,7 @@ class IWbemClassObject(IRemUnknown):
     def createProperties(self, properties):
         for property in properties:
             # Do we have an object property?
-            if properties[property]['type'] == CIM_TYPE_ENUM.CIM_TYPE_OBJECT.value:
+            if properties[property]['type'] == CIM_TYPE_ENUM.CIM_TYPE_OBJECT.value and properties[property]['value'] != None:
                 # Yes.. let's create an Object for it too
                 objRef = OBJREF_CUSTOM()
                 objRef['iid'] = self._iid


### PR DESCRIPTION
This PR fixes #1845

In the createProperties function, added an extra validation (for type='object') to only create an Object when 'value' is not None.
Otherwise it follows default processing; property value is set at its value without extra processing