### PR TITLE
Add the Option to Dump Ntlm Hashes in Ntlmrelayx

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,31 @@
 Impacket
 ========
 
+Ntlm Relay Hash Dump Branch
+----------------
+
+This branch adds the option to dump ntlm hashes to the console
+during runtime in ntlmrelayx using `-dh` or `--dump-hashes`.
+
+**Examples Updated:**
+
+ * ntlmrelayx.py
+ * dnstool.py
+ * printerbug.py
+ * krbrelayx.py
+
+**Modified Libraries:**
+
+ * smbserver.py
+ * httprelayserver.py
+ * rawrelayserver.py
+ * smbrelayserver.py
+ * wcfrelayserver.py
+ * config.py
+
+Original README
+---
+
 [![Latest Version](https://img.shields.io/pypi/v/impacket.svg)](https://pypi.python.org/pypi/impacket/)
 [![Build and test Impacket](https://github.com/fortra/impacket/actions/workflows/build_and_test.yml/badge.svg)](https://github.com/fortra/impacket/actions/workflows/build_and_test.yml)
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,6 @@
 Impacket
 ========
 
-Ntlm Relay Hash Dump Branch
-----------------
-
-This branch adds the option to dump ntlm hashes to the console
-during runtime in ntlmrelayx using `-dh` or `--dump-hashes`.
-
-**Examples Updated:**
-
- * ntlmrelayx.py
- * dnstool.py
- * printerbug.py
- * krbrelayx.py
-
-**Modified Libraries:**
-
- * smbserver.py
- * httprelayserver.py
- * rawrelayserver.py
- * smbrelayserver.py
- * wcfrelayserver.py
- * config.py
-
-Original README
----
-
 [![Latest Version](https://img.shields.io/pypi/v/impacket.svg)](https://pypi.python.org/pypi/impacket/)
 [![Build and test Impacket](https://github.com/fortra/impacket/actions/workflows/build_and_test.yml/badge.svg)](https://github.com/fortra/impacket/actions/workflows/build_and_test.yml)
 

--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -192,6 +192,7 @@ def start_servers(options, threads):
         c.setAttacks(PROTOCOL_ATTACKS)
         c.setLootdir(options.lootdir)
         c.setOutputFile(options.output_file)
+        c.setdumpHashes(options.dump_hashes)
         c.setLDAPOptions(options.no_dump, options.no_da, options.no_acl, options.no_validate_privs, options.escalate_user, options.add_computer, options.delegate_access, options.dump_laps, options.dump_gmsa, options.dump_adcs, options.sid, options.add_dns_record)
         c.setRPCOptions(options.rpc_mode, options.rpc_use_smb, options.auth_smb, options.hashes_smb, options.rpc_smb_port)
         c.setMSSQLOptions(options.query)
@@ -306,6 +307,7 @@ if __name__ == '__main__':
                     'directory in which gathered loot such as SAM dumps will be stored (default: current directory).')
     parser.add_argument('-of','--output-file', action='store',help='base output filename for encrypted hashes. Suffixes '
                                                                    'will be added for ntlm and ntlmv2')
+    parser.add_argument('-dh','--dump-hashes', action='store_true', default=False, help='show encrypted hashes in the console')
     parser.add_argument('-codec', action='store', help='Sets encoding used (codec) from the target\'s output (default '
                                                        '"%s"). If errors are detected, run chcp.com at the target, '
                                                        'map the result with '

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -480,6 +480,10 @@ class HTTPRelayServer(Thread):
                                                         authenticateMessage['lanman'], authenticateMessage['ntlm'])
                     self.client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
 
+                    if self.server.config.dumpHashes is True:
+                        LOG.info("Dumping hash for %s \n%s", self.authUser, ntlm_hash_data['hash_string'])
+                        LOG.info("Done dumping hash")
+
                     if self.server.config.outputFile is not None:
                         writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
                                               self.server.config.outputFile)

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -481,8 +481,7 @@ class HTTPRelayServer(Thread):
                     self.client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
 
                     if self.server.config.dumpHashes is True:
-                        LOG.info("Dumping hash for %s \n%s", self.authUser, ntlm_hash_data['hash_string'])
-                        LOG.info("Done dumping hash")
+                        LOG.info(ntlm_hash_data['hash_string'])
 
                     if self.server.config.outputFile is not None:
                         writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],

--- a/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
@@ -131,8 +131,7 @@ class RAWRelayServer(Thread):
                     self.client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
 
                     if self.server.config.dumpHashes is True:
-                        LOG.info("Dumping hash for %s \n%s", self.authUser, ntlm_hash_data['hash_string'])
-                        LOG.info("Done dumping hash")
+                        LOG.info(ntlm_hash_data['hash_string'])
 
                     if self.server.config.outputFile is not None:
                         writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],

--- a/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
@@ -130,6 +130,10 @@ class RAWRelayServer(Thread):
                                                         authenticateMessage['lanman'], authenticateMessage['ntlm'])
                     self.client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
 
+                    if self.server.config.dumpHashes is True:
+                        LOG.info("Dumping hash for %s \n%s", self.authUser, ntlm_hash_data['hash_string'])
+                        LOG.info("Done dumping hash")
+
                     if self.server.config.outputFile is not None:
                         writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
                                               self.server.config.outputFile)

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -379,8 +379,7 @@ class SMBRelayServer(Thread):
                 client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
 
                 if self.server.getDumpHashes():
-                    LOG.info("Dumping hash for %s \n%s", self.authUser, ntlm_hash_data['hash_string'])
-                    LOG.info("Done dumping hash")
+                    LOG.info(ntlm_hash_data['hash_string'])
 
                 if self.server.getJTRdumpPath() != '':
                     writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
@@ -677,8 +676,7 @@ class SMBRelayServer(Thread):
                     client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
 
                     if self.server.getDumpHashes():
-                        LOG.info("Dumping hash for %s \n%s", self.authUser, ntlm_hash_data['hash_string'])
-                        LOG.info("Done dumping hash")
+                        LOG.info(ntlm_hash_data['hash_string'])
 
                     if self.server.getJTRdumpPath() != '':
                         writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
@@ -756,8 +754,7 @@ class SMBRelayServer(Thread):
                 client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
 
                 if self.server.getDumpHashes():
-                    LOG.info("Dumping hash for %s \n%s", self.authUser, ntlm_hash_data['hash_string'])
-                    LOG.info("Done dumping hash")
+                    LOG.info(ntlm_hash_data['hash_string'])
 
                 if self.server.getJTRdumpPath() != '':
                     writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -91,6 +91,11 @@ class SMBRelayServer(Thread):
         if self.config.outputFile is not None:
             smbConfig.set('global','jtr_dump_path',self.config.outputFile)
 
+        if self.config.dumpHashes is True:
+            smbConfig.set("global", "dump_hashes", "True")
+        else:
+            smbConfig.set("global", "dump_hashes", "False")
+        
         if self.config.SMBServerChallenge is not None:
             smbConfig.set('global', 'challenge', self.config.SMBServerChallenge)
 
@@ -372,6 +377,10 @@ class SMBRelayServer(Thread):
                                                     authenticateMessage['domain_name'], authenticateMessage['lanman'],
                                                     authenticateMessage['ntlm'])
                 client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
+
+                if self.server.getDumpHashes():
+                    LOG.info("Dumping hash for %s \n%s", self.authUser, ntlm_hash_data['hash_string'])
+                    LOG.info("Done dumping hash")
 
                 if self.server.getJTRdumpPath() != '':
                     writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
@@ -667,6 +676,10 @@ class SMBRelayServer(Thread):
                                                         authenticateMessage['lanman'], authenticateMessage['ntlm'])
                     client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
 
