### PR TITLE
Remove random print

### DIFF
--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -1819,9 +1819,6 @@ class SMB3:
                     if (e.get_error_code()) != STATUS_NO_MORE_FILES:
                         raise
                     break
-                except Exception as e:
-                    print(str(e))
-                    raise
         finally:
             if fileId is not None:
                 self.close(treeId, fileId)


### PR DESCRIPTION
When `conn.listPath` runs into an Exception that is not a `SessionError`, before raising it it is printed out. This results in random Exception messages on stdout when using impacket.

Tried to add Exception handling for the `spider_plus` module of [NetExec](https://github.com/Pennyw0rth/NetExec) and it took me a lot of time figuring out where the random Exception messages came from which were suddenly in the console. Imo this should definitely be removed, as it is just annoying for applications using impacket. If i would have to guess this is a leftover from debugging.
![image](https://github.com/user-attachments/assets/ebc3adc8-1aaa-40bf-8de5-6a18cda76230)
