### PR TITLE
Fix file length not matching file name because of multi-byte UTF-16

### DIFF
--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -1171,7 +1171,7 @@ class SMB3:
 
         treeConnect = SMB2TreeConnect()
         treeConnect['Buffer']     = path.encode('utf-16le')
-        treeConnect['PathLength'] = len(path.encode('utf-16le'))
+        treeConnect['PathLength'] = len(treeConnect['Buffer'])
 
         packet = self.SMB_PACKET()
         packet['Command'] = SMB2_TREE_CONNECT
@@ -1470,8 +1470,9 @@ class SMB3:
         if maxBufferSize is None:
             maxBufferSize = self._Connection['MaxReadSize']
         queryDirectory['OutputBufferLength'] = maxBufferSize
-        queryDirectory['FileNameLength']     = len(searchString.encode('utf-16le'))
         queryDirectory['Buffer']             = searchString.encode('utf-16le')
+        queryDirectory['FileNameLength']     = len(queryDirectory['Buffer'])
+        
 
         packet['Data'] = queryDirectory
 
@@ -1718,8 +1719,9 @@ class SMB3:
             renameReq = FILE_RENAME_INFORMATION_TYPE_2()
             renameReq['ReplaceIfExists'] = 1
             renameReq['RootDirectory']   = '\x00'*8
-            renameReq['FileNameLength']  = len(newPath.encode('utf-16le'))
             renameReq['FileName']        = newPath.encode('utf-16le')
+            renameReq['FileNameLength']  = len(renameReq['FileName'])
+
             self.setInfo(treeId, fileId, renameReq, infoType = SMB2_0_INFO_FILE, fileInfoClass = SMB2_FILE_RENAME_INFO)
         finally:
             if fileId is not None:
@@ -1964,9 +1966,10 @@ class SMB3:
 
         pipeWait = FSCTL_PIPE_WAIT_STRUCTURE()
         pipeWait['Timeout']          = timeout*100000
-        pipeWait['NameLength']       = len(pipename.encode('utf-16le'))
-        pipeWait['TimeoutSpecified'] = 1
         pipeWait['Name']             = pipename.encode('utf-16le')
+        pipeWait['NameLength']       = len(pipeWait['Name'] )
+        pipeWait['TimeoutSpecified'] = 1
+
 
         return self.ioctl(treeId, None, FSCTL_PIPE_WAIT,flags=SMB2_0_IOCTL_IS_FSCTL, inputBlob=pipeWait, maxInputResponse = 0, maxOutputResponse=0)
 

--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -1171,7 +1171,7 @@ class SMB3:
 
         treeConnect = SMB2TreeConnect()
         treeConnect['Buffer']     = path.encode('utf-16le')
-        treeConnect['PathLength'] = len(path)*2
+        treeConnect['PathLength'] = len(path.encode('utf-16le'))
 
         packet = self.SMB_PACKET()
         packet['Command'] = SMB2_TREE_CONNECT
@@ -1284,7 +1284,7 @@ class SMB3:
         smb2Create['CreateDisposition']    = creationDisposition
         smb2Create['CreateOptions']        = creationOptions
 
-        smb2Create['NameLength']           = len(fileName)*2
+        smb2Create['NameLength']           = len(fileName.encode('utf-16le'))
         if fileName != '':
             smb2Create['Buffer']           = fileName.encode('utf-16le')
         else:
@@ -1470,7 +1470,7 @@ class SMB3:
         if maxBufferSize is None:
             maxBufferSize = self._Connection['MaxReadSize']
         queryDirectory['OutputBufferLength'] = maxBufferSize
-        queryDirectory['FileNameLength']     = len(searchString)*2
+        queryDirectory['FileNameLength']     = len(searchString.encode('utf-16le'))
         queryDirectory['Buffer']             = searchString.encode('utf-16le')
 
         packet['Data'] = queryDirectory
@@ -1718,7 +1718,7 @@ class SMB3:
             renameReq = FILE_RENAME_INFORMATION_TYPE_2()
             renameReq['ReplaceIfExists'] = 1
             renameReq['RootDirectory']   = '\x00'*8
