### PR TITLE
Add autocomplete to "cat" command in smbclient.py

### DIFF
--- a/impacket/examples/smbclient.py
+++ b/impacket/examples/smbclient.py
@@ -581,6 +581,9 @@ class MiniImpacketShell(cmd.Cmd):
             raise
         fh.close()
 
+    def complete_cat(self, text, line, begidx, endidx):
+        return self.complete_get(text, line, begidx, endidx, include=1)
+    
     def do_cat(self, filename):
         if self.tid is None:
             LOG.error("No share selected")


### PR DESCRIPTION
A small contribution to add autocomplete functionality to the `cat` command, similar to `cd`.