### PR TITLE
DHCP unpackOptions type mismatch error fix

### DIFF
--- a/impacket/dhcp.py
+++ b/impacket/dhcp.py
@@ -178,7 +178,7 @@ class DhcpPacket(ProtocolPacket, structure.Structure):
             # size = self.calcUnpackSize(format, options[i+1:])
             size = options[i+1]
             # print i, name, format, size
-            value = self.unpack(format, options[i+2:i+2+size])
+            value = self.unpack(format, bytes(options[i+2:i+2+size]))
             answer.append((name, value))
             i += 2+size
 


### PR DESCRIPTION
This PR fixes #1633 .
Some DHCP packages couldn't be parsed, this happens because `options` is first defined as a bytearray here: https://github.com/fortra/impacket/blob/3ce41be452dfe578f7edea16bc816e4f7fabe04d/impacket/dhcp.py#L175 
but structure->unpack() expects a `bytes` object here: https://github.com/fortra/impacket/blob/3ce41be452dfe578f7edea16bc816e4f7fabe04d/impacket/structure.py#L384

an example package which caused this error:
`b'\x01\x01\x06\x00\xa3Y\xdf\x06\x00\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf84A\xdb2.\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00c\x82Sc5\x01\x032\x04\xc0\xa8\x00\x8c6\x04\xc0\xa8\x00\x019\x02\x02@7\x07\x01\x03\x06\x0c\x0f\x1c*<\x0cudhcp 1.36.1=\x07\x01\xf84A\xdb2.\xff\x00\x00\x00\x00\x00\x00\x00\x00'`