+                    if self.server.getDumpHashes():
+                        LOG.info("Dumping hash for %s \n%s", self.authUser, ntlm_hash_data['hash_string'])
+                        LOG.info("Done dumping hash")
+
                     if self.server.getJTRdumpPath() != '':
                         writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
                                               self.server.getJTRdumpPath())
@@ -741,6 +754,10 @@ class SMBRelayServer(Thread):
                 ntlm_hash_data = outputToJohnFormat('', sessionSetupData['Account'], sessionSetupData['PrimaryDomain'],
                                                     sessionSetupData['AnsiPwd'], sessionSetupData['UnicodePwd'])
                 client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
+
+                if self.server.getDumpHashes():
+                    LOG.info("Dumping hash for %s \n%s", self.authUser, ntlm_hash_data['hash_string'])
+                    LOG.info("Done dumping hash")
 
                 if self.server.getJTRdumpPath() != '':
                     writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],

--- a/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
@@ -270,6 +270,10 @@ class WCFRelayServer(Thread):
                                                 authenticateMessage['lanman'], authenticateMessage['ntlm'])
             self.client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
 
+            if self.server.config.dumpHashes is True:
+                LOG.info("Dumping hash for %s \n%s", self.authUser, ntlm_hash_data['hash_string'])
+                LOG.info("Done dumping hash")
+
             if self.server.config.outputFile is not None:
                 writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
                                       self.server.config.outputFile)

