### PR TITLE
Service account username when dumping LSA secrets offline

### DIFF
--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -291,8 +291,9 @@ class DumpSecrets:
                             else:
                                 SECURITYFileName = self.__securityHive
 
-                            self.__LSASecrets = LSASecrets(SECURITYFileName, bootKey, self.__remoteOps,
-                                                       isRemote=self.__isRemote, history=self.__history)
+                            localOps = LocalOperations(self.__systemHive)
+                            self.__LSASecrets = LSASecrets(SECURITYFileName, bootKey, self.__remoteOps, localOps, self.__remoteSSMethod,
+                                                            isRemote=self.__isRemote, history=self.__history)
                             self.__LSASecrets.dumpCachedHashes()
                             if self.__outputFileName is not None:
                                 self.__LSASecrets.exportCached(self.__outputFileName)


### PR DESCRIPTION
When dumping LSA Secrets from local/offline or when utilizing -use-remoteSSMethod, the username that a service runs in the context of is not displayed and instead shows "(Unknown User)".

![image](https://github.com/user-attachments/assets/520d27ae-75f7-4aeb-9232-a0cc4641357a)

![image](https://github.com/user-attachments/assets/200786ae-e0bc-4a05-befd-cff2eabf95db)

The code [mentions this in a comment as well](https://github.com/fortra/impacket/blob/0fd9f288cd2f551573850175c12593c6ac34b689/impacket/examples/secretsdump.py#L1701-L1702), that this is not currently supported.

This PR enables displaying the username with LOCAL and -use-remoteSSMethod.

![image](https://github.com/user-attachments/assets/c11ac9bd-d729-4771-99cf-48b763b698a7)
