### PR TITLE
Fix directory traversal bug for smbComDeleteDirectory()

### DIFF
--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -1756,7 +1756,7 @@ class SMBCommands:
                 smbServer.log("Path not in current working directory", logging.ERROR)
                 errorCode = STATUS_OBJECT_PATH_SYNTAX_BAD
 
-            if os.path.exists(pathName) is not True:
+            elif not os.path.exists(pathName):
                 errorCode = STATUS_NO_SUCH_FILE
 
             else:


### PR DESCRIPTION
In the `smbComDeleteDirectory()` function of `smbserver.py`, the return value of the `isInFileJail()` function is ignored:
https://github.com/fortra/impacket/blob/impacket_0_12_0/impacket/smbserver.py#L1756)

This allows an authenticated attacker (or simply by connecting to the `IPC$` share: https://github.com/fortra/impacket/issues/1416) to bypass file jail restrictions and delete arbitrary empty directories.

The fix is to simply ensure that the return value of `isInFileJail()` is properly handled, like the other command handlers.