### PR TITLE
Add Kerberos Request Options to Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,37 @@
 Impacket
 ========
 
+Kerberos Options Branch
+-----------------------
+
+This branch exposes functionality to change the options on Kerberos requests.
+Originally taken from [Orpheus](https://github.com/trustedsec/orpheus).
+The functionality has been added to the underlying functions, and has been propogated up to the command line examples that use it. There has also been an example added that can generate the option codes that are used by the examples (follows the same format as Orpheus).
+
+**Examples updated:**
+
+ * GetUserSPNs.py
+ * addcomputer.py
+ * dacledit.py
+ * getPac.py
+ * getST.py
+ * getTGT.py
+ * goldenPac.py
+ * owneredit.py
+ * raiseChild.py
+ * rbcd.py
+ * ticketer.py
+
+**Added:**
+
+ * GenerateKerberosOptions.py
+
+**Modified Libraries:**
+
+ * kerberosv5.py
+
+---
+
 [![Latest Version](https://img.shields.io/pypi/v/impacket.svg)](https://pypi.python.org/pypi/impacket/)
 [![Build and test Impacket](https://github.com/fortra/impacket/actions/workflows/build_and_test.yml/badge.svg)](https://github.com/fortra/impacket/actions/workflows/build_and_test.yml)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Kerberos Options Branch
 
 This branch exposes functionality to change the options on Kerberos requests.
 Originally taken from [Orpheus](https://github.com/trustedsec/orpheus).
-The functionality has been added to the underlying functions, and has been propogated up to the command line examples that use it. There has also been an example added that can generate the option codes that are used by the examples (follows the same format as Orpheus).
+The functionality has been added to the underlying functions, and has been propagated up to the command line examples that use it. There has also been an example added that can generate the option codes that are used by the examples (follows the same format as Orpheus).
 
 **Examples updated:**
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The functionality has been added to the underlying functions, and has been propo
 
  * kerberosv5.py
 
+Original README
 ---
 
 [![Latest Version](https://img.shields.io/pypi/v/impacket.svg)](https://pypi.python.org/pypi/impacket/)

--- a/examples/GenerateKerberosOptions.py
+++ b/examples/GenerateKerberosOptions.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright Fortra, LLC and its affiliated companies
+#
+# All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+# Description:
+#   This module generates a hex value that can be passed to other examples (GetUserSPNs, etc.) to set Kerberos options.
+#   Both parsing of command line arguments in the form of a comma separated integer list, and an interactive menu are provided.
+#   The logic in here simply sets bits in a 32-bit integer based on the value of the option, then converts that to hex.
+#   This is based off of the code written by @ben0xa for Orpheus: https://github.com/trustedsec/orpheus.
+#
+# Author:
+#   p0rtL (@p0rtl6)
+#
+
+import sys
+from impacket.krb5 import constants
+
+selectedOptions = {enum.value: False for enum in constants.KDCOptions}
+
+
+def print_help():
+    print("Generate Kerberos Options Script")
+    print("")
+    print("Run without any arguments to open the interactive menu")
+    print("OR")
+    print("Provide a comma separated list of integers between 0-31 (e.g. 1,8,15,27)")
+    print("")
+
+
+def print_options():
+    print("")
+
+    output = list()
+
+    for option in sorted(constants.KDCOptions, key=lambda variant: variant.value):
+        output.append(
+            "({}) {} [{}]".format(
+                option.value,
+                option.name,
+                "On" if selectedOptions[option.value] else "Off",
+            )
+        )
+
+    output.append("")  # Pad to even number of elements
+
+    halfPoint = len(output) // 2
+    firstHalf = output[:halfPoint]
+    secondHalf = output[halfPoint:]
+
+    for left, right in zip(firstHalf, secondHalf):
+        print("{:30s}{}".format(left, right))
+
+    print("")
+
+
+def print_hex(simple=False):
+    binOptions = "".join("1" if selectedOptions.get(i, False) else "0" for i in range(32))
+    hexOptions = hex(int(binOptions, 2))
+
+    if simple:
+        print(hexOptions)
+    else:
+        print("Generated Hex [{}]".format(hexOptions))
+        print("")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        strippedArg = sys.argv[1].lstrip("-")
+        if strippedArg == "help" or strippedArg == "h":
+            print_help()
+            sys.exit()
+
+    # Take command line list of options
+    if len(sys.argv) > 1:
+        try:
+            argInputString = sys.argv[1]
+            argInputList = [int(number) for number in argInputString.split(",")]
+            for optionNumber in argInputList:
+                if optionNumber < 0 or optionNumber > 31:
+                    raise ValueError("Number is not between 0-31")
+
+                selectedOptions[optionNumber] = True
+
+            print_hex(simple=True)
+            sys.exit()
+        except Exception as _:
+            print("[ERROR] Cannot parse argument list, make sure you are providing a comma seperated list of integers between 0-31.")
+
+    # If options are not provided on the command line, prompt for them in a menu
+    while True:
+        print_options()
+        print_hex()
+
+        userInput = input("Enter a number to toggle the corresponding option (or 'exit' to exit): ")
+        if userInput.lower() == "exit":
+            break
+
+        try:
+            userInputInteger = int(userInput)
+            if userInputInteger < 0 or userInputInteger > 31:
+                raise ValueError("Number is not between 0-31")
+
+            selectedOptions[userInputInteger] = not selectedOptions[userInputInteger]
+        except:
+            print("[ERROR] Please enter a valid number from 0-31")

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -47,7 +47,7 @@ from impacket.examples.utils import parse_credentials
 from impacket.krb5 import constants
 from impacket.krb5.asn1 import TGS_REP, AS_REP
 from impacket.krb5.ccache import CCache
-from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGS
+from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGS, parseKerberosOptions
 from impacket.krb5.types import Principal
 from impacket.ldap import ldap, ldapasn1
 from impacket.smbconnection import SMBConnection, SessionError
@@ -92,8 +92,8 @@ class GetUserSPNs:
         self.__saveTGS = cmdLineOptions.save
         self.__requestUser = cmdLineOptions.request_user
         self.__stealth = cmdLineOptions.stealth
-        self.__tgsOptions = self.parseKerberosOptions(cmdLineOptions.tgs_options)
-        self.__tgtOptions = self.parseKerberosOptions(cmdLineOptions.tgt_options)
+        self.__tgsOptions = parseKerberosOptions(cmdLineOptions.tgs_options)
+        self.__tgtOptions = parseKerberosOptions(cmdLineOptions.tgt_options)
         self.__encryption = cmdLineOptions.encryption
         if cmdLineOptions.hashes is not None:
             self.__lmhash, self.__nthash = cmdLineOptions.hashes.split(':')
@@ -135,23 +135,6 @@ class GetUserSPNs:
         else:
             s.logoff()
         return "%s.%s" % (s.getServerName(), s.getServerDNSDomainName())
-
-    @staticmethod
-    def parseKerberosOptions(hex):
-        # convert hex to binary
-        scale = 16
-        kdcbin = bin(int(hex, scale))[2:].zfill(32)
-
-        # enable options based on binary (left to right)
-        opt = list()
-        idx = -1
-        for b in kdcbin:
-            idx += 1
-            if int(b) == 1:
-                print("Adding " + constants.KDCOptions(idx).name)
-                opt.append(constants.KDCOptions(idx).value)
-        
-        return opt
 
     @staticmethod
     def getUnixTime(t):
@@ -558,7 +541,7 @@ if __name__ == '__main__':
                                                                             'specified in the account parameter will be used')
 
     kerberos_options = parser.add_argument_group('kerberos options')
-    
+
     kerberos_options.add_argument('-tgs-options', action="store", metavar="hex value", default=None, help='The hexadecimal value to send to the Kerberos Ticket Granting Service (TGS).')
     kerberos_options.add_argument('-tgt-options', action="store", metavar="hex value", default=None, help='The hexadecimal value to send to the Kerberos Ticket Granting Ticket (TGT).')
     kerberos_options.add_argument('-encryption', action="store", metavar="18 or 23", default="23", help='Set encryption to AES256 (18) or RC4 (23).')

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -92,6 +92,9 @@ class GetUserSPNs:
         self.__saveTGS = cmdLineOptions.save
         self.__requestUser = cmdLineOptions.request_user
         self.__stealth = cmdLineOptions.stealth
+        self.__tgsOptions = self.parseKerberosOptions(cmdLineOptions.tgs_options)
+        self.__tgtOptions = self.parseKerberosOptions(cmdLineOptions.tgt_options)
+        self.__encryption = cmdLineOptions.encryption
         if cmdLineOptions.hashes is not None:
             self.__lmhash, self.__nthash = cmdLineOptions.hashes.split(':')
 
@@ -134,6 +137,23 @@ class GetUserSPNs:
         return "%s.%s" % (s.getServerName(), s.getServerDNSDomainName())
 
     @staticmethod
+    def parseKerberosOptions(hex):
+        # convert hex to binary
+        scale = 16
+        kdcbin = bin(int(hex, scale))[2:].zfill(32)
+
+        # enable options based on binary (left to right)
+        opt = list()
+        idx = -1
+        for b in kdcbin:
+            idx += 1
+            if int(b) == 1:
+                print("Adding " + constants.KDCOptions(idx).name)
+                opt.append(constants.KDCOptions(idx).value)
+        
+        return opt
+
+    @staticmethod
     def getUnixTime(t):
         t -= 116444736000000000
         t /= 10000000
@@ -156,19 +176,25 @@ class GetUserSPNs:
                 tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, '', self.__domain,
                                                                         compute_lmhash(self.__password),
                                                                         compute_nthash(self.__password), self.__aesKey,
-                                                                        kdcHost=self.__kdcIP)
+                                                                        kdcHost=self.__kdcIP,
+                                                                        encType=self.__encryption,
+                                                                        options=self.__tgtOptions)
             except Exception as e:
                 logging.debug('TGT: %s' % str(e))
                 tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, self.__password, self.__domain,
                                                                         unhexlify(self.__lmhash),
                                                                         unhexlify(self.__nthash), self.__aesKey,
-                                                                        kdcHost=self.__kdcIP)
+                                                                        kdcHost=self.__kdcIP,
+                                                                        encType=self.__encryption,
+                                                                        options=self.__tgtOptions)
 
         else:
             tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, self.__password, self.__domain,
                                                                     unhexlify(self.__lmhash),
                                                                     unhexlify(self.__nthash), self.__aesKey,
-                                                                    kdcHost=self.__kdcIP)
+                                                                    kdcHost=self.__kdcIP,
+                                                                        encType=self.__encryption,
+                                                                        options=self.__tgtOptions)
         TGT = {}
         TGT['KDC_REP'] = tgt
         TGT['cipher'] = cipher
@@ -412,7 +438,7 @@ class GetUserSPNs:
                         tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(principalName, self.__domain,
                                                                                 self.__kdcIP,
                                                                                 TGT['KDC_REP'], TGT['cipher'],
-                                                                                TGT['sessionKey'])
+                                                                                TGT['sessionKey'], options=self.__tgsOptions, encType=self.__encryption)
                         self.outputTGS(tgs, oldSessionKey, sessionKey, sAMAccountName,
                                        self.__targetDomain + "/" + sAMAccountName, fd)
                     except Exception as e:
