### PR TITLE
Add Native SOCKS Proxy Options for Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,32 @@
 Impacket
 ========
 
+Socks Branch
+-----------------------
+
+This branch adds native socks proxy functionality for some examples.
+This is done to eliminate the need for an extra tool like
+[proxychains](https://github.com/haad/proxychains).
+
+The extra options added are found under the `SOCKS Proxy Options` category in the help menu:
+
+ * socks (enables socks)
+ * socks-address
+ * socks-port
+
+**Examples updated:**
+
+ * atexec.py
+ * dcomexec.py
+ * mssqlclient.py
+ * psexec.py
+ * secretsdump.py
+ * smbexec.py
+ * wmiexec.py
+
+Original README
+---
+
 [![Latest Version](https://img.shields.io/pypi/v/impacket.svg)](https://pypi.python.org/pypi/impacket/)
 [![Build and test Impacket](https://github.com/fortra/impacket/actions/workflows/build_and_test.yml/badge.svg)](https://github.com/fortra/impacket/actions/workflows/build_and_test.yml)
 

--- a/examples/DumpNTLMInfo.py
+++ b/examples/DumpNTLMInfo.py
@@ -644,12 +644,27 @@ if __name__ == '__main__':
     parser.add_argument('-protocol', choices=['SMB', 'RPC'], nargs='?', metavar="protocol",
                         help='Protocol to use (SMB or RPC). Default is SMB, port 135 uses RPC normally.')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
 
     options = parser.parse_args()
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     if options.port == 135:
         if not options.protocol:

--- a/examples/Get-GPPPassword.py
+++ b/examples/Get-GPPPassword.py
@@ -227,6 +227,12 @@ def parse_args():
     group.add_argument("-target-ip", action="store", metavar="ip address", help="IP Address of the target machine. If omitted it will use whatever was specified as target. This is useful when target is the NetBIOS name and you cannot resolve it")
     group.add_argument("-port", choices=["139", "445"], nargs="?", default="445", metavar="destination port", help="Destination port to connect to SMB Server")
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
@@ -283,6 +289,15 @@ if __name__ == '__main__':
     print(version.BANNER)
     args = parse_args()
     logger.init(args.ts, args.debug)
+
+    # Relay connections through a socks proxy
+    if (args.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', args.socks_address, args.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, args.socks_address, args.socks_port)
+        socket.socket = socks.socksocket
 
     if args.target.upper() == "LOCAL":
         if args.xmlfile is not None:

--- a/examples/GetADComputers.py
+++ b/examples/GetADComputers.py
@@ -209,6 +209,12 @@ if __name__ == '__main__':
                                                                               'If ommited, the domain part (FQDN) '
                                                                               'specified in the account parameter will be used')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     
 
 
@@ -220,6 +226,15 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, _, _, options.k = parse_identity(options.target, options.hashes, options.no_pass, options.aesKey, options.k)
 

--- a/examples/GetADUsers.py
+++ b/examples/GetADUsers.py
@@ -173,6 +173,12 @@ if __name__ == '__main__':
                                                                               'If ommited, the domain part (FQDN) '
                                                                               'specified in the account parameter will be used')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
@@ -181,6 +187,15 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, _, _, options.k = parse_identity(options.target, options.hashes, options.no_pass, options.aesKey, options.k)
 

--- a/examples/GetLAPSPassword.py
+++ b/examples/GetLAPSPassword.py
@@ -277,6 +277,12 @@ if __name__ == '__main__':
                                                                                 'Required when querying a Windows Server 2025'
                                                                                 'domain controller with LDAPS enforced.')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
@@ -285,6 +291,15 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, _, _, options.k = parse_identity(options.target, options.hashes, options.no_pass, options.aesKey, options.k)
 

--- a/examples/GetNPUsers.py
+++ b/examples/GetNPUsers.py
@@ -369,6 +369,12 @@ if __name__ == '__main__':
                                                                               'If ommited, the domain part (FQDN) '
                                                                               'specified in the account parameter will be used')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         print("\nThere are a few modes for using this script")
@@ -391,6 +397,15 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, _, _, options.k = parse_identity(options.target, options.hashes, options.no_pass, options.aesKey, options.k)
 

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -499,6 +499,12 @@ if __name__ == '__main__':
                                                                             'If ommited, the domain part (FQDN) '
                                                                             'specified in the account parameter will be used')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
@@ -512,6 +518,15 @@ if __name__ == '__main__':
         logging.error('You have to specify -usersfile when -no-preauth is supplied. Usersfile must contain'
                       ' a list of SPNs and/or sAMAccountNames to Kerberoast.')
         sys.exit(1)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     userDomain, username, password, _, _, options.k = parse_identity(options.target, options.hashes, options.no_pass, options.aesKey, options.k)
 

--- a/examples/addcomputer.py
+++ b/examples/addcomputer.py
@@ -419,6 +419,11 @@ if __name__ == '__main__':
                                                                       'Useful if you can\'t translate the FQDN.'
                                                                       'specified in the account parameter will be used')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
 
     if len(sys.argv)==1:
         parser.print_help()