--- a/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
@@ -271,8 +271,7 @@ class WCFRelayServer(Thread):
             self.client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
 
             if self.server.config.dumpHashes is True:
-                LOG.info("Dumping hash for %s \n%s", self.authUser, ntlm_hash_data['hash_string'])
-                LOG.info("Done dumping hash")
+                LOG.info(ntlm_hash_data['hash_string'])
 
             if self.server.config.outputFile is not None:
                 writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -38,6 +38,7 @@ class NTLMRelayxConfig:
         self.mode = None
         self.redirecthost = None
         self.outputFile = None
+        self.dumpHashes = False
         self.attacks = None
         self.lootdir = None
         self.randomtargets = False
@@ -132,6 +133,9 @@ class NTLMRelayxConfig:
 
     def setOutputFile(self, outputFile):
         self.outputFile = outputFile
+
+    def setdumpHashes(self, dumpHashes):
+        self.dumpHashes = dumpHashes
 
     def setTargets(self, target):
         self.target = target

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -4358,6 +4358,9 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
     def getJTRdumpPath(self):
         return self.__jtr_dump_path
 
+    def getDumpHashes(self):
+        return self.__dump_hashes
+
     def getAuthCallback(self):
         return self.auth_callback
 
@@ -4674,11 +4677,15 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
         if self.__serverConfig.has_option("global", "jtr_dump_path"):
             self.__jtr_dump_path = self.__serverConfig.get("global", "jtr_dump_path")
 
+        if self.__serverConfig.has_option("global", "dump_hashes"):
+            self.__dump_hashes = self.__serverConfig.getboolean("global", "dump_hashes")
+        else:
+            self.__dump_hashes = False
+
         if self.__serverConfig.has_option("global", "SMB2Support"):
             self.__SMB2Support = self.__serverConfig.getboolean("global", "SMB2Support")
         else:
             self.__SMB2Support = False
-
 
         if self.__serverConfig.has_option("global", "anonymous_logon"):
             self.__anonymousLogon = self.__serverConfig.getboolean("global", "anonymous_logon")


### PR DESCRIPTION
This branch adds the option to dump ntlm hashes to the console during runtime in ntlmrelayx using `-dh` or `--dump-hashes`.

**Examples Updated:**

 * ntlmrelayx.py
 * dnstool.py
 * printerbug.py
 * krbrelayx.py

**Modified Libraries:**

 * smbserver.py
 * httprelayserver.py
 * rawrelayserver.py
 * smbrelayserver.py
 * wcfrelayserver.py
 * config.py

The above is copied from the updated README file for this branch, if merged, the README will need to be updated.