@@ -450,7 +476,9 @@ class GetUserSPNs:
                                                                             aesKey=self.__aesKey,
                                                                             kdcHost=self.__kdcHost,
                                                                             serverName=username,
-                                                                            kerberoast_no_preauth=True)
+                                                                            kerberoast_no_preauth=True,
+                                                                            encType=self.__encryption,
+                                                                            options=self.__tgtOptions)
                     self.outputTGS(tgt, oldSessionKey, sessionKey, username, username, fd)
                 except Exception as e:
                     logging.debug("Exception:", exc_info=True)
@@ -471,7 +499,7 @@ class GetUserSPNs:
                     tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(principalName, self.__domain,
                                                                             self.__kdcIP,
                                                                             TGT['KDC_REP'], TGT['cipher'],
-                                                                            TGT['sessionKey'])
+                                                                            TGT['sessionKey'], options=self.__tgsOptions, encType=self.__encryption)
                     self.outputTGS(tgs, oldSessionKey, sessionKey, username, username, fd)
                 except Exception as e:
                     logging.debug("Exception:", exc_info=True)
@@ -528,6 +556,12 @@ if __name__ == '__main__':
     group.add_argument('-dc-host', action='store', metavar='hostname', help='Hostname of the domain controller to use. '
                                                                             'If ommited, the domain part (FQDN) '
                                                                             'specified in the account parameter will be used')