@@ -428,6 +433,15 @@ if __name__ == '__main__':
 
     logger.init(options.ts, options.debug)
     
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
+
     domain, username, password, _, _, options.k = parse_identity(options.account, options.hashes, options.no_pass, options.aesKey, options.k)
 
     if domain == '':

--- a/examples/atexec.py
+++ b/examples/atexec.py
@@ -271,6 +271,12 @@ if __name__ == '__main__':
                                          'If omitted it will use the domain part (FQDN) specified in the target parameter')
     group.add_argument('-keytab', action="store", help='Read keys for SPN from keytab file')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
@@ -279,6 +285,15 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     if options.codec is not None:
         CODEC = options.codec

--- a/examples/changepasswd.py
+++ b/examples/changepasswd.py
@@ -819,6 +819,13 @@ def parse_args():
         ),
     )
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
+
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
@@ -831,6 +838,15 @@ if __name__ == "__main__":
 
     options = parse_args()
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     handlers = {
         "kpasswd": KPassword,

--- a/examples/dacledit.py
+++ b/examples/dacledit.py
@@ -731,6 +731,12 @@ def parse_args():
     dacl_parser.add_argument('-inheritance', action="store_true", help='Enable the inheritance in the ACE flag with CONTAINER_INHERIT_ACE and OBJECT_INHERIT_ACE. Useful when target is a Container or an OU, '
                                                                        'ACE will be inherited by objects within the container/OU (except objects with adminCount=1)')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
@@ -742,6 +748,15 @@ def main():
     print(version.BANNER)
     args = parse_args()
     logger.init(args.ts, args.debug)
+
+    # Relay connections through a socks proxy
+    if (args.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', args.socks_address, args.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, args.socks_address, args.socks_port)
+        socket.socket = socks.socksocket
 
     if args.action == 'write' and args.principal_sAMAccountName is None and args.principal_SID is None and args.principal_DN is None:
         logging.critical('-principal, -principal-sid, or -principal-dn should be specified when using -action write')

--- a/examples/dcomexec.py
+++ b/examples/dcomexec.py
@@ -589,6 +589,12 @@ if __name__ == '__main__':
     group.add_argument('-A', action="store", metavar = "authfile", help="smbclient/mount.cifs-style authentication file. "
                                                                         "See smbclient man page's -A option.")
     group.add_argument('-keytab', action="store", help='Read keys for SPN from keytab file')
+    
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
 
     if len(sys.argv)==1:
         parser.print_help()
@@ -597,6 +603,15 @@ if __name__ == '__main__':
     options = parser.parse_args()
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     if options.codec is not None:
         CODEC = options.codec

--- a/examples/describeTicket.py
+++ b/examples/describeTicket.py
@@ -699,6 +699,11 @@ def parse_args():
                                   'The information is encrypted using the AS reply key. Attack primitive known as UnPAC-the-Hash. (https://www.thehacker.recipes/ad/movement/kerberos/unpac-the-hash)'
     credential_info.add_argument('--asrep-key', action="store", metavar="HEXKEY", help='AS reply key for PAC Credentials decryption')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
 
     if len(sys.argv) == 1:
         parser.print_help()
@@ -721,6 +726,15 @@ def main():
     print(version.BANNER)
     args = parse_args()
     logger.init(args.ts, args.debug)
+
+    # Relay connections through a socks proxy
+    if (args.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', args.socks_address, args.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, args.socks_address, args.socks_port)
+        socket.socket = socks.socksocket
 
     try:
         parse_ccache(args)

--- a/examples/dpapi.py
+++ b/examples/dpapi.py
@@ -618,6 +618,12 @@ if __name__ == '__main__':
     credhist.add_argument('-password', action='store', help='User\'s password')
     credhist.add_argument('-entry', action='store', type=int, help='Entry index in CREDHIST')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     options = parser.parse_args()
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
@@ -625,6 +631,22 @@ if __name__ == '__main__':
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
+
+    if options.debug is True:
+        logging.getLogger().setLevel(logging.DEBUG)
+        # Print the Library's installation path
+        logging.debug(version.getInstallationPath())
+    else:
+        logging.getLogger().setLevel(logging.INFO)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     try:
         executer = DPAPI(options)

--- a/examples/esentutl.py
+++ b/examples/esentutl.py
@@ -81,6 +81,12 @@ def main():
     export_parser = subparsers.add_parser('export', help='dumps the catalog info for the DB')
     export_parser.add_argument('-table', action='store', required=True, help='table to dump')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
@@ -88,6 +94,15 @@ def main():
     options = parser.parse_args()
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     ese = ESENT_DB(options.databaseFile)
 

--- a/examples/exchanger.py
+++ b/examples/exchanger.py
@@ -979,6 +979,12 @@ if __name__ == '__main__':
         help='Output format for binary objects')
     dnt_lookup.add_argument('-output-file', action='store', help='Output filename')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
@@ -986,6 +992,15 @@ if __name__ == '__main__':
     options = parser.parse_args()
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, remoteName = parse_target(options.target)
 

--- a/examples/findDelegation.py
+++ b/examples/findDelegation.py
@@ -256,6 +256,12 @@ if __name__ == '__main__':
                                                                               'If ommited, the domain part (FQDN) '
                                                                               'specified in the account parameter will be used')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
@@ -264,6 +270,15 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     userDomain, username, password, _, _, options.k = parse_identity(options.target, options.hashes, options.no_pass, options.aesKey, options.k)
 

--- a/examples/getArch.py
+++ b/examples/getArch.py
@@ -90,6 +90,12 @@ if __name__ == '__main__':
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
@@ -101,6 +107,15 @@ if __name__ == '__main__':
     if options.target is None and options.targets is None:
         logging.error('You have to specify a target!')
         sys.exit(1)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     try:
         getArch = TARGETARCH(options)

--- a/examples/getPac.py
+++ b/examples/getPac.py
@@ -305,12 +305,28 @@ if __name__ == '__main__':
     group = parser.add_argument_group('authentication')
 
     group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
+
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
 
     options = parser.parse_args()
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, _, _, _ = parse_identity(options.credentials, options.hashes)
 

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -887,6 +887,12 @@ if __name__ == '__main__':
     group.add_argument('-dc-ip', action='store', metavar="ip address", help='IP Address of the domain controller. If '
                                                                             'omitted it use the domain part (FQDN) specified in the target parameter')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv) == 1:
         parser.print_help()
         print("\nExamples: ")
