### PR TITLE
Secretsdump - Change log level for message when account does not have hash info

### DIFF
--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -1432,7 +1432,7 @@ class SAMHashes(OfflineRegistry):
             userName = V[userAccount['NameOffset']:userAccount['NameOffset']+userAccount['NameLength']].decode('utf-16le')
 
             if userAccount['NTHashLength'] == 0:
-                logging.error('SAM hashes extraction for user %s failed. The account doesn\'t have hash information.' % userName)
+                logging.debug('The account %s doesn\'t have hash information.' % userName)
                 continue
 
             encNTHash = b''


### PR DESCRIPTION
This PR fixes #1839.

Changed log level when there's no hash information in the account being parsed.
Also changed a bit the message shown