+
+    kerberos_options = parser.add_argument_group('kerberos options')
+    
+    kerberos_options.add_argument('-tgs-options', action="store", metavar="hex value", default=None, help='The hexadecimal value to send to the Kerberos Ticket Granting Service (TGS).')
+    kerberos_options.add_argument('-tgt-options', action="store", metavar="hex value", default=None, help='The hexadecimal value to send to the Kerberos Ticket Granting Ticket (TGT).')
+    kerberos_options.add_argument('-encryption', action="store", metavar="18 or 23", default="23", help='Set encryption to AES256 (18) or RC4 (23).')
 
     if len(sys.argv) == 1:
         parser.print_help()

--- a/examples/goldenPac.py
+++ b/examples/goldenPac.py
@@ -433,7 +433,7 @@ class MS14_068:
         )
 
     def __init__(self, target, targetIp=None, username='', password='', domain='', hashes=None, command='',
-                 copyFile=None, writeTGT=None, kdcHost=None):
+                 copyFile=None, writeTGT=None, kdcHost=None, encType=None, tgtOptions=None, tgsOptions=None):
         self.__username = username
         self.__password = password
         self.__domain = domain
@@ -450,6 +450,9 @@ class MS14_068:
         self.__forestSid = None
         self.__domainControllers = list()
         self.__kdcHost = kdcHost