@@ -917,6 +923,15 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, _, _, options.k = parse_identity(options.identity, options.hashes, options.no_pass, options.aesKey, options.k)
 

--- a/examples/getTGT.py
+++ b/examples/getTGT.py
@@ -91,6 +91,12 @@ if __name__ == '__main__':
     group.add_argument('-service', action='store', metavar="SPN", help='Request a Service Ticket directly through an AS-REQ')
     group.add_argument('-principalType', nargs="?", type=lambda value: constants.PrincipalNameType[value.upper()] if value.upper() in constants.PrincipalNameType.__members__ else None,  action='store', default=constants.PrincipalNameType.NT_PRINCIPAL, help='PrincipalType of the token, can be one of  NT_UNKNOWN, NT_PRINCIPAL, NT_SRV_INST, NT_SRV_HST, NT_SRV_XHST, NT_UID, NT_SMTP_NAME, NT_ENTERPRISE, NT_WELLKNOWN, NT_SRV_HST_DOMAIN, NT_MS_PRINCIPAL, NT_MS_PRINCIPAL_AND_ID, NT_ENT_PRINCIPAL_AND_ID; default is NT_PRINCIPAL, ')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         print("\nExamples: ")
@@ -101,6 +107,15 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, _, _, options.k = parse_identity(options.identity, options.hashes, options.no_pass, options.aesKey, options.k)
     

