### PR TITLE
Include version string vor win build 26100

### DIFF
--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -163,6 +163,7 @@ WIN_VERSIONS = {
     22621:"Windows 11",
     22631:"Windows 11",
     25398:"Windows Server 2022",
+    26100:"Windows 11 / Server 2025",
 }
 
 


### PR DESCRIPTION
Quick update vor the build version table, so that the latest Win11 and Server 2025 are correctly displayed.
Before&After:
![image](https://github.com/user-attachments/assets/ad0b1e5e-f9d5-490b-96dd-de03e9b1adc7)

Should fix https://github.com/Pennyw0rth/NetExec/issues/543
