### PR TITLE
Improve file timestamp resolution

### DIFF
--- a/examples/karmaSMB.py
+++ b/examples/karmaSMB.py
@@ -415,7 +415,11 @@ class KarmaSMBServer(Thread):
             return [smb2.SMB2Error()], None, STATUS_NO_MORE_FILES 
         else:
             origName, targetFile =  connData['MS15011']['FileData']
-            (mode, ino, dev, nlink, uid, gid, size, atime, mtime, ctime) = os.stat(targetFile)
+            stat_result = os.stat(targetFile)
+            size = stat_result.st_size
+            atime = stat_result.st_atime
+            mtime = stat_result.st_mtime
+            ctime = stat_result.st_ctime
 
             infoRecord = smb.SMBFindFileIdBothDirectoryInfo( smb.SMB.FLAGS2_UNICODE )
             infoRecord['ExtFileAttributes'] = smb.ATTR_NORMAL | smb.ATTR_ARCHIVE

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -201,7 +201,7 @@ def encodeSMBString(flags, text):
 def getFileTime(t):
     t *= 10000000
     t += 116444736000000000
-    return t
+    return int(t)
 
 
 def getUnixTime(t):
@@ -337,7 +337,9 @@ def queryFsInformation(path, filename, level=None, pktFlags=smb.SMB.FLAGS2_UNICO
     fileName = normalize_path(filename)
     pathName = os.path.join(path, fileName)
     fileSize = os.path.getsize(pathName)
-    (mode, ino, dev, nlink, uid, gid, size, atime, mtime, ctime) = os.stat(pathName)
+    stat_result = os.stat(pathName)
+    mtime = stat_result.st_mtime
+    ctime = stat_result.st_ctime
 
     if level is None:
         lastWriteTime = mtime
@@ -452,7 +454,11 @@ def findFirst2(path, fileName, level, searchAttributes, pktFlags=smb.SMB.FLAGS2_
             LOG.error("Wrong level %d!" % level)
             return searchResult, searchCount, STATUS_NOT_SUPPORTED
 
-        (mode, ino, dev, nlink, uid, gid, size, atime, mtime, ctime) = os.stat(i)
+        stat_result = os.stat(i)
+        size = stat_result.st_size
+        atime = stat_result.st_atime
+        mtime = stat_result.st_mtime
+        ctime = stat_result.st_ctime
         if os.path.isdir(i):
             item['ExtFileAttributes'] = smb.ATTR_DIRECTORY
         else:
@@ -531,7 +537,11 @@ def queryPathInformation(path, filename, level):
             return None, STATUS_OBJECT_PATH_SYNTAX_BAD
 
         if os.path.exists(pathName):
-            (mode, ino, dev, nlink, uid, gid, size, atime, mtime, ctime) = os.stat(pathName)
+            stat_result = os.stat(pathName)
+            size = stat_result.st_size
+            atime = stat_result.st_atime
+            mtime = stat_result.st_mtime
+            ctime = stat_result.st_ctime
             if os.path.isdir(pathName):
                 fileAttributes = smb.ATTR_DIRECTORY
             else:
@@ -2100,7 +2110,11 @@ class SMBCommands:
                 errorCode = STATUS_SUCCESS
                 pathName = connData['OpenedFiles'][queryInformation2['Fid']]['FileName']
                 try:
-                    (mode, ino, dev, nlink, uid, gid, size, atime, mtime, ctime) = os.stat(pathName)
+                    stat_result = os.stat(pathName)
+                    size = stat_result.st_size
+                    atime = stat_result.st_atime
+                    mtime = stat_result.st_mtime
+                    ctime = stat_result.st_ctime
                     respParameters['CreateDate'] = getSMBDate(ctime)
                     respParameters['CreationTime'] = getSMBTime(ctime)
                     respParameters['LastAccessDate'] = getSMBDate(atime)


### PR DESCRIPTION
Currently, file timestamps returned by the SMBServer are obtained by unpacking the 10-tuple returned by `os.stat(some_path)`. However, accessing the timestamp fields in that manner returns an integer Unix timestamp, providing 1-second resolution.

This PR changes such occurences to use named access instead (using the field `st_{a/c/m}time` ), which returns a float value with improved resolution.

Testing with one of my projects that uses the SMB client's `listPath` method:

**Before**
```
>>> c.retrieve_run_result()
2025-01-29 09:43:25.717 | INFO     | controller:retrieve_run_result:39 - Retrieving run result
2025-01-29 09:43:26.750 | INFO     | driver:retrieve_results:47 - Found new result file test.csv created at 133826174050000000
```
**After**
```
>>> c.retrieve_run_result()
2025-01-29 09:44:53.474 | INFO     | controller:retrieve_run_result:39 - Retrieving run result
2025-01-29 09:44:54.516 | DEBUG    | driver:retrieve_results:47 - Found new result file test.csv created at 133826174934897888
```