--- a/examples/goldenPac.py
+++ b/examples/goldenPac.py
@@ -1105,10 +1105,25 @@ if __name__ == '__main__':
         print("\tpython goldenPac.py -c xxx.exe domain.net/normaluser:mypwd@domain-host param1 param2 paramn\n")
         sys.exit(1)
  
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     options = parser.parse_args()
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, address = parse_target(options.target)
 

--- a/examples/karmaSMB.py
+++ b/examples/karmaSMB.py
@@ -608,6 +608,11 @@ if __name__ == '__main__':
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
 
     if len(sys.argv)==1:
         parser.print_help()
@@ -621,6 +626,15 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     s = KarmaSMBServer(options.smb2support)
     s.setDefaultFile(os.path.normpath(options.fileName))

--- a/examples/keylistattack.py
+++ b/examples/keylistattack.py
@@ -177,6 +177,12 @@ if __name__ == '__main__':
                        help='IP Address of the target machine. If omitted it will use whatever was specified as target. '
                             'This is useful when target is the NetBIOS name and you cannot resolve it')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
@@ -185,6 +191,15 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     if options.rodcNo is None:
         logging.error("You must specify the RODC number (krbtgt_XXXXX)")

--- a/examples/kintercept.py
+++ b/examples/kintercept.py
@@ -271,6 +271,13 @@ def parse_args():
     parser.add_argument('--reply-handler', default='', metavar='HANDLER:ARG', help='Example: tgs-rep-user:user')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     return vars(parser.parse_args())
 
 
@@ -281,6 +288,15 @@ if __name__ == '__main__':
     args = parse_args()
 
     logger.init(args.ts, args.debug)
+
+    # Relay connections through a socks proxy
+    if (args.socks):
+        print('Relaying connections through SOCKS proxy (%s:%s)', args.socks_address, args.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, args.socks_address, args.socks_port)
+        socket.socket = socks.socksocket
 
     req_factory = rep_factory = InterceptConnFactory()
     if args['request_handler']:

--- a/examples/lookupsid.py
+++ b/examples/lookupsid.py
@@ -178,6 +178,13 @@ if __name__ == '__main__':
                             '(KRB5CCNAME) based on target parameters. If valid credentials '
                             'cannot be found, it will use the ones specified in the command '
                             'line')
+    
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
@@ -186,6 +193,15 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, remoteName = parse_target(options.target)
 

--- a/examples/machine_role.py
+++ b/examples/machine_role.py
@@ -147,6 +147,12 @@ if __name__ == '__main__':
     group.add_argument('-aesKey', action='store', metavar='hex key', help='AES key to use for Kerberos Authentication '
                                                                           '(128 or 256 bits)')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
@@ -155,6 +161,15 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, remoteName = parse_target(options.target)
 

--- a/examples/mimikatz.py
+++ b/examples/mimikatz.py
@@ -142,6 +142,12 @@ def main():
                        help='IP Address of the target machine. If omitted it will use whatever was specified as target. '
                             'This is useful when target is the NetBIOS name and you cannot resolve it')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
@@ -149,6 +155,15 @@ def main():
     options = parser.parse_args()
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, address = parse_target(options.target)
 

--- a/examples/mqtt_check.py
+++ b/examples/mqtt_check.py
@@ -65,6 +65,12 @@ if __name__ == '__main__':
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     try:
         options = parser.parse_args()
     except Exception as e:
@@ -73,6 +79,15 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, address = parse_target(options.target)
 

--- a/examples/mssqlclient.py
+++ b/examples/mssqlclient.py
@@ -74,6 +74,11 @@ if __name__ == '__main__':
                             'This is useful when target is the NetBIOS name and you cannot resolve it')
     group.add_argument('-port', action='store', default='1433', help='target MSSQL port (default 1433)')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
 
     if len(sys.argv)==1:
         parser.print_help()