+        self.__encryption = encType
+        self.__tgtOptions = parseKerberosOptions(tgtOptions)
+        self.__tgsOptions = parseKerberosOptions(tgsOptions)
 
         if hashes is not None:
             self.__lmhash, self.__nthash = hashes.split(':')
@@ -936,7 +939,7 @@ class MS14_068:
                 try:
                     tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, self.__password, self.__domain,
                                                                             self.__lmhash, self.__nthash, None,
-                                                                            self.__kdcHost, requestPAC=False)
+                                                                            self.__kdcHost, requestPAC=False, encType=self.__encryption, options=self.__tgtOptions)
                 except KerberosError as e:
                     if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
                         # We might face this if the target does not support AES (most probably
@@ -991,7 +994,7 @@ class MS14_068:
                 try:
                     tgsCIFS, cipher, oldSessionKeyCIFS, sessionKeyCIFS = getKerberosTGS(serverName, domain,
                                                                                         self.__kdcHost, tgs, cipher,
-                                                                                        sessionKey)
+                                                                                        sessionKey, encType=self.__encryption, options=self.__tgsOptions)
                 except KerberosError as e:
                     if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
                         # We might face this if the target does not support AES (most probably
@@ -1060,7 +1063,7 @@ if __name__ == '__main__':
     from impacket.dcerpc.v5 import transport
     from impacket.krb5.types import Principal, Ticket, KerberosTime
     from impacket.krb5 import constants
-    from impacket.krb5.kerberosv5 import sendReceive, getKerberosTGT, getKerberosTGS, KerberosError
+    from impacket.krb5.kerberosv5 import sendReceive, getKerberosTGT, getKerberosTGS, KerberosError, parseKerberosOptions
     from impacket.krb5.asn1 import AS_REP, TGS_REQ, AP_REQ, TGS_REP, Authenticator, EncASRepPart, AuthorizationData, \
         AD_IF_RELEVANT, seq_set, seq_set_iter, KERB_PA_PAC_REQUEST, \
         EncTGSRepPart, ETYPE_INFO2_ENTRY
@@ -1097,6 +1100,13 @@ if __name__ == '__main__':
     group = parser.add_argument_group('authentication')
 
     group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
+
+    kerberos_options = parser.add_argument_group('kerberos options')
+
+    kerberos_options.add_argument('-tgs-options', action="store", metavar="hex value", default=None, help='The hexadecimal value to send to the Kerberos Ticket Granting Service (TGS).')
+    kerberos_options.add_argument('-tgt-options', action="store", metavar="hex value", default=None, help='The hexadecimal value to send to the Kerberos Ticket Granting Ticket (TGT).')
+    kerberos_options.add_argument('-encryption', action="store", metavar="18 or 23", default="23", help='Set encryption to AES256 (18) or RC4 (23).')
+
     if len(sys.argv)==1:
         parser.print_help()
         print("\nExamples: ")
@@ -1137,7 +1147,7 @@ if __name__ == '__main__':
         commands = 'cmd.exe'
 
     dumper = MS14_068(address, options.target_ip, username, password, domain, options.hashes, commands, options.c,
-                      options.w, options.dc_ip)
+                      options.w, options.dc_ip, options.encryption, options.tgt_options, options.tgs_options)
 
     try:
         dumper.exploit()

--- a/examples/owneredit.py
+++ b/examples/owneredit.py
@@ -256,6 +256,12 @@ def parse_args():
 
     dacl_parser = parser.add_argument_group("dacl editor")
     dacl_parser.add_argument('-action', choices=['read', 'write'], nargs='?', default='read', help='Action to operate on the owner attribute')
+    
+    kerberos_options = parser.add_argument_group('kerberos options')
+
+    kerberos_options.add_argument('-tgs-options', action="store", metavar="hex value", default=None, help='The hexadecimal value to send to the Kerberos Ticket Granting Service (TGS).')
+    kerberos_options.add_argument('-tgt-options', action="store", metavar="hex value", default=None, help='The hexadecimal value to send to the Kerberos Ticket Granting Ticket (TGT).')
+    kerberos_options.add_argument('-encryption', action="store", metavar="18 or 23", default="23", help='Set encryption to AES256 (18) or RC4 (23).')
 
     if len(sys.argv) == 1:
         parser.print_help()
