### PR TITLE
[netview.py] Use logging.info to handle -ts switch properly

### DIFF
--- a/examples/netview.py
+++ b/examples/netview.py
@@ -327,11 +327,11 @@ class USERENUM:
                     # Are we filtering users?
                     if self.__filterUsers is not None:
                         if userName in self.__filterUsers:
-                            print("%s: user %s logged from host %s - active: %d, idle: %d" % (
+                            logging.info("%s: user %s logged from host %s - active: %d, idle: %d" % (
                             target, userName, sourceIP, session['sesi10_time'], session['sesi10_idle_time']))
                             printCRLF = True
                     else:
-                        print("%s: user %s logged from host %s - active: %d, idle: %d" % (
+                        logging.info("%s: user %s logged from host %s - active: %d, idle: %d" % (
                         target, userName, sourceIP, session['sesi10_time'], session['sesi10_idle_time']))
                         printCRLF = True
 
@@ -343,10 +343,10 @@ class USERENUM:
                 # Are we filtering users?
                 if self.__filterUsers is not None:
                     if userName in self.__filterUsers:
-                        print("%s: user %s logged off from host %s" % (target, userName, sourceIP))
+                        logging.info("%s: user %s logged off from host %s" % (target, userName, sourceIP))
                         printCRLF=True
                 else:
-                    print("%s: user %s logged off from host %s" % (target, userName, sourceIP))
+                    logging.info("%s: user %s logged off from host %s" % (target, userName, sourceIP))
                     printCRLF=True
                 
         if printCRLF is True:
@@ -409,10 +409,10 @@ class USERENUM:
                 # Are we filtering users?
                 if self.__filterUsers is not None:
                     if userName in self.__filterUsers:
-                        print("%s: user %s\\%s logged in LOCALLY" % (target,logonDomain,userName))
+                        logging.info("%s: user %s\\%s logged in LOCALLY" % (target,logonDomain,userName))
                         printCRLF=True
                 else:
-                    print("%s: user %s\\%s logged in LOCALLY" % (target,logonDomain,userName))
+                    logging.info("%s: user %s\\%s logged in LOCALLY" % (target,logonDomain,userName))
                     printCRLF=True
 
         # Let's see who logged out since last check
@@ -423,10 +423,10 @@ class USERENUM:
                 # Are we filtering users?
                 if self.__filterUsers is not None:
                     if userName in self.__filterUsers:
-                        print("%s: user %s\\%s logged off LOCALLY" % (target,logonDomain,userName))
+                        logging.info("%s: user %s\\%s logged off LOCALLY" % (target,logonDomain,userName))
                         printCRLF=True
                 else:
-                    print("%s: user %s\\%s logged off LOCALLY" % (target,logonDomain,userName))
+                    logging.info("%s: user %s\\%s logged off LOCALLY" % (target,logonDomain,userName))
                     printCRLF=True
                 
         if printCRLF is True:


### PR DESCRIPTION
In the current state, when using `netview.py`, the `-ts` switch only affects the `logging` methods. But, the information displayed regarding connections are printed using `print`, thus, the timestamp is not included in the output.

This PR fixes this behavior to ensure the `-ts` switch is correctly handeld.