@@ -82,6 +87,15 @@ if __name__ == '__main__':
     options = parser.parse_args()
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, remoteName = parse_target(options.target)
 

--- a/examples/mssqlinstance.py
+++ b/examples/mssqlinstance.py
@@ -39,6 +39,12 @@ if __name__ == '__main__':
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
@@ -46,6 +52,15 @@ if __name__ == '__main__':
     options = parser.parse_args()
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        print('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     ms_sql = tds.MSSQL(options.host)
     instances = ms_sql.getInstances(int(options.timeout))

--- a/examples/net.py
+++ b/examples/net.py
@@ -542,6 +542,12 @@ if __name__ == '__main__':
     group.add_argument('-port', choices=['139', '445'], nargs='?', default='445', metavar="destination port",
                        help='Destination port to connect to SMB Server')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
@@ -557,6 +563,15 @@ if __name__ == '__main__':
         sys.exit(1)
 
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, address = parse_target(options.target)
 

--- a/examples/netview.py
+++ b/examples/netview.py
@@ -472,6 +472,12 @@ if __name__ == '__main__':
     group.add_argument('-dc-ip', action='store',metavar = "ip address",  help='IP Address of the domain controller. If '
                        'ommited it use the domain part (FQDN) specified in the target parameter')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
@@ -480,6 +486,15 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, _, _, options.k = parse_identity(options.identity, options.hashes, options.no_pass, options.aesKey, options.k)
 

--- a/examples/ntfs-read.py
+++ b/examples/ntfs-read.py
@@ -1439,12 +1439,27 @@ def main():
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
     options = parser.parse_args()
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     shell = MiniShell(options.volume)
     if options.extract is not None:

--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -459,6 +459,12 @@ if __name__ == '__main__':
     sccmdpoptions.add_argument('--sccm-dp-extensions', action='store', required=False, help='A custom list of extensions to look for when downloading files from the SCCM Distribution Point. If not provided, defaults to .ps1,.bat,.xml,.txt,.pfx')
     sccmdpoptions.add_argument('--sccm-dp-files', action='store', required=False, help='The path to a file containing a list of specific URLs to download from the Distribution Point, instead of downloading by extensions. Providing this argument will skip file indexing')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     try:
        options = parser.parse_args()
     except Exception as e:
@@ -486,6 +492,15 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     # Let's register the protocol clients we have
     # ToDo: Do this better somehow

--- a/examples/owneredit.py
+++ b/examples/owneredit.py
@@ -240,6 +240,12 @@ def parse_args():
     dacl_parser = parser.add_argument_group("dacl editor")
     dacl_parser.add_argument('-action', choices=['read', 'write'], nargs='?', default='read', help='Action to operate on the owner attribute')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
@@ -251,6 +257,15 @@ def main():
     print(version.BANNER)
     args = parse_args()
     logger.init(args.ts, args.debug)
+
+    # Relay connections through a socks proxy
+    if (args.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', args.socks_address, args.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, args.socks_address, args.socks_port)
+        socket.socket = socks.socksocket
 
     if args.action == 'write' and args.new_owner_sAMAccountName is None and args.new_owner_SID is None and args.new_owner_DN is None:
         logging.critical('-owner, -owner-sid, or -owner-dn should be specified when using -action write')

--- a/examples/ping.py
+++ b/examples/ping.py
@@ -29,6 +29,7 @@
 #   ImpactDecoder
 #
 
+import argparse
 import select
 import socket
 import time
@@ -36,12 +37,29 @@ import sys
 
 from impacket import ImpactDecoder, ImpactPacket
 
-if len(sys.argv) < 3:
-    print("Use: %s <src ip> <dst ip>" % sys.argv[0])
-    sys.exit(1)
+parser = argparse.ArgumentParser(add_help=True, description='Simple ICMP ping.')
+parser.add_argument('src', help='Source IP')
+parser.add_argument('dst', help='Destination IP')
 
-src = sys.argv[1]
-dst = sys.argv[2]
+group = parser.add_argument_group('SOCKS Proxy Options')
+group.add_argument('-socks', action='store_true', default=False,
+                    help='Use a SOCKS proxy for the connection')
+group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
+options = parser.parse_args()
+
+# Relay connections through a socks proxy
+if (options.socks):
+    print('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+    import socket
+    import socks
+
+    socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+    socket.socket = socks.socksocket
+
+src = options.src
+dst = options.dst
 
 # Create a new IP packet and set its source and destination addresses.
 

--- a/examples/ping6.py
+++ b/examples/ping6.py
@@ -28,6 +28,7 @@
 #   ImpactDecoder
 #
 
+import argparse
 import select
 import socket
 import time
@@ -37,12 +38,29 @@ from impacket import ImpactDecoder, IP6, ICMP6, version
 
 print(version.BANNER)
 
-if len(sys.argv) < 3:
-    print("Use: %s <src ip> <dst ip>" % sys.argv[0])
-    sys.exit(1)
+parser = argparse.ArgumentParser(add_help=True, description='Simple ICMP6 ping.')
+parser.add_argument('src', help='Source IP')
+parser.add_argument('dst', help='Destination IP')
 
-src = sys.argv[1]
-dst = sys.argv[2]
+group = parser.add_argument_group('SOCKS Proxy Options')
+group.add_argument('-socks', action='store_true', default=False,
+                    help='Use a SOCKS proxy for the connection')
+group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
+options = parser.parse_args()
+
+# Relay connections through a socks proxy
+if (options.socks):
+    print('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+    import socket
+    import socks
+
+    socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+    socket.socket = socks.socksocket
+
+src = options.src
+dst = options.dst
 
 # Create a new IP packet and set its source and destination addresses.
 

--- a/examples/psexec.py
+++ b/examples/psexec.py
@@ -633,6 +633,12 @@ if __name__ == '__main__':
                                                                                 ' used to trigger the payload')
     group.add_argument('-remote-binary-name', action='store', metavar="remote_binary_name", default = None, help='This will '
                                                             'be the name of the executable uploaded on the target')
+    
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
 
     if len(sys.argv)==1:
         parser.print_help()
@@ -642,6 +648,15 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     if options.codec is not None:
         CODEC = options.codec

--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -1259,6 +1259,12 @@ if __name__ == '__main__':
     group.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key to use for Kerberos Authentication '
                                                                             '(128 or 256 bits)')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         print("\nExamples: ")
@@ -1284,6 +1290,15 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, _, _, options.k = parse_identity(options.target, options.hashes, options.no_pass, options.aesKey, options.k)
 

--- a/examples/rbcd.py
+++ b/examples/rbcd.py
@@ -290,6 +290,12 @@ def parse_args():
                             'the identity parameter')
     group.add_argument('-dc-host', action='store', metavar="hostname", help='Hostname of the domain controller or KDC (Key Distribution Center) for Kerberos. If omitted, -dc-ip will be used')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
@@ -301,6 +307,15 @@ def main():
     print(version.BANNER)
     args = parse_args()
     logger.init(args.ts, args.debug)
+
+    # Relay connections through a socks proxy
+    if (args.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', args.socks_address, args.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, args.socks_address, args.socks_port)
+        socket.socket = socks.socksocket
 
     if args.action == 'write' and args.delegate_from is None:
         logging.critical('`-delegate-from` should be specified when using `-action write` !')

--- a/examples/rdp_check.py
+++ b/examples/rdp_check.py
@@ -562,9 +562,24 @@ if __name__ == '__main__':
         parser.print_help()
         sys.exit(1)
  
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     options = parser.parse_args()
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, address = parse_target(options.target)
 

--- a/examples/reg.py
+++ b/examples/reg.py
@@ -672,6 +672,12 @@ if __name__ == '__main__':
     group.add_argument('-port', choices=['139', '445'], nargs='?', default='445', metavar="destination port",
                        help='Destination port to connect to SMB Server')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
@@ -679,6 +685,15 @@ if __name__ == '__main__':
     options = parser.parse_args()
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, remoteName = parse_target(options.target)
 

--- a/examples/registry-read.py
+++ b/examples/registry-read.py
@@ -148,6 +148,12 @@ def main():
     walk_parser = subparsers.add_parser('walk', help='walks the registry from the name node down')
     walk_parser.add_argument('-name', action='store', required=True, help='registry class name to start walking down from')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
@@ -155,6 +161,15 @@ def main():
     options = parser.parse_args()
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        print('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     reg = winregistry.get_registry_parser(options.hive)
 

--- a/examples/rpcdump.py
+++ b/examples/rpcdump.py
@@ -185,6 +185,13 @@ if __name__ == '__main__':
     group = parser.add_argument_group('authentication')
 
     group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
+
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
@@ -192,6 +199,15 @@ if __name__ == '__main__':
     options = parser.parse_args()
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, remoteName = parse_target(options.target)
 

--- a/examples/rpcmap.py
+++ b/examples/rpcmap.py
@@ -316,6 +316,12 @@ if __name__ == '__main__':
     group.add_argument('-hashes-transport', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
     group.add_argument('-no-pass', action="store_true", help='don\'t ask for passwords')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
@@ -323,6 +329,15 @@ if __name__ == '__main__':
     options = parser.parse_args()
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     rpcdomain, rpcuser, rpcpass, _, _, _ = parse_identity(options.auth_rpc, options.hashes_rpc, options.no_pass, getpass_msg='Password for MSRPC communication:')
     transportdomain, transportuser, transportpass, _, _, _ = parse_identity(options.auth_transport, options.hashes_transport, options.no_pass, getpass_msg='Password for RPC transport (SMB or HTTP):')

--- a/examples/sambaPipe.py
+++ b/examples/sambaPipe.py
@@ -232,6 +232,12 @@ if __name__ == '__main__':
     group.add_argument('-port', choices=['139', '445'], nargs='?', default='445', metavar="destination port",
                        help='Destination port to connect to SMB Server')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
@@ -239,6 +245,15 @@ if __name__ == '__main__':
     options = parser.parse_args()
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, address = parse_target(options.target)
 

--- a/examples/samrdump.py
+++ b/examples/samrdump.py
@@ -230,6 +230,12 @@ if __name__ == '__main__':
     group.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key to use for Kerberos Authentication '
                                                                             '(128 or 256 bits)')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
@@ -238,6 +244,15 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, remoteName = parse_target(options.target)
 

--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -484,6 +484,12 @@ if __name__ == '__main__':
                        help='IP Address of the target machine. If omitted it will use whatever was specified as target. '
                             'This is useful when target is the NetBIOS name and you cannot resolve it')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
@@ -492,6 +498,15 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, remoteName = parse_target(options.target)
 

--- a/examples/services.py
+++ b/examples/services.py
@@ -323,6 +323,12 @@ if __name__ == '__main__':
     group.add_argument('-port', choices=['139', '445'], nargs='?', default='445', metavar="destination port",
                        help='Destination port to connect to SMB Server')
  
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
@@ -330,6 +336,15 @@ if __name__ == '__main__':
     options = parser.parse_args()
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, remoteName = parse_target(options.target)
 

--- a/examples/smbclient.py
+++ b/examples/smbclient.py
@@ -68,6 +68,12 @@ def main():
     group.add_argument('-port', choices=['139', '445'], nargs='?', default='445', metavar="destination port",
                        help='Destination port to connect to SMB Server')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
@@ -75,6 +81,15 @@ def main():
     options = parser.parse_args()
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, address = parse_target(options.target)
 

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -359,6 +359,11 @@ if __name__ == '__main__':
                                                                             '(128 or 256 bits)')
     group.add_argument('-keytab', action="store", help='Read keys for SPN from keytab file')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
 
     if len(sys.argv)==1:
         parser.print_help()
@@ -368,6 +373,15 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     if options.codec is not None:
         CODEC = options.codec

--- a/examples/smbserver.py
+++ b/examples/smbserver.py
@@ -58,6 +58,12 @@ if __name__ == '__main__':
     parser.add_argument('-smb2support', action='store_true', default=False, help='SMB2 Support (experimental!)')
     parser.add_argument('-outputfile', action='store', default=None, help='Output file to log smbserver output messages')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
@@ -69,6 +75,15 @@ if __name__ == '__main__':
        sys.exit(1)
 
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     if options.comment is None:
         comment = ''

--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -1036,6 +1036,12 @@ if __name__ == '__main__':
                                                              ' for querying the ST and extracting the PAC, which will be'
                                                              ' included in the new ticket')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         print("\nExamples: ")