@@ -315,7 +321,7 @@ def get_machine_name(args, domain):
     return s.getServerName()
 
 
-def ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='', nthash='', aesKey='', kdcHost=None, TGT=None, TGS=None, useCache=True):
+def ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='', nthash='', aesKey='', kdcHost=None, TGT=None, TGS=None, useCache=True, encType=None, tgtOptions=None, tgsOptions=None):
     from pyasn1.codec.ber import encoder, decoder
     from pyasn1.type.univ import noValue
     """
@@ -347,7 +353,7 @@ def ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='
     # Importing down here so pyasn1 is not required if kerberos is not used.
     from impacket.krb5.ccache import CCache
     from impacket.krb5.asn1 import AP_REQ, Authenticator, TGS_REP, seq_set
-    from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGS
+    from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGS, parseKerberosOptions
     from impacket.krb5 import constants
     from impacket.krb5.types import Principal, KerberosTime, Ticket
     import datetime
@@ -364,7 +370,7 @@ def ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='
     if TGT is None:
         if TGS is None:
             tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, password, domain, lmhash, nthash,
-                                                                    aesKey, kdcHost)
+                                                                    aesKey, kdcHost, encType=encType, options=parseKerberosOptions(tgtOptions))
     else:
         tgt = TGT['KDC_REP']
         cipher = TGT['cipher']
@@ -373,7 +379,7 @@ def ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='
     if TGS is None:
         serverName = Principal(target, type=constants.PrincipalNameType.NT_SRV_INST.value)
         tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(serverName, domain, kdcHost, tgt, cipher,
-                                                                sessionKey)
+                                                                sessionKey, encType=encType, options=parseKerberosOptions(tgsOptions))
     else:
         tgs = TGS['KDC_REP']
         cipher = TGS['cipher']
@@ -458,7 +464,7 @@ def init_ldap_connection(target, tls_version, args, domain, username, password, 
     if args.k:
         ldap_session = ldap3.Connection(ldap_server)
         ldap_session.bind()
-        ldap3_kerberos_login(ldap_session, target, username, password, domain, lmhash, nthash, args.aesKey, kdcHost=args.dc_ip)
+        ldap3_kerberos_login(ldap_session, target, username, password, domain, lmhash, nthash, args.aesKey, kdcHost=args.dc_ip, encType=args.encryption, tgtOptions=args.tgt_options, tgsOptions=args.tgs_options)
     elif args.hashes is not None:
         ldap_session = ldap3.Connection(ldap_server, user=user, password=lmhash + ":" + nthash, authentication=ldap3.NTLM, auto_bind=True)
     else:

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -94,6 +94,25 @@ def sendReceive(data, host, kdcHost, port=88):
 
     return r
 
+def parseKerberosOptions(hex=None):
+        if hex is None:
+            return None
+        
+        # convert hex to binary
+        scale = 16
+        kdcbin = bin(int(hex, scale))[2:].zfill(32)
+
+        # enable options based on binary (left to right)
+        options = list()
+        idx = -1
+        for b in kdcbin:
+            idx += 1
+            if int(b) == 1:
+                print("Adding " + constants.KDCOptions(idx).name)
+                options.append(constants.KDCOptions(idx).value)
+        
+        return options
+
 def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcHost=None, requestPAC=True, serverName=None, kerberoast_no_preauth=False, encType=None, options=None):
 
     # Convert to binary form, just in case we're receiving strings


### PR DESCRIPTION
This branch exposes functionality to change the options on Kerberos requests. Originally taken from [Orpheus](https://github.com/trustedsec/orpheus). The functionality has been added to the underlying functions, and has been propagated up to the command line examples that use it. There has also been an example added that can generate the option codes that are used by the examples (follows the same format as Orpheus).

**Examples updated:**

 * GetUserSPNs.py
 * addcomputer.py
 * dacledit.py
 * getPac.py
 * getST.py
 * getTGT.py
 * goldenPac.py
 * owneredit.py
 * raiseChild.py
 * rbcd.py
 * ticketer.py

**Added:**

 * GenerateKerberosOptions.py

**Modified Libraries:**

 * kerberosv5.py

The above is copied from the updated README file for this branch, if merged, the README will need to be updated.