-            renameReq['FileNameLength']  = len(newPath)*2
+            renameReq['FileNameLength']  = len(newPath.encode('utf-16le'))
             renameReq['FileName']        = newPath.encode('utf-16le')
             self.setInfo(treeId, fileId, renameReq, infoType = SMB2_0_INFO_FILE, fileInfoClass = SMB2_FILE_RENAME_INFO)
         finally:
@@ -1964,7 +1964,7 @@ class SMB3:
 
         pipeWait = FSCTL_PIPE_WAIT_STRUCTURE()
         pipeWait['Timeout']          = timeout*100000
-        pipeWait['NameLength']       = len(pipename)*2
+        pipeWait['NameLength']       = len(pipename.encode('utf-16le'))
         pipeWait['TimeoutSpecified'] = 1
         pipeWait['Name']             = pipename.encode('utf-16le')
 


### PR DESCRIPTION
Fixes https://github.com/fortra/impacket/issues/1796

Before, filenames with multi-byte symbols such as emojis cut off the filename in several cases:
![Screenshot from 2024-12-05 09-41-30](https://github.com/user-attachments/assets/27bf92cf-38ff-4ba6-9bf8-89679aa70c14)

There are still some of these left in the code, but I did not know if the encoding can be assumed in those cases, whereas in the cases I fixed it was already assumed to be UTF-16LE

Here is a rough grep for the remaining cases:

```bash
$ grep -REn "len\([^)]*\)\*2"
impacket/dcerpc/v5/samr.py:2838:        samUser['Buffer'] = b'A'*(512-len(newPassword)*2) + newPassword.encode('utf-16le')
impacket/dcerpc/v5/samr.py:2841:        samUser['Buffer'] = b'A'*(512-len(newPassword)*2) + newPassword.decode(sys.getfilesystemencoding()).encode('utf-16le')
impacket/dcerpc/v5/samr.py:2843:    samUser['Length'] = len(newPassword)*2
impacket/dcerpc/v5/dcom/oaut.py:276:            self['cBytes'] = len(value)*2
impacket/dcerpc/v5/dtypes.py:384:            self['Length'] = len(value)*2
impacket/dcerpc/v5/dtypes.py:385:            self['MaximumLength'] = len(value)*2
impacket/examples/ntlmrelayx/utils/shadow_credentials.py:108:    return "B:%d:%s:%s" % (len(binaryData)*2,hexdata,owner)
impacket/smb.py:927:        ('FileNameLength','<L-FileName','len(FileName)*2'),
impacket/smb.py:956:        ('FileNameLength','<L-FileName','len(FileName)*2'),
impacket/smb.py:987:        ('FileNameLength','<L-FileName','len(FileName)*2'),
impacket/smb.py:1015:        ('FileNameLength','<L-FileName','len(FileName)*2'),
impacket/smb.py:1030:        ('FileNameLength','<L-FileName','len(FileName)*2'),
impacket/smb.py:1053:        ('FileNameLength','<L-FileName','len(FileName)*2'),
impacket/smb.py:1077:        ('FileNameLength','<B-FileName','len(FileName)*2'),
examples/karmaSMB.py:389:        ntCreateRequest['NameLength'] = len(targetFile)*2
tests/dcerpc/test_samr.py:326:        #entry.fields['MaximumLength'] = len('Administrator\x00')*2
tests/dcerpc/test_samr.py:2288:        samUser['Buffer'] = b'A'*(512-len(newPwd)*2) + newPwd.encode('utf-16le')
tests/dcerpc/test_samr.py:2289:        samUser['Length'] = len(newPwd)*2
tests/dcerpc/test_scmr.py:127:           self.assertEqual(arrayData[offset:][:len(changeDone)*2].decode('utf-16le'), changeDone)
tests/dcerpc/test_rrp.py:216:        request['cbData'] = len(self.test_value_data)*2
tests/misc/test_structure.py:81:            ('code1', '>L=len(arr1)*2+0x1000'),
tests/misc/test_structure.py:191:            ('leni', '<L=len(uno)*2'),
```