@@ -1072,6 +1078,15 @@ if __name__ == '__main__':
     if options.request is True and options.user is None:
         logging.error('-request parameter needs -user to be specified')
         sys.exit(1)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     if options.request is True and options.hashes is None and options.password is None:
         from getpass import getpass

--- a/examples/tstool.py
+++ b/examples/tstool.py
@@ -708,6 +708,12 @@ if __name__ == '__main__':
     group.add_argument('-port', choices=['139', '445'], nargs='?', default='445', metavar="destination port",
                        help='Destination port to connect to SMB Server')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
@@ -721,6 +727,15 @@ if __name__ == '__main__':
         parser.print_help()
         LOG.error('Too few arguments...')
         sys.exit(1)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, remoteName = parse_target(options.target)
 

--- a/examples/wmiexec.py
+++ b/examples/wmiexec.py
@@ -399,6 +399,12 @@ if __name__ == '__main__':
                                                                       "See smbclient man page's -A option.")
     group.add_argument('-keytab', action="store", help='Read keys for SPN from keytab file')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
@@ -407,6 +413,15 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     if options.codec is not None:
         CODEC = options.codec

--- a/examples/wmipersist.py
+++ b/examples/wmipersist.py
@@ -204,6 +204,12 @@ if __name__ == '__main__':
     group.add_argument('-dc-ip', action='store',metavar = "ip address",  help='IP Address of the domain controller. If '
                        'ommited it use the domain part (FQDN) specified in the target parameter')
  
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
@@ -224,6 +230,15 @@ if __name__ == '__main__':
         if (options.filter is None and options.timer is None) or  (options.filter is not None and options.timer is not None):
             logging.error("You have to either specify -filter or -timer (and not both)")
             sys.exit(1)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, address = parse_target(options.target)
 

