### PR TITLE
SAMR: rephrased error message to account for non-relayed users

### DIFF
--- a/impacket/dcerpc/v5/samr.py
+++ b/impacket/dcerpc/v5/samr.py
@@ -1,6 +1,6 @@
 # Impacket - Collection of Python classes for working with network protocols.
 #
-# Copyright Fortra, LLC and its affiliated companies 
+# Copyright Fortra, LLC and its affiliated companies
 #
 # All rights reserved.
 #
@@ -2590,11 +2590,11 @@ def hSamrCreateUser2InDomain(dce, domainHandle, name, accountType=USER_NORMAL_AC
         return dce.request(request)
     except DCERPCSessionError as e:
         if e.error_code == 0xc0000022:
-            raise Exception("Relayed user doesn't have right to create a machine account!")
+            raise Exception("Authenticating account doesn't have the right to create a new machine account!")
         elif e.error_code == 0xc00002e7:
-            raise Exception("Relayed user machine quota exceeded!")
+            raise Exception("Authenticating account's machine account quota exceeded!")
         elif e.error_code == 0xc0000062:
-            raise Exception("Account name not accepted, maybe the '$' at the end is missing ?")
+            raise Exception("Account name not accepted, maybe the '$' at the end is missing?")
         else:
             raise e
 


### PR DESCRIPTION
When trying to add a new machine account without the proper right, an error message is returned explaining that the relayed user doesn't have the right.

However, it's not necessarily a user being relayed. It could also be a direct authentication attempt by `addcomputer.py`.

Therefore, I rephrased the error message to be less confusing and more generic.