--- a/examples/wmiquery.py
+++ b/examples/wmiquery.py
@@ -155,6 +155,12 @@ if __name__ == '__main__':
                             '(RPC_C_AUTHN_LEVEL_PKT_PRIVACY). For example CIM path "root/MSCluster" would require '
                             'privacy level by default)')
 
+    group = parser.add_argument_group('SOCKS Proxy Options')
+    group.add_argument('-socks', action='store_true', default=False,
+                        help='Use a SOCKS proxy for the connection')
+    group.add_argument('-socks-address', default='127.0.0.1', help='SOCKS5 server address')
+    group.add_argument('-socks-port', default=1080, type=int, help='SOCKS5 server port')
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
@@ -170,6 +176,15 @@ if __name__ == '__main__':
         except Exception:
             logging.error("Wrong COMVERSION format, use dot separated integers e.g. \"5.7\"")
             sys.exit(1)
+
+    # Relay connections through a socks proxy
+    if (options.socks):
+        logging.info('Relaying connections through SOCKS proxy (%s:%s)', options.socks_address, options.socks_port)
+        import socket
+        import socks
+
+        socks.set_default_proxy(socks.SOCKS5, options.socks_address, options.socks_port)
+        socket.socket = socks.socksocket
 
     domain, username, password, address = parse_target(options.target)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6
 ldapdomaindump>=0.9.0
 flask>=1.0
 pyreadline3;sys_platform == 'win32'
+pysocks


### PR DESCRIPTION
This branch adds native socks proxy functionality for some examples.
This is done to eliminate the need for an extra tool like [proxychains](https://github.com/haad/proxychains).

The extra options added are found under the `SOCKS Proxy Options` category in the help menu:

 * socks (enables socks)
 * socks-address
 * socks-port

**Examples updated:**

 * atexec.py
 * dcomexec.py
 * mssqlclient.py
 * psexec.py
 * secretsdump.py
 * smbexec.py
 * wmiexec.py

The above is copied from the updated README file for this branch, if merged, the README will need to be updated.
This also adds `pysocks` to the requirements for the repository.