### PR TITLE
Standardize examples requirements and common functionality

### DIFF
--- a/examples/DumpNTLMInfo.py
+++ b/examples/DumpNTLMInfo.py
@@ -631,11 +631,11 @@ class DumpNtlm:
 if __name__ == '__main__':
 
     print(version.BANNER)
-    logger.init()
 
     parser = argparse.ArgumentParser(add_help = True, description = "Do ntlm authentication and parse information.")
     parser.add_argument('target', action='store', help='<targetName or address>')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-target-ip', action='store', metavar="ip address",
                        help='IP Address of the target machine. If omitted it will use whatever was specified as target. '
                             'This is useful when target is the NetBIOS name and you cannot resolve it')
@@ -649,6 +649,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     options = parser.parse_args()
+    logger.init(options.ts, options.debug)
 
     if options.port == 135:
         if not options.protocol:
@@ -659,12 +660,6 @@ if __name__ == '__main__':
     elif not options.protocol:
         options.protocol = 'SMB'
         logging.info("Defaulting to SMB protocol.")
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
 
     try:
         if options.target_ip is not None:

--- a/examples/Get-GPPPassword.py
+++ b/examples/Get-GPPPassword.py
@@ -257,19 +257,6 @@ def parse_target(args):
 
     return domain, username, password, address, lmhash, nthash
 
-
-def init_logger(args):
-    # Init the example's logger theme and debug level
-    logger.init(args.ts)
-    if args.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
-        logging.getLogger("impacket.smbserver").setLevel(logging.ERROR)
-
-
 def init_smb_session(args, domain, username, password, address, lmhash, nthash):
     smbClient = SMBConnection(address, args.target_ip, sess_port=int(args.port))
     dialect = smbClient.getDialect()
@@ -295,7 +282,7 @@ def init_smb_session(args, domain, username, password, address, lmhash, nthash):
 if __name__ == '__main__':
     print(version.BANNER)
     args = parse_args()
-    init_logger(args)
+    logger.init(args.ts, args.debug)
 
     if args.target.upper() == "LOCAL":
         if args.xmlfile is not None:

--- a/examples/GetADComputers.py
+++ b/examples/GetADComputers.py
@@ -283,13 +283,6 @@ if __name__ == '__main__':
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
 
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
-
     domain, username, password = parse_credentials(options.target)
 
     if domain == '':

--- a/examples/GetADComputers.py
+++ b/examples/GetADComputers.py
@@ -281,7 +281,7 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # Init the example's logger theme
-    logger.init(options.ts)
+    logger.init(options.ts, options.debug)
 
     if options.debug is True:
         logging.getLogger().setLevel(logging.DEBUG)

--- a/examples/GetADComputers.py
+++ b/examples/GetADComputers.py
@@ -38,7 +38,7 @@ from datetime import datetime
 from impacket import version
 from impacket.dcerpc.v5.samr import UF_ACCOUNTDISABLE
 from impacket.examples import logger
-from impacket.examples.utils import parse_credentials
+from impacket.examples.utils import parse_identity
 from impacket.ldap import ldap, ldapasn1
 from impacket.smbconnection import SMBConnection, SessionError
 
@@ -283,18 +283,11 @@ if __name__ == '__main__':
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
 
-    domain, username, password = parse_credentials(options.target)
+    domain, username, password, _, _, options.k = parse_identity(options.target, options.hashes, options.no_pass, options.aesKey, options.k)
 
     if domain == '':
         logging.critical('Domain should be specified!')
         sys.exit(1)
-
-    if password == '' and username != '' and options.hashes is None and options.no_pass is False and options.aesKey is None:
-        from getpass import getpass
-        password = getpass("Password:")
-
-    if options.aesKey is not None:
-        options.k = True
 
     try:
         executer = GetADComputers(username, password, domain, options)

--- a/examples/GetADUsers.py
+++ b/examples/GetADUsers.py
@@ -242,13 +242,6 @@ if __name__ == '__main__':
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
 
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
-
     domain, username, password = parse_credentials(options.target)
 
     if domain == '':

--- a/examples/GetADUsers.py
+++ b/examples/GetADUsers.py
@@ -240,7 +240,7 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # Init the example's logger theme
-    logger.init(options.ts)
+    logger.init(options.ts, options.debug)
 
     if options.debug is True:
         logging.getLogger().setLevel(logging.DEBUG)

--- a/examples/GetADUsers.py
+++ b/examples/GetADUsers.py
@@ -35,7 +35,7 @@ from datetime import datetime
 from impacket import version
 from impacket.dcerpc.v5.samr import UF_ACCOUNTDISABLE
 from impacket.examples import logger
-from impacket.examples.utils import parse_credentials
+from impacket.examples.utils import parse_identity
 from impacket.ldap import ldap, ldapasn1
 from impacket.smbconnection import SMBConnection, SessionError
 
@@ -242,18 +242,11 @@ if __name__ == '__main__':
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
 
-    domain, username, password = parse_credentials(options.target)
+    domain, username, password, _, _, options.k = parse_identity(options.target, options.hashes, options.no_pass, options.aesKey, options.k)
 
     if domain == '':
         logging.critical('Domain should be specified!')
         sys.exit(1)
-
-    if password == '' and username != '' and options.hashes is None and options.no_pass is False and options.aesKey is None:
-        from getpass import getpass
-        password = getpass("Password:")
-
-    if options.aesKey is not None:
-        options.k = True
 
     try:
         executer = GetADUsers(username, password, domain, options)

--- a/examples/GetLAPSPassword.py
+++ b/examples/GetLAPSPassword.py
@@ -339,13 +339,6 @@ if __name__ == '__main__':
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
 
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
-
     domain, username, password = parse_credentials(options.target)
 
     if domain == '':

--- a/examples/GetLAPSPassword.py
+++ b/examples/GetLAPSPassword.py
@@ -337,7 +337,7 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # Init the example's logger theme
-    logger.init(options.ts)
+    logger.init(options.ts, options.debug)
 
     if options.debug is True:
         logging.getLogger().setLevel(logging.DEBUG)

--- a/examples/GetLAPSPassword.py
+++ b/examples/GetLAPSPassword.py
@@ -32,7 +32,7 @@ from impacket.dcerpc.v5.gkdi import MSRPC_UUID_GKDI, GkdiGetKey, GroupKeyEnvelop
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_LEVEL_PKT_INTEGRITY, RPC_C_AUTHN_LEVEL_PKT_PRIVACY
 from impacket.dpapi_ng import EncryptedPasswordBlob, KeyIdentifier, compute_kek, create_sd, decrypt_plaintext, unwrap_cek
 from impacket.examples import logger
-from impacket.examples.utils import parse_credentials
+from impacket.examples.utils import parse_identity
 from impacket.ldap import ldap, ldapasn1
 from impacket.smbconnection import SMBConnection, SessionError
 from pyasn1.codec.der import decoder
@@ -339,18 +339,11 @@ if __name__ == '__main__':
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
 
-    domain, username, password = parse_credentials(options.target)
+    domain, username, password, _, _, options.k = parse_identity(options.target, options.hashes, options.no_pass, options.aesKey, options.k)
 
     if domain == '':
         logging.critical('Domain should be specified!')
         sys.exit(1)
-
-    if password == '' and username != '' and options.hashes is None and options.no_pass is False and options.aesKey is None:
-        from getpass import getpass
-        password = getpass("Password:")
-
-    if options.aesKey is not None:
-        options.k = True
 
     try:
         executer = GetLAPSPassword(username, password, domain, options)

--- a/examples/GetNPUsers.py
+++ b/examples/GetNPUsers.py
@@ -41,7 +41,7 @@ from pyasn1.type.univ import noValue
 from impacket import version
 from impacket.dcerpc.v5.samr import UF_ACCOUNTDISABLE, UF_DONT_REQUIRE_PREAUTH
 from impacket.examples import logger
-from impacket.examples.utils import parse_credentials
+from impacket.examples.utils import parse_identity
 from impacket.krb5 import constants
 from impacket.krb5.asn1 import AS_REQ, KERB_PA_PAC_REQUEST, KRB_ERROR, AS_REP, seq_set, seq_set_iter
 from impacket.krb5.kerberosv5 import sendReceive, KerberosError
@@ -440,18 +440,11 @@ if __name__ == '__main__':
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
 
-    domain, username, password = parse_credentials(options.target)
+    domain, username, password, _, _, options.k = parse_identity(options.target, options.hashes, options.no_pass, options.aesKey, options.k)
 
     if domain == '':
         logging.critical('Domain should be specified!')
         sys.exit(1)
-
-    if password == '' and username != '' and options.hashes is None and options.no_pass is False and options.aesKey is None:
-        from getpass import getpass
-        password = getpass("Password:")
-
-    if options.aesKey is not None:
-        options.k = True
 
     if options.k is False and options.no_pass is True and username == '' and options.usersfile is None:
         logging.critical('If the -no-pass option was specified, but Kerberos (-k) is not used, then a username or the -usersfile option should be specified!')

--- a/examples/GetNPUsers.py
+++ b/examples/GetNPUsers.py
@@ -438,7 +438,7 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # Init the example's logger theme
-    logger.init(options.ts)
+    logger.init(options.ts, options.debug)
 
     if options.debug is True:
         logging.getLogger().setLevel(logging.DEBUG)

--- a/examples/GetNPUsers.py
+++ b/examples/GetNPUsers.py
@@ -440,13 +440,6 @@ if __name__ == '__main__':
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
 
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
-
     domain, username, password = parse_credentials(options.target)
 
     if domain == '':

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -536,7 +536,7 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # Init the example's logger theme
-    logger.init(options.ts)
+    logger.init(options.ts, options.debug)
 
     if options.no_preauth and options.usersfile is None:
         logging.error('You have to specify -usersfile when -no-preauth is supplied. Usersfile must contain'

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -43,7 +43,7 @@ from impacket import version
 from impacket.dcerpc.v5.samr import UF_ACCOUNTDISABLE, UF_TRUSTED_FOR_DELEGATION, \
     UF_TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION
 from impacket.examples import logger
-from impacket.examples.utils import parse_credentials
+from impacket.examples.utils import parse_identity
 from impacket.krb5 import constants
 from impacket.krb5.asn1 import TGS_REP, AS_REP
 from impacket.krb5.ccache import CCache
@@ -543,7 +543,7 @@ if __name__ == '__main__':
                       ' a list of SPNs and/or sAMAccountNames to Kerberoast.')
         sys.exit(1)
 
-    userDomain, username, password = parse_credentials(options.target)
+    userDomain, username, password, _, _, options.k = parse_identity(options.identity, options.hashes, options.no_pass, options.aesKey, options.k)
 
     if userDomain == '':
         logging.critical('userDomain should be specified!')
@@ -553,14 +553,6 @@ if __name__ == '__main__':
         targetDomain = options.target_domain
     else:
         targetDomain = userDomain
-
-    if password == '' and username != '' and options.hashes is None and options.no_pass is False and options.aesKey is None:
-        from getpass import getpass
-
-        password = getpass("Password:")
-
-    if options.aesKey is not None:
-        options.k = True
 
     if options.save is True or options.outputfile is not None:
         options.request = True

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -543,13 +543,6 @@ if __name__ == '__main__':
                       ' a list of SPNs and/or sAMAccountNames to Kerberoast.')
         sys.exit(1)
 
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
-
     userDomain, username, password = parse_credentials(options.target)
 
     if userDomain == '':

--- a/examples/addcomputer.py
+++ b/examples/addcomputer.py
@@ -35,7 +35,7 @@ from impacket.examples.utils import parse_identity
 from impacket.dcerpc.v5 import samr, epm, transport
 from impacket.spnego import SPNEGO_NegTokenInit, TypesMech
 
-from impacket.examples.utils import _ldap3_kerberos_login
+from impacket.examples.utils import ldap3_kerberos_login
 
 import ldap3
 import argparse
@@ -157,7 +157,7 @@ class ADDCOMPUTER:
                 ldapServer = ldap3.Server(connectTo, use_ssl=True, port=self.__port, get_info=ldap3.ALL, tls=tls)
                 if self.__doKerberos:
                     ldapConn = ldap3.Connection(ldapServer)
-                    _ldap3_kerberos_login(ldapConn, connectTo, self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
+                    ldap3_kerberos_login(ldapConn, connectTo, self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
                                                  self.__aesKey, kdcHost=self.__kdcHost)
                 elif self.__hashes is not None:
                     ldapConn = ldap3.Connection(ldapServer, user=user, password=self.__hashes, authentication=ldap3.NTLM)
@@ -172,7 +172,7 @@ class ADDCOMPUTER:
                 ldapServer = ldap3.Server(connectTo, use_ssl=True, port=self.__port, get_info=ldap3.ALL, tls=tls)
                 if self.__doKerberos:
                     ldapConn = ldap3.Connection(ldapServer)
-                    _ldap3_kerberos_login(ldapConn, connectTo, self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
+                    ldap3_kerberos_login(ldapConn, connectTo, self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
                                                  self.__aesKey, kdcHost=self.__kdcHost)
                 elif self.__hashes is not None:
                     ldapConn = ldap3.Connection(ldapServer, user=user, password=self.__hashes, authentication=ldap3.NTLM)

--- a/examples/addcomputer.py
+++ b/examples/addcomputer.py
@@ -35,6 +35,8 @@ from impacket.examples.utils import parse_credentials
 from impacket.dcerpc.v5 import samr, epm, transport
 from impacket.spnego import SPNEGO_NegTokenInit, TypesMech
 
+from impacket.examples.utils import _ldap3_kerberos_login
+
 import ldap3
 import argparse
 import logging
@@ -155,7 +157,7 @@ class ADDCOMPUTER:
                 ldapServer = ldap3.Server(connectTo, use_ssl=True, port=self.__port, get_info=ldap3.ALL, tls=tls)
                 if self.__doKerberos:
                     ldapConn = ldap3.Connection(ldapServer)
-                    self.LDAP3KerberosLogin(ldapConn, self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
+                    _ldap3_kerberos_login(ldapConn, connectTo, self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
                                                  self.__aesKey, kdcHost=self.__kdcHost)
                 elif self.__hashes is not None:
                     ldapConn = ldap3.Connection(ldapServer, user=user, password=self.__hashes, authentication=ldap3.NTLM)
@@ -170,7 +172,7 @@ class ADDCOMPUTER:
                 ldapServer = ldap3.Server(connectTo, use_ssl=True, port=self.__port, get_info=ldap3.ALL, tls=tls)
                 if self.__doKerberos:
                     ldapConn = ldap3.Connection(ldapServer)
-                    self.LDAP3KerberosLogin(ldapConn, self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
+                    _ldap3_kerberos_login(ldapConn, connectTo, self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
                                                  self.__aesKey, kdcHost=self.__kdcHost)
                 elif self.__hashes is not None:
                     ldapConn = ldap3.Connection(ldapServer, user=user, password=self.__hashes, authentication=ldap3.NTLM)
@@ -264,135 +266,6 @@ class ADDCOMPUTER:
     def LDAPGetComputer(self, connection, computerName):
         connection.search(self.__baseDN, '(sAMAccountName=%s)' % computerName)
         return connection.entries[0]
-
-    def LDAP3KerberosLogin(self, connection, user, password, domain='', lmhash='', nthash='', aesKey='', kdcHost=None, TGT=None,
-                      TGS=None, useCache=True):
-        from pyasn1.codec.ber import encoder, decoder
-        from pyasn1.type.univ import noValue
-        """
-        logins into the target system explicitly using Kerberos. Hashes are used if RC4_HMAC is supported.
-
-        :param string user: username
-        :param string password: password for the user
-        :param string domain: domain where the account is valid for (required)
-        :param string lmhash: LMHASH used to authenticate using hashes (password is not used)
-        :param string nthash: NTHASH used to authenticate using hashes (password is not used)
-        :param string aesKey: aes256-cts-hmac-sha1-96 or aes128-cts-hmac-sha1-96 used for Kerberos authentication
-        :param string kdcHost: hostname or IP Address for the KDC. If None, the domain will be used (it needs to resolve tho)
-        :param struct TGT: If there's a TGT available, send the structure here and it will be used
-        :param struct TGS: same for TGS. See smb3.py for the format
-        :param bool useCache: whether or not we should use the ccache for credentials lookup. If TGT or TGS are specified this is False
-
-        :return: True, raises an Exception if error.
-        """
-
-        if lmhash != '' or nthash != '':
-            if len(lmhash) % 2:
-                lmhash = '0' + lmhash
-            if len(nthash) % 2:
-                nthash = '0' + nthash
-            try:  # just in case they were converted already
-                lmhash = unhexlify(lmhash)
-                nthash = unhexlify(nthash)
-            except TypeError:
-                pass
-
-        # Importing down here so pyasn1 is not required if kerberos is not used.
-        from impacket.krb5.ccache import CCache
-        from impacket.krb5.asn1 import AP_REQ, Authenticator, TGS_REP, seq_set
-        from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGS
-        from impacket.krb5 import constants
-        from impacket.krb5.types import Principal, KerberosTime, Ticket
-        import datetime
-
-        if TGT is not None or TGS is not None:
-            useCache = False
-
-        targetName = 'ldap/%s' % self.__target
-        if useCache:
-            domain, user, TGT, TGS = CCache.parseFile(domain, user, targetName)
-
-        # First of all, we need to get a TGT for the user
-        userName = Principal(user, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
-        if TGT is None:
-            if TGS is None:
-                tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, password, domain, lmhash, nthash,
-                                                                        aesKey, kdcHost)
-        else:
-            tgt = TGT['KDC_REP']
-            cipher = TGT['cipher']
-            sessionKey = TGT['sessionKey']
-
-        if TGS is None:
-            serverName = Principal(targetName, type=constants.PrincipalNameType.NT_SRV_INST.value)
-            tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(serverName, domain, kdcHost, tgt, cipher,
-                                                                    sessionKey)
-        else:
-            tgs = TGS['KDC_REP']
-            cipher = TGS['cipher']
-            sessionKey = TGS['sessionKey']
-
-            # Let's build a NegTokenInit with a Kerberos REQ_AP
-
-        blob = SPNEGO_NegTokenInit()
-
-        # Kerberos
-        blob['MechTypes'] = [TypesMech['MS KRB5 - Microsoft Kerberos 5']]
-
-        # Let's extract the ticket from the TGS
-        tgs = decoder.decode(tgs, asn1Spec=TGS_REP())[0]
-        ticket = Ticket()
-        ticket.from_asn1(tgs['ticket'])
-
-        # Now let's build the AP_REQ
-        apReq = AP_REQ()
-        apReq['pvno'] = 5
-        apReq['msg-type'] = int(constants.ApplicationTagNumbers.AP_REQ.value)
-
-        opts = []
-        apReq['ap-options'] = constants.encodeFlags(opts)
-        seq_set(apReq, 'ticket', ticket.to_asn1)
-
-        authenticator = Authenticator()
-        authenticator['authenticator-vno'] = 5
-        authenticator['crealm'] = domain
-        seq_set(authenticator, 'cname', userName.components_to_asn1)
-        now = datetime.datetime.now(datetime.timezone.utc)
-
-        authenticator['cusec'] = now.microsecond
-        authenticator['ctime'] = KerberosTime.to_asn1(now)
-
-        encodedAuthenticator = encoder.encode(authenticator)
-
-        # Key Usage 11
-        # AP-REQ Authenticator (includes application authenticator
-        # subkey), encrypted with the application session key
-        # (Section 5.5.1)
-        encryptedEncodedAuthenticator = cipher.encrypt(sessionKey, 11, encodedAuthenticator, None)
-
-        apReq['authenticator'] = noValue
-        apReq['authenticator']['etype'] = cipher.enctype
-        apReq['authenticator']['cipher'] = encryptedEncodedAuthenticator
-
-        blob['MechToken'] = encoder.encode(apReq)
-
-
-        request = ldap3.operation.bind.bind_operation(connection.version, ldap3.SASL, user, None, 'GSS-SPNEGO', blob.getData())
-
-        # Done with the Kerberos saga, now let's get into LDAP
-        # try to open connection if closed
-        if connection.closed:
-            connection.open(read_server_info=False)
-
-        connection.sasl_in_progress = True
-        response = connection.post_send_single_response(connection.send('bindRequest', request, None))
-        connection.sasl_in_progress = False
-        if response[0]['result'] != 0:
-            raise Exception(response)
-
-        connection.bound = True
-
-        return True
 
     def generateComputerName(self):
         return 'DESKTOP-' + (''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(8)) + '$')

--- a/examples/addcomputer.py
+++ b/examples/addcomputer.py
@@ -31,7 +31,7 @@ from __future__ import unicode_literals
 
 from impacket import version
 from impacket.examples import logger
-from impacket.examples.utils import parse_credentials
+from impacket.examples.utils import parse_identity
 from impacket.dcerpc.v5 import samr, epm, transport
 from impacket.spnego import SPNEGO_NegTokenInit, TypesMech
 
@@ -457,22 +457,14 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     logger.init(options.ts, options.debug)
+    
+    domain, username, password, _, _, options.k = parse_identity(options.account, options.hashes, options.no_pass, options.aesKey, options.k)
 
-    domain, username, password = parse_credentials(options.account)
+    if domain == '':
+        logging.critical('Domain should be specified!')
+        sys.exit(1)
 
     try:
-        if domain is None or domain == '':
-            logging.critical('Domain should be specified!')
-            sys.exit(1)
-
-        if password == '' and username != '' and options.hashes is None and options.no_pass is False and options.aesKey is None:
-            from getpass import getpass
-            password = getpass("Password:")
-
-        if options.aesKey is not None:
-            options.k = True
-
-
         executer = ADDCOMPUTER(username, password, domain, options)
         executer.run()
     except Exception as e:

--- a/examples/addcomputer.py
+++ b/examples/addcomputer.py
@@ -526,9 +526,7 @@ class ADDCOMPUTER:
 
 # Process command-line arguments.
 if __name__ == '__main__':
-    # Init the example's logger theme
-    logger.init()
-    print((version.BANNER))
+    print(version.BANNER)
 
     parser = argparse.ArgumentParser(add_help = True, description = "Adds a computer account to domain")
 
@@ -543,6 +541,7 @@ if __name__ == '__main__':
                                                                                  'If omitted, a random [A-Za-z0-9]{32} will be used.')
     parser.add_argument('-no-add', action='store_true', help='Don\'t add a computer, only set password on existing one.')
     parser.add_argument('-delete', action='store_true', help='Delete an existing computer.')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
     parser.add_argument('-method', choices=['SAMR', 'LDAPS'], default='SAMR', help='Method of adding the computer.'
                                                                                 'SAMR works over SMB.'
@@ -584,12 +583,7 @@ if __name__ == '__main__':
 
     options = parser.parse_args()
 
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    logger.init(options.ts, options.debug)
 
     domain, username, password = parse_credentials(options.account)
 

--- a/examples/atexec.py
+++ b/examples/atexec.py
@@ -292,13 +292,6 @@ if __name__ == '__main__':
         logging.error('You need to specify a command to execute!')
         sys.exit(1)
 
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
-
     domain, username, password, address = parse_target(options.target)
 
     if domain is None:

--- a/examples/atexec.py
+++ b/examples/atexec.py
@@ -278,7 +278,7 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # Init the example's logger theme
-    logger.init(options.ts)
+    logger.init(options.ts, options.debug)
 
     if options.codec is not None:
         CODEC = options.codec

--- a/examples/changepasswd.py
+++ b/examples/changepasswd.py
@@ -744,16 +744,6 @@ class LdapPassword(PasswordHandler):
         newPasswordEncoded = self.encodeLdapPassword(newPassword)
         return self._modifyPassword(False, targetUsername, targetDomain, None, newPasswordEncoded)
 
-
-def init_logger(options):
-    logger.init(options.ts)
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
-
-
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Change or reset passwords over different protocols.",
@@ -844,7 +834,7 @@ if __name__ == "__main__":
     print(version.BANNER)
 
     options = parse_args()
-    init_logger(options)
+    logger.init(options.ts, options.debug)
 
     handlers = {
         "kpasswd": KPassword,

--- a/examples/changepasswd.py
+++ b/examples/changepasswd.py
@@ -130,13 +130,9 @@ from impacket.krb5 import kerberosv5, kpasswd
 from impacket.ldap import ldap, ldapasn1
 
 from impacket.examples import logger
-from impacket.examples.utils import parse_target
+from impacket.examples.utils import parse_target, EMPTY_LM_HASH
 
 import OpenSSL
-
-
-EMPTY_LM_HASH = "aad3b435b51404eeaad3b435b51404ee"
-
 
 class PasswordHandler:
     """Generic interface for all the password protocols supported by this script"""

--- a/examples/dacledit.py
+++ b/examples/dacledit.py
@@ -742,7 +742,7 @@ def main():
     if args.action == "restore" and not args.filename:
         logging.critical('-file is required when using -action restore')
 
-    domain, username, password, lmhash, nthash = parse_identity(args)
+    domain, username, password, lmhash, nthash, args.k = parse_identity(args.identity, args.hashes, args.no_pass, args.aesKey, args.k)
 
     try:
         ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.aesKey, args.use_ldaps)

--- a/examples/dacledit.py
+++ b/examples/dacledit.py
@@ -41,7 +41,7 @@ from ldap3.utils.conv import escape_filter_chars
 from ldap3.protocol.microsoft import security_descriptor_control
 from impacket.uuid import string_to_bin, bin_to_string
 
-from impacket.examples.utils import init_ldap_session, EMPTY_LM_HASH
+from impacket.examples.utils import init_ldap_session, parse_identity
 
 OBJECT_TYPES_GUID = {}
 OBJECT_TYPES_GUID.update(SCHEMA_OBJECTS)
@@ -730,30 +730,6 @@ def parse_args():
     return parser.parse_args()
 
 
-def parse_identity(args):
-    domain, username, password = utils.parse_credentials(args.identity)
-
-    if domain == '':
-        logging.critical('Domain should be specified!')
-        sys.exit(1)
-
-    if password == '' and username != '' and args.hashes is None and args.no_pass is False and args.aesKey is None:
-        from getpass import getpass
-        logging.info("No credentials supplied, supply password")
-        password = getpass("Password:")
-
-    if args.aesKey is not None:
-        args.k = True
-
-    if args.hashes is not None:
-        lmhash, nthash = args.hashes.split(':')
-    else:
-        lmhash = ''
-        nthash = ''
-
-    return domain, username, password, lmhash, nthash
-
-
 def main():
     print(version.BANNER)
     args = parse_args()
@@ -767,8 +743,6 @@ def main():
         logging.critical('-file is required when using -action restore')
 
     domain, username, password, lmhash, nthash = parse_identity(args)
-    if len(nthash) > 0 and lmhash == "":
-        lmhash = EMPTY_LM_HASH
 
     try:
         ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.aesKey, args.use_ldaps)

--- a/examples/dacledit.py
+++ b/examples/dacledit.py
@@ -41,7 +41,7 @@ from ldap3.utils.conv import escape_filter_chars
 from ldap3.protocol.microsoft import security_descriptor_control
 from impacket.uuid import string_to_bin, bin_to_string
 
-from impacket.examples.utils import init_ldap_session
+from impacket.examples.utils import init_ldap_session, EMPTY_LM_HASH
 
 OBJECT_TYPES_GUID = {}
 OBJECT_TYPES_GUID.update(SCHEMA_OBJECTS)
@@ -768,7 +768,7 @@ def main():
 
     domain, username, password, lmhash, nthash = parse_identity(args)
     if len(nthash) > 0 and lmhash == "":
-        lmhash = "aad3b435b51404eeaad3b435b51404ee"
+        lmhash = EMPTY_LM_HASH
 
     try:
         ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.aesKey, args.use_ldaps)

--- a/examples/dacledit.py
+++ b/examples/dacledit.py
@@ -755,19 +755,6 @@ def parse_identity(args):
 
     return domain, username, password, lmhash, nthash
 
-
-def init_logger(args):
-    # Init the example's logger theme and debug level
-    logger.init(args.ts)
-    if args.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
-        logging.getLogger('impacket.smbserver').setLevel(logging.ERROR)
-
-
 def get_machine_name(args, domain):
     if args.dc_ip is not None:
         s = SMBConnection(args.dc_ip, args.dc_ip)
@@ -957,7 +944,7 @@ def init_ldap_session(args, domain, username, password, lmhash, nthash):
 def main():
     print(version.BANNER)
     args = parse_args()
-    init_logger(args)
+    logger.init(args.ts, args.debug)
 
     if args.action == 'write' and args.principal_sAMAccountName is None and args.principal_SID is None and args.principal_DN is None:
         logging.critical('-principal, -principal-sid, or -principal-dn should be specified when using -action write')

--- a/examples/dacledit.py
+++ b/examples/dacledit.py
@@ -29,9 +29,7 @@ import traceback
 import datetime
 
 import ldap3
-import ssl
 import ldapdomaindump
-from binascii import unhexlify
 from enum import Enum
 from ldap3.protocol.formatters.formatters import format_sid
 
@@ -39,11 +37,11 @@ from impacket import version
 from impacket.examples import logger, utils
 from impacket.ldap import ldaptypes
 from impacket.msada_guids import SCHEMA_OBJECTS, EXTENDED_RIGHTS
-from impacket.smbconnection import SMBConnection
-from impacket.spnego import SPNEGO_NegTokenInit, TypesMech
 from ldap3.utils.conv import escape_filter_chars
 from ldap3.protocol.microsoft import security_descriptor_control
 from impacket.uuid import string_to_bin, bin_to_string
+
+from impacket.examples.utils import init_ldap_session
 
 OBJECT_TYPES_GUID = {}
 OBJECT_TYPES_GUID.update(SCHEMA_OBJECTS)
@@ -755,191 +753,6 @@ def parse_identity(args):
 
     return domain, username, password, lmhash, nthash
 
-def get_machine_name(args, domain):
-    if args.dc_ip is not None:
-        s = SMBConnection(args.dc_ip, args.dc_ip)
-    else:
-        s = SMBConnection(domain, domain)
-    try:
-        s.login('', '')
-    except Exception:
-        if s.getServerName() == '':
-            raise Exception('Error while anonymous logging into %s' % domain)
-    else:
-        s.logoff()
-    return s.getServerName()
-
-
-def ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='', nthash='', aesKey='', kdcHost=None,
-                         TGT=None, TGS=None, useCache=True):
-    from pyasn1.codec.ber import encoder, decoder
-    from pyasn1.type.univ import noValue
-    """
-    logins into the target system explicitly using Kerberos. Hashes are used if RC4_HMAC is supported.
-    :param string user: username
-    :param string password: password for the user
-    :param string domain: domain where the account is valid for (required)
-    :param string lmhash: LMHASH used to authenticate using hashes (password is not used)
-    :param string nthash: NTHASH used to authenticate using hashes (password is not used)
-    :param string aesKey: aes256-cts-hmac-sha1-96 or aes128-cts-hmac-sha1-96 used for Kerberos authentication
-    :param string kdcHost: hostname or IP Address for the KDC. If None, the domain will be used (it needs to resolve tho)
-    :param struct TGT: If there's a TGT available, send the structure here and it will be used
-    :param struct TGS: same for TGS. See smb3.py for the format
-    :param bool useCache: whether or not we should use the ccache for credentials lookup. If TGT or TGS are specified this is False
-    :return: True, raises an Exception if error.
-    """
-
-    if lmhash != '' or nthash != '':
-        if len(lmhash) % 2:
-            lmhash = '0' + lmhash
-        if len(nthash) % 2:
-            nthash = '0' + nthash
-        try:  # just in case they were converted already
-            lmhash = unhexlify(lmhash)
-            nthash = unhexlify(nthash)
-        except TypeError:
-            pass
-
-    # Importing down here so pyasn1 is not required if kerberos is not used.
-    from impacket.krb5.ccache import CCache
-    from impacket.krb5.asn1 import AP_REQ, Authenticator, TGS_REP, seq_set
-    from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGS
-    from impacket.krb5 import constants
-    from impacket.krb5.types import Principal, KerberosTime, Ticket
-    import datetime
-
-    if TGT is not None or TGS is not None:
-        useCache = False
-
-    target = 'ldap/%s' % target
-    if useCache:
-        domain, user, TGT, TGS = CCache.parseFile(domain, user, target)
-
-    # First of all, we need to get a TGT for the user
-    userName = Principal(user, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
-    if TGT is None:
-        if TGS is None:
-            tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, password, domain, lmhash, nthash,
-                                                                    aesKey, kdcHost)
-    else:
-        tgt = TGT['KDC_REP']
-        cipher = TGT['cipher']
-        sessionKey = TGT['sessionKey']
-
-    if TGS is None:
-        serverName = Principal(target, type=constants.PrincipalNameType.NT_SRV_INST.value)
-        tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(serverName, domain, kdcHost, tgt, cipher,
-                                                                sessionKey)
-    else:
-        tgs = TGS['KDC_REP']
-        cipher = TGS['cipher']
-        sessionKey = TGS['sessionKey']
-
-        # Let's build a NegTokenInit with a Kerberos REQ_AP
-
-    blob = SPNEGO_NegTokenInit()
-
-    # Kerberos
-    blob['MechTypes'] = [TypesMech['MS KRB5 - Microsoft Kerberos 5']]
-
-    # Let's extract the ticket from the TGS
-    tgs = decoder.decode(tgs, asn1Spec=TGS_REP())[0]
-    ticket = Ticket()
-    ticket.from_asn1(tgs['ticket'])
-
-    # Now let's build the AP_REQ
-    apReq = AP_REQ()
-    apReq['pvno'] = 5
-    apReq['msg-type'] = int(constants.ApplicationTagNumbers.AP_REQ.value)
-
-    opts = []
-    apReq['ap-options'] = constants.encodeFlags(opts)
-    seq_set(apReq, 'ticket', ticket.to_asn1)
-
-    authenticator = Authenticator()
-    authenticator['authenticator-vno'] = 5
-    authenticator['crealm'] = domain
-    seq_set(authenticator, 'cname', userName.components_to_asn1)
-    now = datetime.datetime.now(datetime.timezone.utc)
-
-    authenticator['cusec'] = now.microsecond
-    authenticator['ctime'] = KerberosTime.to_asn1(now)
-
-    encodedAuthenticator = encoder.encode(authenticator)
-
-    # Key Usage 11
-    # AP-REQ Authenticator (includes application authenticator
-    # subkey), encrypted with the application session key
-    # (Section 5.5.1)
-    encryptedEncodedAuthenticator = cipher.encrypt(sessionKey, 11, encodedAuthenticator, None)
-
-    apReq['authenticator'] = noValue
-    apReq['authenticator']['etype'] = cipher.enctype
-    apReq['authenticator']['cipher'] = encryptedEncodedAuthenticator
-
-    blob['MechToken'] = encoder.encode(apReq)
-
-    request = ldap3.operation.bind.bind_operation(connection.version, ldap3.SASL, user, None, 'GSS-SPNEGO',
-                                                  blob.getData())
-
-    # Done with the Kerberos saga, now let's get into LDAP
-    if connection.closed:  # try to open connection if closed
-        connection.open(read_server_info=False)
-
-    connection.sasl_in_progress = True
-    response = connection.post_send_single_response(connection.send('bindRequest', request, None))
-    connection.sasl_in_progress = False
-    if response[0]['result'] != 0:
-        raise Exception(response)
-
-    connection.bound = True
-
-    return True
-
-
-def init_ldap_connection(target, tls_version, args, domain, username, password, lmhash, nthash):
-    user = '%s\\%s' % (domain, username)
-    connect_to = target
-    if args.dc_ip is not None:
-        connect_to = args.dc_ip
-    if tls_version is not None:
-        use_ssl = True
-        port = 636
-        tls = ldap3.Tls(validate=ssl.CERT_NONE, version=tls_version)
-    else:
-        use_ssl = False
-        port = 389
-        tls = None
-    ldap_server = ldap3.Server(connect_to, get_info=ldap3.ALL, port=port, use_ssl=use_ssl, tls=tls)
-    if args.k:
-        ldap_session = ldap3.Connection(ldap_server)
-        ldap_session.bind()
-        ldap3_kerberos_login(ldap_session, target, username, password, domain, lmhash, nthash, args.aesKey, kdcHost=args.dc_ip)
-    elif args.hashes is not None:
-        ldap_session = ldap3.Connection(ldap_server, user=user, password=lmhash + ":" + nthash, authentication=ldap3.NTLM, auto_bind=True)
-    else:
-        ldap_session = ldap3.Connection(ldap_server, user=user, password=password, authentication=ldap3.NTLM, auto_bind=True)
-
-    return ldap_server, ldap_session
-
-
-def init_ldap_session(args, domain, username, password, lmhash, nthash):
-    if args.k:
-        target = get_machine_name(args, domain)
-    else:
-        if args.dc_ip is not None:
-            target = args.dc_ip
-        else:
-            target = domain
-
-    if args.use_ldaps is True:
-        try:
-            return init_ldap_connection(target, ssl.PROTOCOL_TLSv1_2, args, domain, username, password, lmhash, nthash)
-        except ldap3.core.exceptions.LDAPSocketOpenError:
-            return init_ldap_connection(target, ssl.PROTOCOL_TLSv1, args, domain, username, password, lmhash, nthash)
-    else:
-        return init_ldap_connection(target, None, args, domain, username, password, lmhash, nthash)
-
 
 def main():
     print(version.BANNER)
@@ -958,7 +771,7 @@ def main():
         lmhash = "aad3b435b51404eeaad3b435b51404ee"
 
     try:
-        ldap_server, ldap_session = init_ldap_session(args, domain, username, password, lmhash, nthash)
+        ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.aesKey, args.use_ldaps)
         dacledit = DACLedit(ldap_server, ldap_session, args)
         if args.action == 'read':
             dacledit.read()

--- a/examples/dcomexec.py
+++ b/examples/dcomexec.py
@@ -595,9 +595,8 @@ if __name__ == '__main__':
         sys.exit(1)
 
     options = parser.parse_args()
-
     # Init the example's logger theme
-    logger.init(options.ts)
+    logger.init(options.ts, options.debug)
 
     if options.codec is not None:
         CODEC = options.codec
@@ -611,13 +610,6 @@ if __name__ == '__main__':
     if options.silentcommand and options.command == ' ':
         logging.error("-silentcommand switch and interactive shell not supported")
         sys.exit(1)
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
 
     if options.com_version is not None:
         try:

--- a/examples/describeTicket.py
+++ b/examples/describeTicket.py
@@ -769,23 +769,10 @@ def parse_args():
 
     return args
 
-
-def init_logger(args):
-    # Init the example's logger theme and debug level
-    logger.init(args.ts)
-    if args.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
-        logging.getLogger('impacket.smbserver').setLevel(logging.ERROR)
-
-
 def main():
     print(version.BANNER)
     args = parse_args()
-    init_logger(args)
+    logger.init(args.ts, args.debug)
 
     try:
         parse_ccache(args)

--- a/examples/dpapi.py
+++ b/examples/dpapi.py
@@ -543,12 +543,11 @@ class DPAPI:
 
 
 if __name__ == '__main__':
-    # Init the example's logger theme
-    logger.init()
     print(version.BANNER)
 
     parser = argparse.ArgumentParser(add_help=True, description="Example for using the DPAPI/Vault structures to unlock Windows Secrets.")
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     subparsers = parser.add_subparsers(help='actions', dest='action')
 
     # A domain backup key command
@@ -612,18 +611,12 @@ if __name__ == '__main__':
     credhist.add_argument('-entry', action='store', type=int, help='Entry index in CREDHIST')
 
     options = parser.parse_args()
+    # Init the example's logger theme
+    logger.init(options.ts, options.debug)
 
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
-
 
     try:
         executer = DPAPI(options)

--- a/examples/esentutl.py
+++ b/examples/esentutl.py
@@ -60,13 +60,12 @@ def exportTable(ese, tableName):
 
 def main():
     print(version.BANNER)
-    # Init the example's logger theme
-    logger.init()
 
     parser = argparse.ArgumentParser(add_help = True, description = "Extensive Storage Engine utility. Allows dumping "
                                                                     "catalog, pages and tables.")
     parser.add_argument('databaseFile', action='store', help='ESE to open')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-page', action='store', help='page to open')
 
     subparsers = parser.add_subparsers(help='actions', dest='action')
@@ -87,13 +86,8 @@ def main():
         sys.exit(1)
 
     options = parser.parse_args()
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    # Init the example's logger theme
+    logger.init(options.ts, options.debug)
 
     ese = ESENT_DB(options.databaseFile)
 

--- a/examples/exchanger.py
+++ b/examples/exchanger.py
@@ -874,9 +874,6 @@ class ExchangerHelper:
 
 # Process command-line arguments.
 if __name__ == '__main__':
-    # Init the example's logger theme
-    logger.init()
-
     # Explicitly changing the stdout encoding format
     if sys.stdout.encoding is None:
         # Output is redirected to a file
@@ -898,6 +895,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(add_help=True, description="A tool to abuse Exchange services")
     parser.add_argument('target', action='store', help='[[domain/]username[:password]@]<targetName or address>')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG and EXTENDED output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     #parser.add_argument('-transport', choices=['RPC', 'MAPI'], nargs='?', default='RPC', help='Protocol to use')
     parser.add_argument('-rpc-hostname', action='store', help='A name of the server in GUID (preferred) '
         'or NetBIOS name format (see description in the beggining of this file)')
@@ -982,13 +980,8 @@ if __name__ == '__main__':
         sys.exit(1)
 
     options = parser.parse_args()
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    # Init the example's logger theme
+    logger.init(options.ts, options.debug)
 
     domain, username, password, remoteName = parse_target(options.target)
 

--- a/examples/findDelegation.py
+++ b/examples/findDelegation.py
@@ -311,14 +311,7 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # Init the example's logger theme
-    logger.init(options.ts)
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    logger.init(options.ts, options.debug)
 
     userDomain, username, password = parse_credentials(options.target)
 

--- a/examples/findDelegation.py
+++ b/examples/findDelegation.py
@@ -31,7 +31,7 @@ import sys
 from impacket import version
 from impacket.dcerpc.v5.samr import UF_ACCOUNTDISABLE, UF_TRUSTED_FOR_DELEGATION, UF_TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION
 from impacket.examples import logger
-from impacket.examples.utils import parse_credentials
+from impacket.examples.utils import parse_identity
 from impacket.ldap import ldap, ldapasn1
 from impacket.ldap import ldaptypes
 from impacket.smbconnection import SMBConnection, SessionError
@@ -313,7 +313,7 @@ if __name__ == '__main__':
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
 
-    userDomain, username, password = parse_credentials(options.target)
+    userDomain, username, password, _, _, options.k = parse_identity(options.target, options.hashes, options.no_pass, options.aesKey, options.k)
 
     if userDomain == '':
         logging.critical('userDomain should be specified!')
@@ -323,13 +323,6 @@ if __name__ == '__main__':
         targetDomain = options.target_domain
     else:
         targetDomain = userDomain
-
-    if password == '' and username != '' and options.hashes is None and options.no_pass is False and options.aesKey is None:
-        from getpass import getpass
-        password = getpass("Password:")
-
-    if options.aesKey is not None:
-        options.k = True
 
     try:
         executer = FindDelegation(username, password, userDomain, targetDomain, options)

--- a/examples/getArch.py
+++ b/examples/getArch.py
@@ -80,8 +80,6 @@ class TARGETARCH:
 
 # Process command-line arguments.
 if __name__ == '__main__':
-    # Init the example's logger theme
-    logger.init()
     print(version.BANNER)
 
     parser = argparse.ArgumentParser(add_help = True, description = "Gets the target system's OS architecture version")
@@ -90,23 +88,19 @@ if __name__ == '__main__':
                         'from (one per line). ')
     parser.add_argument('-timeout', action='store', default='2', help='socket timeout out when connecting to the target (default 2 sec)')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
 
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
 
     options = parser.parse_args()
+    # Init the example's logger theme
+    logger.init(options.ts, options.debug)
 
     if options.target is None and options.targets is None:
         logging.error('You have to specify a target!')
         sys.exit(1)
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
 
     try:
         getArch = TARGETARCH(options)

--- a/examples/getPac.py
+++ b/examples/getPac.py
@@ -321,13 +321,6 @@ if __name__ == '__main__':
         from getpass import getpass
         password = getpass("Password:")
 
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
-
     try:
         dumper = S4U2SELF(options.targetUser, username, password, domain, options.hashes)
         dumper.dump()

--- a/examples/getPac.py
+++ b/examples/getPac.py
@@ -292,7 +292,6 @@ class S4U2SELF:
 
 # Process command-line arguments.
 if __name__ == '__main__':
-    logger.init()
     print(version.BANNER)
 
     parser = argparse.ArgumentParser()
@@ -301,6 +300,7 @@ if __name__ == '__main__':
                                                        'for grabbing targetUser\'s PAC')
     parser.add_argument('-targetUser', action='store', required=True, help='the target user to retrieve the PAC of')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
 
     group = parser.add_argument_group('authentication')
 
@@ -310,6 +310,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     options = parser.parse_args()
+    logger.init(options.ts, options.debug)
 
     domain, username, password = parse_credentials(options.credentials)
 

--- a/examples/getPac.py
+++ b/examples/getPac.py
@@ -40,7 +40,7 @@ from pyasn1.type.univ import noValue
 from impacket import version
 from impacket.dcerpc.v5.rpcrt import TypeSerialization1
 from impacket.examples import logger
-from impacket.examples.utils import parse_credentials
+from impacket.examples.utils import parse_identity
 from impacket.krb5 import constants
 from impacket.krb5.asn1 import AP_REQ, AS_REP, TGS_REQ, Authenticator, TGS_REP, seq_set, seq_set_iter, PA_FOR_USER_ENC, \
     EncTicketPart, AD_IF_RELEVANT, Ticket as TicketAsn1
@@ -312,14 +312,7 @@ if __name__ == '__main__':
     options = parser.parse_args()
     logger.init(options.ts, options.debug)
 
-    domain, username, password = parse_credentials(options.credentials)
-
-    if domain is None:
-        domain = ''
-
-    if password == '' and username != '' and options.hashes is None:
-        from getpass import getpass
-        password = getpass("Password:")
+    domain, username, password, _, _, _ = parse_identity(options.credentials, options.hashes)
 
     try:
         dumper = S4U2SELF(options.targetUser, username, password, domain, options.hashes)

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -799,13 +799,6 @@ if __name__ == '__main__':
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
 
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
-
     domain, username, password = parse_credentials(options.identity)
 
     try:

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -797,7 +797,7 @@ if __name__ == '__main__':
         # the request would also need to embed an additional-ticket (the target user's TGT)
 
     # Init the example's logger theme
-    logger.init(options.ts)
+    logger.init(options.ts, options.debug)
 
     if options.debug is True:
         logging.getLogger().setLevel(logging.DEBUG)

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -60,7 +60,7 @@ from pyasn1.type.univ import noValue
 
 from impacket import version
 from impacket.examples import logger
-from impacket.examples.utils import parse_credentials
+from impacket.examples.utils import parse_identity
 from impacket.krb5 import constants, types, crypto, ccache
 from impacket.krb5.asn1 import AP_REQ, AS_REP, TGS_REQ, Authenticator, TGS_REP, seq_set, seq_set_iter, PA_FOR_USER_ENC, \
     Ticket as TicketAsn1, EncTGSRepPart, PA_PAC_OPTIONS, EncTicketPart
@@ -799,21 +799,13 @@ if __name__ == '__main__':
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
 
-    domain, username, password = parse_credentials(options.identity)
+    domain, username, password, _, _, options.k = parse_identity(options.identity, options.hashes, options.no_pass, options.aesKey, options.k)
+
+    if domain == '':
+        logging.critical('Domain should be specified!')
+        sys.exit(1)
 
     try:
-        if domain is None:
-            logging.critical('Domain should be specified!')
-            sys.exit(1)
-
-        if password == '' and username != '' and options.hashes is None and options.no_pass is False and options.aesKey is None:
-            from getpass import getpass
-
-            password = getpass("Password:")
-
-        if options.aesKey is not None:
-            options.k = True
-
         executer = GETST(username, password, domain, options)
         executer.run()
     except Exception as e:

--- a/examples/getTGT.py
+++ b/examples/getTGT.py
@@ -100,14 +100,7 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # Init the example's logger theme
-    logger.init(options.ts)
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    logger.init(options.ts, options.debug)
 
     domain, username, password = parse_credentials(options.identity)
 

--- a/examples/getTGT.py
+++ b/examples/getTGT.py
@@ -28,7 +28,7 @@ from binascii import unhexlify
 
 from impacket import version
 from impacket.examples import logger
-from impacket.examples.utils import parse_credentials
+from impacket.examples.utils import parse_identity
 from impacket.krb5.kerberosv5 import getKerberosTGT
 from impacket.krb5 import constants
 from impacket.krb5.types import Principal
@@ -102,24 +102,17 @@ if __name__ == '__main__':
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
 
-    domain, username, password = parse_credentials(options.identity)
+    domain, username, password, _, _, options.k = parse_identity(options.identity, options.hashes, options.no_pass, options.aesKey, options.k)
+    
+    if domain is None:
+        logging.critical('Domain should be specified!')
+        sys.exit(1)
+
+    if options.principalType is None:
+        logging.critical('Invalid principalType!')
+        sys.exit(1)
 
     try:
-        if domain is None:
-            logging.critical('Domain should be specified!')
-            sys.exit(1)
-
-        if options.principalType is None:
-            logging.critical('Invalid principalType!')
-            sys.exit(1)
-
-        if password == '' and username != '' and options.hashes is None and options.no_pass is False and options.aesKey is None:
-            from getpass import getpass
-            password = getpass("Password:")
-
-        if options.aesKey is not None:
-            options.k = True
-
         executer = GETTGT(username, password, domain, options)
         executer.run()
     except Exception as e:

--- a/examples/goldenPac.py
+++ b/examples/goldenPac.py
@@ -1113,7 +1113,7 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # Init the example's logger theme
-    logger.init(options.ts)
+    logger.init(options.ts, options.debug)
 
     domain, username, password, address = parse_target(options.target)
 

--- a/examples/goldenPac.py
+++ b/examples/goldenPac.py
@@ -1121,13 +1121,6 @@ if __name__ == '__main__':
         logging.critical('Domain should be specified!')
         sys.exit(1)
 
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
-
     if password == '' and username != '' and options.hashes is None:
         from getpass import getpass
         password = getpass("Password:")

--- a/examples/karmaSMB.py
+++ b/examples/karmaSMB.py
@@ -596,8 +596,6 @@ class KarmaSMBServer(Thread):
 
 # Process command-line arguments.
 if __name__ == '__main__':
-    # Init the example's logger theme
-    logger.init()
     print(version.BANNER)
     parser = argparse.ArgumentParser(add_help = False, description = "For every file request received, this module will "
                                                                      "return the pathname contents")
@@ -607,6 +605,8 @@ if __name__ == '__main__':
     parser.add_argument('-config', type=argparse.FileType('r'), metavar = 'pathname', help='config file name to map '
                         'extensions to files to deliver. For those extensions not present, pathname will be delivered')
     parser.add_argument('-smb2support', action='store_true', default=False, help='SMB2 Support (experimental!)')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
+    parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
 
 
     if len(sys.argv)==1:
@@ -618,6 +618,9 @@ if __name__ == '__main__':
     except Exception as e:
        logging.critical(str(e))
        sys.exit(1)
+
+    # Init the example's logger theme
+    logger.init(options.ts, options.debug)
 
     s = KarmaSMBServer(options.smb2support)
     s.setDefaultFile(os.path.normpath(options.fileName))

--- a/examples/keylistattack.py
+++ b/examples/keylistattack.py
@@ -153,6 +153,7 @@ if __name__ == '__main__':
     parser.add_argument('-full', action='store_true', default=False, help='Run the attack against all domain users. '
                         'Noisy! It could lead to more TGS requests being rejected')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
 
     group = parser.add_argument_group('LIST option')
     group.add_argument('-domain', action='store', help='The fully qualified domain name (only works with LIST)')
@@ -183,7 +184,7 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # Init the example's logger theme
-    logger.init()
+    logger.init(options.ts, options.debug)
 
     if options.debug is True:
         logging.getLogger().setLevel(logging.DEBUG)

--- a/examples/keylistattack.py
+++ b/examples/keylistattack.py
@@ -186,12 +186,6 @@ if __name__ == '__main__':
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
 
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
-
     if options.rodcNo is None:
         logging.error("You must specify the RODC number (krbtgt_XXXXX)")
         sys.exit(1)

--- a/examples/kintercept.py
+++ b/examples/kintercept.py
@@ -38,6 +38,8 @@ from impacket.krb5.crypto import Cksumtype
 from impacket.krb5.asn1 import TGS_REQ, TGS_REP, seq_set, PA_FOR_USER_ENC
 from impacket.krb5.types import Principal
 
+from impacket.examples import logger
+
 
 MAX_READ_SIZE = 16000
 MAX_BUFF_SIZE = 32000

--- a/examples/kintercept.py
+++ b/examples/kintercept.py
@@ -267,6 +267,8 @@ def parse_args():
     parser.add_argument('--listen-addr', default='', help='Address to listen on')
     parser.add_argument('--request-handler', default='', metavar='HANDLER:ARG', help='Example: s4u2else:user')
     parser.add_argument('--reply-handler', default='', metavar='HANDLER:ARG', help='Example: tgs-rep-user:user')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
+    parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
     return vars(parser.parse_args())
 
 
@@ -275,6 +277,8 @@ if __name__ == '__main__':
     print(version.BANNER)
 
     args = parse_args()
+
+    logger.init(args.ts, args.debug)
 
     req_factory = rep_factory = InterceptConnFactory()
     if args['request_handler']:

--- a/examples/lookupsid.py
+++ b/examples/lookupsid.py
@@ -157,6 +157,7 @@ if __name__ == '__main__':
 
     parser.add_argument('target', action='store', help='[[domain/]username[:password]@]<targetName or address>')
     parser.add_argument('maxRid', action='store', default = '4000', nargs='?', help='max Rid to check (default 4000)')
+    parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
 
     group = parser.add_argument_group('connection')
@@ -184,7 +185,7 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # Init the example's logger theme
-    logger.init(options.ts)
+    logger.init(options.ts, options.debug)
 
     domain, username, password, remoteName = parse_target(options.target)
 

--- a/examples/machine_role.py
+++ b/examples/machine_role.py
@@ -154,14 +154,7 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # Init the example's logger theme
-    logger.init(options.ts)
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    logger.init(options.ts, options.debug)
 
     domain, username, password, remoteName = parse_target(options.target)
 

--- a/examples/mimikatz.py
+++ b/examples/mimikatz.py
@@ -114,14 +114,13 @@ class MimikatzShell(cmd.Cmd):
         self.default('::')
 
 def main():
-    # Init the example's logger theme
-    logger.init()
     print(version.BANNER)
     parser = argparse.ArgumentParser(add_help = True, description = "SMB client implementation.")
 
     parser.add_argument('target', action='store', help='[[domain/]username[:password]@]<targetName or address>')
     parser.add_argument('-file', type=argparse.FileType('r'), help='input file with commands to execute in the mini shell')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
 
     group = parser.add_argument_group('authentication')
 
@@ -148,13 +147,8 @@ def main():
         sys.exit(1)
 
     options = parser.parse_args()
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    # Init the example's logger theme
+    logger.init(options.ts, options.debug)
 
     domain, username, password, address = parse_target(options.target)
 

--- a/examples/mqtt_check.py
+++ b/examples/mqtt_check.py
@@ -54,8 +54,6 @@ class MQTT_LOGIN:
         logging.info(CONNECT_ACK_ERROR_MSGS[0])
 
 if __name__ == '__main__':
-    # Init the example's logger theme
-    logger.init()
     print(version.BANNER)
     parser = argparse.ArgumentParser(add_help=False,
                                      description="MQTT login check")
@@ -65,6 +63,7 @@ if __name__ == '__main__':
     parser.add_argument('-ssl', action='store_true', help='turn SSL on')
     parser.add_argument('-port', action='store', default='1883', help='port to connect to (default 1883)')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
 
     try:
         options = parser.parse_args()
@@ -72,12 +71,8 @@ if __name__ == '__main__':
         logging.error(str(e))
         sys.exit(1)
 
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    # Init the example's logger theme
+    logger.init(options.ts, options.debug)
 
     domain, username, password, address = parse_target(options.target)
 

--- a/examples/mssqlclient.py
+++ b/examples/mssqlclient.py
@@ -30,8 +30,6 @@ from impacket import version, tds
 
 
 if __name__ == '__main__':
-    # Init the example's logger theme
-    logger.init()
     print(version.BANNER)
 
     parser = argparse.ArgumentParser(add_help = True, description = "TDS client implementation (SSL supported).")
@@ -41,6 +39,7 @@ if __name__ == '__main__':
     parser.add_argument('-windows-auth', action='store_true', default=False, help='whether or not to use Windows '
                                                                                   'Authentication (default False)')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-show', action='store_true', help='show the queries')
     parser.add_argument('-command', action='extend', nargs='*', help='Commands to execute in the SQL shell. Multiple commands can be passed.')
     parser.add_argument('-file', type=argparse.FileType('r'), help='input file with commands to execute in the SQL shell')
@@ -70,13 +69,8 @@ if __name__ == '__main__':
         sys.exit(1)
 
     options = parser.parse_args()
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    # Init the example's logger theme
+    logger.init(options.ts, options.debug)
 
     domain, username, password, remoteName = parse_target(options.target)
 

--- a/examples/mssqlinstance.py
+++ b/examples/mssqlinstance.py
@@ -31,19 +31,21 @@ from impacket import version, tds
 if __name__ == '__main__':
 
     print(version.BANNER)
-    # Init the example's logger theme
-    logger.init()
 
     parser = argparse.ArgumentParser(add_help = True, description = "Asks the remote host for its running MSSQL Instances.")
 
     parser.add_argument('host', action='store', help='target host')
     parser.add_argument('-timeout', action='store', default='5', help='timeout to wait for an answer')
+    parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
 
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
  
     options = parser.parse_args()
+    # Init the example's logger theme
+    logger.init(options.ts, options.debug)
 
     ms_sql = tds.MSSQL(options.host)
     instances = ms_sql.getInstances(int(options.timeout))

--- a/examples/net.py
+++ b/examples/net.py
@@ -485,12 +485,12 @@ class Net:
 
 if __name__ == '__main__':
     print(version.BANNER)
-    logger.init()
 
     parser = argparse.ArgumentParser(add_help = True, description = "SAMR rpc client implementation.")
 
     parser.add_argument('target', action='store', help='[[domain/]username[:password]@]<targetName or address>')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
 
     subparsers = parser.add_subparsers(help='An account entry name', dest='entry', required=True)
 
@@ -556,11 +556,7 @@ if __name__ == '__main__':
         logging.error("argument '-newPasswd' is required for creating new account.")
         sys.exit(1)
 
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    logger.init(options.ts, options.debug)
 
     domain, username, password, address = parse_target(options.target)
 

--- a/examples/netview.py
+++ b/examples/netview.py
@@ -61,7 +61,7 @@ from queue import Queue
 from time import sleep
 
 from impacket.examples import logger
-from impacket.examples.utils import parse_credentials
+from impacket.examples.utils import parse_identity
 from impacket import version
 from impacket.smbconnection import SessionError
 from impacket.dcerpc.v5 import transport, wkst, srvs, samr
@@ -481,19 +481,9 @@ if __name__ == '__main__':
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
 
-    domain, username, password = parse_credentials(options.identity)
+    domain, username, password, _, _, options.k = parse_identity(options.identity, options.hashes, options.no_pass, options.aesKey, options.k)
 
     try:
-        if domain is None:
-            domain = ''
-
-        if password == '' and username != '' and options.hashes is None and options.no_pass is False and options.aesKey is None:
-            from getpass import getpass
-            password = getpass("Password:")
-
-        if options.aesKey is not None:
-            options.k = True
-
         executer = USERENUM(username, password, domain, options.hashes, options.aesKey, options.k, options)
         executer.run()
     except Exception as e:

--- a/examples/netview.py
+++ b/examples/netview.py
@@ -479,14 +479,7 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # Init the example's logger theme
-    logger.init(options.ts)
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    logger.init(options.ts, options.debug)
 
     domain, username, password = parse_credentials(options.identity)
 

--- a/examples/ntfs-read.py
+++ b/examples/ntfs-read.py
@@ -1174,24 +1174,18 @@ class MiniShell(cmd.Cmd):
 
 def main():
     print(version.BANNER)
-    # Init the example's logger theme
-    logger.init()
     parser = argparse.ArgumentParser(add_help = True, description = "NTFS explorer (read-only)")
     parser.add_argument('volume', action='store', help='NTFS volume to open (e.g. \\\\.\\C: or /dev/disk1s1)')
     parser.add_argument('-extract', action='store', help='extracts pathname (e.g. \\windows\\system32\\config\\sam)')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
 
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
     options = parser.parse_args()
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    # Init the example's logger theme
+    logger.init(options.ts, options.debug)
 
     shell = MiniShell(options.volume)
     if options.extract is not None:

--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -442,15 +442,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     # Init the example's logger theme
-    logger.init(options.ts)
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
-        logging.getLogger('impacket.smbserver').setLevel(logging.ERROR)
+    logger.init(options.ts, options.debug)
 
     # Let's register the protocol clients we have
     # ToDo: Do this better somehow

--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -192,6 +192,7 @@ def start_servers(options, threads):
         c.setAttacks(PROTOCOL_ATTACKS)
         c.setLootdir(options.lootdir)
         c.setOutputFile(options.output_file)
+        c.setdumpHashes(options.dump_hashes)
         c.setLDAPOptions(options.no_dump, options.no_da, options.no_acl, options.no_validate_privs, options.escalate_user, options.add_computer, options.delegate_access, options.dump_laps, options.dump_gmsa, options.dump_adcs, options.sid, options.add_dns_record)
         c.setRPCOptions(options.rpc_mode, options.rpc_use_smb, options.auth_smb, options.hashes_smb, options.rpc_smb_port)
         c.setMSSQLOptions(options.query)
@@ -306,6 +307,7 @@ if __name__ == '__main__':
                     'directory in which gathered loot such as SAM dumps will be stored (default: current directory).')
     parser.add_argument('-of','--output-file', action='store',help='base output filename for encrypted hashes. Suffixes '
                                                                    'will be added for ntlm and ntlmv2')
+    parser.add_argument('-dh','--dump-hashes', action='store_true', default=False, help='show encrypted hashes in the console')
     parser.add_argument('-codec', action='store', help='Sets encoding used (codec) from the target\'s output (default '
                                                        '"%s"). If errors are detected, run chcp.com at the target, '
                                                        'map the result with '

--- a/examples/owneredit.py
+++ b/examples/owneredit.py
@@ -30,7 +30,7 @@ from impacket.ldap import ldaptypes
 from ldap3.utils.conv import escape_filter_chars
 from ldap3.protocol.microsoft import security_descriptor_control
 
-from impacket.examples.utils import init_ldap_session, EMPTY_LM_HASH
+from impacket.examples.utils import init_ldap_session, parse_identity
 
 
 # Universal SIDs
@@ -262,30 +262,6 @@ def parse_args():
     return parser.parse_args()
 
 
-def parse_identity(args):
-    domain, username, password = utils.parse_credentials(args.identity)
-
-    if domain == '':
-        logging.critical('Domain should be specified!')
-        sys.exit(1)
-
-    if password == '' and username != '' and args.hashes is None and args.no_pass is False and args.aesKey is None:
-        from getpass import getpass
-        logging.info("No credentials supplied, supply password")
-        password = getpass("Password:")
-
-    if args.aesKey is not None:
-        args.k = True
-
-    if args.hashes is not None:
-        lmhash, nthash = args.hashes.split(':')
-    else:
-        lmhash = ''
-        nthash = ''
-
-    return domain, username, password, lmhash, nthash
-
-
 def main():
     print(version.BANNER)
     args = parse_args()
@@ -299,8 +275,6 @@ def main():
         logging.critical('-file is required when using -action restore')
 
     domain, username, password, lmhash, nthash = parse_identity(args)
-    if len(nthash) > 0 and lmhash == "":
-        lmhash = EMPTY_LM_HASH
 
     try:
         ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.aesKey, args.use_ldaps)

--- a/examples/owneredit.py
+++ b/examples/owneredit.py
@@ -274,7 +274,7 @@ def main():
     if args.action == "restore" and not args.filename:
         logging.critical('-file is required when using -action restore')
 
-    domain, username, password, lmhash, nthash = parse_identity(args)
+    domain, username, password, lmhash, nthash, args.k = parse_identity(args.identity, args.hashes, args.no_pass, args.aesKey, args.k)
 
     try:
         ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.aesKey, args.use_ldaps)

--- a/examples/owneredit.py
+++ b/examples/owneredit.py
@@ -287,19 +287,6 @@ def parse_identity(args):
 
     return domain, username, password, lmhash, nthash
 
-
-def init_logger(args):
-    # Init the example's logger theme and debug level
-    logger.init(args.ts)
-    if args.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
-        logging.getLogger('impacket.smbserver').setLevel(logging.ERROR)
-
-
 def get_machine_name(args, domain):
     if args.dc_ip is not None:
         s = SMBConnection(args.dc_ip, args.dc_ip)
@@ -488,7 +475,7 @@ def init_ldap_session(args, domain, username, password, lmhash, nthash):
 def main():
     print(version.BANNER)
     args = parse_args()
-    init_logger(args)
+    logger.init(args.ts, args.debug)
 
     if args.action == 'write' and args.new_owner_sAMAccountName is None and args.new_owner_SID is None and args.new_owner_DN is None:
         logging.critical('-owner, -owner-sid, or -owner-dn should be specified when using -action write')

--- a/examples/owneredit.py
+++ b/examples/owneredit.py
@@ -21,18 +21,16 @@ import sys
 import traceback
 
 import ldap3
-import ssl
 import ldapdomaindump
-from binascii import unhexlify
 from ldap3.protocol.formatters.formatters import format_sid
 
 from impacket import version
 from impacket.examples import logger, utils
 from impacket.ldap import ldaptypes
-from impacket.smbconnection import SMBConnection
-from impacket.spnego import SPNEGO_NegTokenInit, TypesMech
 from ldap3.utils.conv import escape_filter_chars
 from ldap3.protocol.microsoft import security_descriptor_control
+
+from impacket.examples.utils import init_ldap_session
 
 
 # Universal SIDs
@@ -287,190 +285,6 @@ def parse_identity(args):
 
     return domain, username, password, lmhash, nthash
 
-def get_machine_name(args, domain):
-    if args.dc_ip is not None:
-        s = SMBConnection(args.dc_ip, args.dc_ip)
-    else:
-        s = SMBConnection(domain, domain)
-    try:
-        s.login('', '')
-    except Exception:
-        if s.getServerName() == '':
-            raise Exception('Error while anonymous logging into %s' % domain)
-    else:
-        s.logoff()
-    return s.getServerName()
-
-
-def ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='', nthash='', aesKey='', kdcHost=None, TGT=None, TGS=None, useCache=True):
-    from pyasn1.codec.ber import encoder, decoder
-    from pyasn1.type.univ import noValue
-    """
-    logins into the target system explicitly using Kerberos. Hashes are used if RC4_HMAC is supported.
-    :param string user: username
-    :param string password: password for the user
-    :param string domain: domain where the account is valid for (required)
-    :param string lmhash: LMHASH used to authenticate using hashes (password is not used)
-    :param string nthash: NTHASH used to authenticate using hashes (password is not used)
-    :param string aesKey: aes256-cts-hmac-sha1-96 or aes128-cts-hmac-sha1-96 used for Kerberos authentication
-    :param string kdcHost: hostname or IP Address for the KDC. If None, the domain will be used (it needs to resolve tho)
-    :param struct TGT: If there's a TGT available, send the structure here and it will be used
-    :param struct TGS: same for TGS. See smb3.py for the format
-    :param bool useCache: whether or not we should use the ccache for credentials lookup. If TGT or TGS are specified this is False
-    :return: True, raises an Exception if error.
-    """
-
-    if lmhash != '' or nthash != '':
-        if len(lmhash) % 2:
-            lmhash = '0' + lmhash
-        if len(nthash) % 2:
-            nthash = '0' + nthash
-        try:  # just in case they were converted already
-            lmhash = unhexlify(lmhash)
-            nthash = unhexlify(nthash)
-        except TypeError:
-            pass
-
-    # Importing down here so pyasn1 is not required if kerberos is not used.
-    from impacket.krb5.ccache import CCache
-    from impacket.krb5.asn1 import AP_REQ, Authenticator, TGS_REP, seq_set
-    from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGS
-    from impacket.krb5 import constants
-    from impacket.krb5.types import Principal, KerberosTime, Ticket
-    import datetime
-
-    if TGT is not None or TGS is not None:
-        useCache = False
-
-    target = 'ldap/%s' % target
-    if useCache:
-        domain, user, TGT, TGS = CCache.parseFile(domain, user, target)
-
-    # First of all, we need to get a TGT for the user
-    userName = Principal(user, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
-    if TGT is None:
-        if TGS is None:
-            tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, password, domain, lmhash, nthash,
-                                                                    aesKey, kdcHost)
-    else:
-        tgt = TGT['KDC_REP']
-        cipher = TGT['cipher']
-        sessionKey = TGT['sessionKey']
-
-    if TGS is None:
-        serverName = Principal(target, type=constants.PrincipalNameType.NT_SRV_INST.value)
-        tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(serverName, domain, kdcHost, tgt, cipher,
-                                                                sessionKey)
-    else:
-        tgs = TGS['KDC_REP']
-        cipher = TGS['cipher']
-        sessionKey = TGS['sessionKey']
-
-        # Let's build a NegTokenInit with a Kerberos REQ_AP
-
-    blob = SPNEGO_NegTokenInit()
-
-    # Kerberos
-    blob['MechTypes'] = [TypesMech['MS KRB5 - Microsoft Kerberos 5']]
-
-    # Let's extract the ticket from the TGS
-    tgs = decoder.decode(tgs, asn1Spec=TGS_REP())[0]
-    ticket = Ticket()
-    ticket.from_asn1(tgs['ticket'])
-
-    # Now let's build the AP_REQ
-    apReq = AP_REQ()
-    apReq['pvno'] = 5
-    apReq['msg-type'] = int(constants.ApplicationTagNumbers.AP_REQ.value)
-
-    opts = []
-    apReq['ap-options'] = constants.encodeFlags(opts)
-    seq_set(apReq, 'ticket', ticket.to_asn1)
-
-    authenticator = Authenticator()
-    authenticator['authenticator-vno'] = 5
-    authenticator['crealm'] = domain
-    seq_set(authenticator, 'cname', userName.components_to_asn1)
-    now = datetime.datetime.now(datetime.timezone.utc)
-
-    authenticator['cusec'] = now.microsecond
-    authenticator['ctime'] = KerberosTime.to_asn1(now)
-
-    encodedAuthenticator = encoder.encode(authenticator)
-
-    # Key Usage 11
-    # AP-REQ Authenticator (includes application authenticator
-    # subkey), encrypted with the application session key
-    # (Section 5.5.1)
-    encryptedEncodedAuthenticator = cipher.encrypt(sessionKey, 11, encodedAuthenticator, None)
-
-    apReq['authenticator'] = noValue
-    apReq['authenticator']['etype'] = cipher.enctype
-    apReq['authenticator']['cipher'] = encryptedEncodedAuthenticator
-
-    blob['MechToken'] = encoder.encode(apReq)
-
-    request = ldap3.operation.bind.bind_operation(connection.version, ldap3.SASL, user, None, 'GSS-SPNEGO',
-                                                  blob.getData())
-
-    # Done with the Kerberos saga, now let's get into LDAP
-    if connection.closed:  # try to open connection if closed
-        connection.open(read_server_info=False)
-
-    connection.sasl_in_progress = True
-    response = connection.post_send_single_response(connection.send('bindRequest', request, None))
-    connection.sasl_in_progress = False
-    if response[0]['result'] != 0:
-        raise Exception(response)
-
-    connection.bound = True
-
-    return True
-
-
-def init_ldap_connection(target, tls_version, args, domain, username, password, lmhash, nthash):
-    user = '%s\\%s' % (domain, username)
-    connect_to = target
-    if args.dc_ip is not None:
-        connect_to = args.dc_ip
-    if tls_version is not None:
-        use_ssl = True
-        port = 636
-        tls = ldap3.Tls(validate=ssl.CERT_NONE, version=tls_version)
-    else:
-        use_ssl = False
-        port = 389
-        tls = None
-    ldap_server = ldap3.Server(connect_to, get_info=ldap3.ALL, port=port, use_ssl=use_ssl, tls=tls)
-    if args.k:
-        ldap_session = ldap3.Connection(ldap_server)
-        ldap_session.bind()
-        ldap3_kerberos_login(ldap_session, target, username, password, domain, lmhash, nthash, args.aesKey, kdcHost=args.dc_ip)
-    elif args.hashes is not None:
-        ldap_session = ldap3.Connection(ldap_server, user=user, password=lmhash + ":" + nthash, authentication=ldap3.NTLM, auto_bind=True)
-    else:
-        ldap_session = ldap3.Connection(ldap_server, user=user, password=password, authentication=ldap3.NTLM, auto_bind=True)
-
-    return ldap_server, ldap_session
-
-
-def init_ldap_session(args, domain, username, password, lmhash, nthash):
-    if args.k:
-        target = get_machine_name(args, domain)
-    else:
-        if args.dc_ip is not None:
-            target = args.dc_ip
-        else:
-            target = domain
-
-    if args.use_ldaps is True:
-        try:
-            return init_ldap_connection(target, ssl.PROTOCOL_TLSv1_2, args, domain, username, password, lmhash, nthash)
-        except ldap3.core.exceptions.LDAPSocketOpenError:
-            return init_ldap_connection(target, ssl.PROTOCOL_TLSv1, args, domain, username, password, lmhash, nthash)
-    else:
-        return init_ldap_connection(target, None, args, domain, username, password, lmhash, nthash)
-
 
 def main():
     print(version.BANNER)
@@ -489,7 +303,7 @@ def main():
         lmhash = "aad3b435b51404eeaad3b435b51404ee"
 
     try:
-        ldap_server, ldap_session = init_ldap_session(args, domain, username, password, lmhash, nthash)
+        ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.aesKey, args.use_ldaps)
         owneredit = OwnerEdit(ldap_server, ldap_session, args)
         if args.action == 'read':
             owneredit.read()

--- a/examples/owneredit.py
+++ b/examples/owneredit.py
@@ -30,7 +30,7 @@ from impacket.ldap import ldaptypes
 from ldap3.utils.conv import escape_filter_chars
 from ldap3.protocol.microsoft import security_descriptor_control
 
-from impacket.examples.utils import init_ldap_session
+from impacket.examples.utils import init_ldap_session, EMPTY_LM_HASH
 
 
 # Universal SIDs
@@ -300,7 +300,7 @@ def main():
 
     domain, username, password, lmhash, nthash = parse_identity(args)
     if len(nthash) > 0 and lmhash == "":
-        lmhash = "aad3b435b51404eeaad3b435b51404ee"
+        lmhash = EMPTY_LM_HASH
 
     try:
         ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.aesKey, args.use_ldaps)

--- a/examples/psexec.py
+++ b/examples/psexec.py
@@ -641,7 +641,7 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # Init the example's logger theme
-    logger.init(options.ts)
+    logger.init(options.ts, options.debug)
 
     if options.codec is not None:
         CODEC = options.codec

--- a/examples/psexec.py
+++ b/examples/psexec.py
@@ -649,13 +649,6 @@ if __name__ == '__main__':
         if CODEC is None:
             CODEC = 'utf-8'
 
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
-
     domain, username, password, remoteName = parse_target(options.target)
 
     if domain is None:

--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -92,7 +92,7 @@ from impacket.dcerpc.v5.samr import NULL, GROUP_MEMBERSHIP, SE_GROUP_MANDATORY, 
 from pyasn1.codec.der import decoder, encoder
 from pyasn1.type.univ import noValue
 from impacket.examples import logger
-from impacket.examples.utils import parse_credentials
+from impacket.examples.utils import parse_identity
 from impacket.ntlm import LMOWFv1, NTOWFv1
 from impacket.dcerpc.v5.dtypes import RPC_SID, MAXIMUM_ALLOWED
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_LEVEL_PKT_PRIVACY, RPC_C_AUTHN_GSS_NEGOTIATE
@@ -1295,18 +1295,11 @@ if __name__ == '__main__':
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
 
-    domain, username, password = parse_credentials(options.target)
+    domain, username, password, _, _, options.k = parse_identity(options.target, options.hashes, options.no_pass, options.aesKey, options.k)
 
     if domain == '':
         logging.critical('Domain should be specified!')
         sys.exit(1)
-
-    if password == '' and username != '' and options.hashes is None and options.aesKey is None:
-        from getpass import getpass
-        password = getpass("Password:")
-
-    if options.aesKey is not None:
-        options.k = True
 
     commands = 'cmd.exe'
 

--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -1293,16 +1293,9 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # Init the example's logger theme
-    logger.init(options.ts)
+    logger.init(options.ts, options.debug)
 
     domain, username, password = parse_credentials(options.target)
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
 
     if domain == '':
         logging.critical('Domain should be specified!')

--- a/examples/rbcd.py
+++ b/examples/rbcd.py
@@ -310,7 +310,7 @@ def main():
         logging.critical('`-delegate-from` should be specified when using `-action write` !')
         sys.exit(1)
 
-    domain, username, password, lmhash, nthash = parse_identity(args)
+    domain, username, password, lmhash, nthash, args.k = parse_identity(args.identity, args.hashes, args.no_pass, args.aesKey, args.k)
 
     try:
         ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.aesKey, args.use_ldaps)

--- a/examples/rbcd.py
+++ b/examples/rbcd.py
@@ -32,7 +32,7 @@ from impacket.examples import logger, utils
 from impacket.ldap import ldaptypes
 from ldap3.utils.conv import escape_filter_chars
 
-from impacket.examples.utils import init_ldap_session, EMPTY_LM_HASH
+from impacket.examples.utils import init_ldap_session, parse_identity
 
 def create_empty_sd():
     sd = ldaptypes.SR_SECURITY_DESCRIPTOR()
@@ -301,32 +301,6 @@ def parse_args():
     return parser.parse_args()
 
 
-def parse_identity(args):
-    domain, username, password = utils.parse_credentials(args.identity)
-
-    if domain == '':
-        logging.critical('Domain should be specified!')
-        sys.exit(1)
-
-    if password == '' and username != '' and args.hashes is None and args.no_pass is False and args.aesKey is None:
-        from getpass import getpass
-        logging.info("No credentials supplied, supply password")
-        password = getpass("Password:")
-
-    if args.aesKey is not None:
-        args.k = True
-
-    if args.hashes is not None:
-        lmhash, nthash = args.hashes.split(':')
-        if lmhash == '':
-            lmhash = EMPTY_LM_HASH
-    else:
-        lmhash = ''
-        nthash = ''
-
-    return domain, username, password, lmhash, nthash
-
-
 def main():
     print(version.BANNER)
     args = parse_args()
@@ -337,8 +311,6 @@ def main():
         sys.exit(1)
 
     domain, username, password, lmhash, nthash = parse_identity(args)
-    if len(nthash) > 0 and lmhash == "":
-        lmhash = EMPTY_LM_HASH
 
     try:
         ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.aesKey, args.use_ldaps)

--- a/examples/rbcd.py
+++ b/examples/rbcd.py
@@ -32,7 +32,7 @@ from impacket.examples import logger, utils
 from impacket.ldap import ldaptypes
 from ldap3.utils.conv import escape_filter_chars
 
-from impacket.examples.utils import init_ldap_session
+from impacket.examples.utils import init_ldap_session, EMPTY_LM_HASH
 
 def create_empty_sd():
     sd = ldaptypes.SR_SECURITY_DESCRIPTOR()
@@ -319,7 +319,7 @@ def parse_identity(args):
     if args.hashes is not None:
         lmhash, nthash = args.hashes.split(':')
         if lmhash == '':
-            lmhash = 'aad3b435b51404eeaad3b435b51404ee'
+            lmhash = EMPTY_LM_HASH
     else:
         lmhash = ''
         nthash = ''
@@ -338,7 +338,7 @@ def main():
 
     domain, username, password, lmhash, nthash = parse_identity(args)
     if len(nthash) > 0 and lmhash == "":
-        lmhash = "aad3b435b51404eeaad3b435b51404ee"
+        lmhash = EMPTY_LM_HASH
 
     try:
         ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.aesKey, args.use_ldaps)

--- a/examples/rbcd.py
+++ b/examples/rbcd.py
@@ -471,19 +471,6 @@ def parse_identity(args):
 
     return domain, username, password, lmhash, nthash
 
-
-def init_logger(args):
-    # Init the example's logger theme and debug level
-    logger.init(args.ts)
-    if args.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
-        logging.getLogger('impacket.smbserver').setLevel(logging.ERROR)
-
-
 def init_ldap_connection(target, tls_version, args, domain, username, password, lmhash, nthash):
     user = '%s\\%s' % (domain, username)
     if tls_version is not None:
@@ -528,7 +515,7 @@ def init_ldap_session(args, domain, username, password, lmhash, nthash):
 def main():
     print(version.BANNER)
     args = parse_args()
-    init_logger(args)
+    logger.init(args.ts, args.debug)
 
     if args.action == 'write' and args.delegate_from is None:
         logging.critical('`-delegate-from` should be specified when using `-action write` !')

--- a/examples/rbcd.py
+++ b/examples/rbcd.py
@@ -24,160 +24,15 @@ import logging
 import sys
 import traceback
 import ldap3
-import ssl
 import ldapdomaindump
-from binascii import unhexlify
 from ldap3.protocol.formatters.formatters import format_sid
 
 from impacket import version
 from impacket.examples import logger, utils
 from impacket.ldap import ldaptypes
-from impacket.smbconnection import SMBConnection
-from impacket.spnego import SPNEGO_NegTokenInit, TypesMech
 from ldap3.utils.conv import escape_filter_chars
 
-
-def get_machine_name(args, domain):
-    if args.dc_ip is not None:
-        s = SMBConnection(args.dc_ip, args.dc_ip)
-    else:
-        s = SMBConnection(domain, domain)
-    try:
-        s.login('', '')
-    except Exception:
-        if s.getServerName() == '':
-            raise Exception('Error while anonymous logging into %s' % domain)
-    else:
-        s.logoff()
-    return s.getServerName()
-
-
-def ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='', nthash='', aesKey='', kdcHost=None,
-                         TGT=None, TGS=None, useCache=True):
-    from pyasn1.codec.ber import encoder, decoder
-    from pyasn1.type.univ import noValue
-    """
-    logins into the target system explicitly using Kerberos. Hashes are used if RC4_HMAC is supported.
-    :param string user: username
-    :param string password: password for the user
-    :param string domain: domain where the account is valid for (required)
-    :param string lmhash: LMHASH used to authenticate using hashes (password is not used)
-    :param string nthash: NTHASH used to authenticate using hashes (password is not used)
-    :param string aesKey: aes256-cts-hmac-sha1-96 or aes128-cts-hmac-sha1-96 used for Kerberos authentication
-    :param string kdcHost: hostname or IP Address for the KDC. If None, the domain will be used (it needs to resolve tho)
-    :param struct TGT: If there's a TGT available, send the structure here and it will be used
-    :param struct TGS: same for TGS. See smb3.py for the format
-    :param bool useCache: whether or not we should use the ccache for credentials lookup. If TGT or TGS are specified this is False
-    :return: True, raises an Exception if error.
-    """
-
-    if lmhash != '' or nthash != '':
-        if len(lmhash) % 2:
-            lmhash = '0' + lmhash
-        if len(nthash) % 2:
-            nthash = '0' + nthash
-        try:  # just in case they were converted already
-            lmhash = unhexlify(lmhash)
-            nthash = unhexlify(nthash)
-        except TypeError:
-            pass
-
-    # Importing down here so pyasn1 is not required if kerberos is not used.
-    from impacket.krb5.ccache import CCache
-    from impacket.krb5.asn1 import AP_REQ, Authenticator, TGS_REP, seq_set
-    from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGS
-    from impacket.krb5 import constants
-    from impacket.krb5.types import Principal, KerberosTime, Ticket
-    import datetime
-
-    if TGT is not None or TGS is not None:
-        useCache = False
-
-    target = 'ldap/%s' % target
-    if useCache:
-        domain, user, TGT, TGS = CCache.parseFile(domain, user, target)
-
-    # First of all, we need to get a TGT for the user
-    userName = Principal(user, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
-    if TGT is None:
-        if TGS is None:
-            tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, password, domain, lmhash, nthash,
-                                                                    aesKey, kdcHost)
-    else:
-        tgt = TGT['KDC_REP']
-        cipher = TGT['cipher']
-        sessionKey = TGT['sessionKey']
-
-    if TGS is None:
-        serverName = Principal(target, type=constants.PrincipalNameType.NT_SRV_INST.value)
-        tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(serverName, domain, kdcHost, tgt, cipher,
-                                                                sessionKey)
-    else:
-        tgs = TGS['KDC_REP']
-        cipher = TGS['cipher']
-        sessionKey = TGS['sessionKey']
-
-        # Let's build a NegTokenInit with a Kerberos REQ_AP
-
-    blob = SPNEGO_NegTokenInit()
-
-    # Kerberos
-    blob['MechTypes'] = [TypesMech['MS KRB5 - Microsoft Kerberos 5']]
-
-    # Let's extract the ticket from the TGS
-    tgs = decoder.decode(tgs, asn1Spec=TGS_REP())[0]
-    ticket = Ticket()
-    ticket.from_asn1(tgs['ticket'])
-
-    # Now let's build the AP_REQ
-    apReq = AP_REQ()
-    apReq['pvno'] = 5
-    apReq['msg-type'] = int(constants.ApplicationTagNumbers.AP_REQ.value)
-
-    opts = []
-    apReq['ap-options'] = constants.encodeFlags(opts)
-    seq_set(apReq, 'ticket', ticket.to_asn1)
-
-    authenticator = Authenticator()
-    authenticator['authenticator-vno'] = 5
-    authenticator['crealm'] = domain
-    seq_set(authenticator, 'cname', userName.components_to_asn1)
-    now = datetime.datetime.now(datetime.timezone.utc)
-
-    authenticator['cusec'] = now.microsecond
-    authenticator['ctime'] = KerberosTime.to_asn1(now)
-
-    encodedAuthenticator = encoder.encode(authenticator)
-
-    # Key Usage 11
-    # AP-REQ Authenticator (includes application authenticator
-    # subkey), encrypted with the application session key
-    # (Section 5.5.1)
-    encryptedEncodedAuthenticator = cipher.encrypt(sessionKey, 11, encodedAuthenticator, None)
-
-    apReq['authenticator'] = noValue
-    apReq['authenticator']['etype'] = cipher.enctype
-    apReq['authenticator']['cipher'] = encryptedEncodedAuthenticator
-
-    blob['MechToken'] = encoder.encode(apReq)
-
-    request = ldap3.operation.bind.bind_operation(connection.version, ldap3.SASL, user, None, 'GSS-SPNEGO',
-                                                  blob.getData())
-
-    # Done with the Kerberos saga, now let's get into LDAP
-    if connection.closed:  # try to open connection if closed
-        connection.open(read_server_info=False)
-
-    connection.sasl_in_progress = True
-    response = connection.post_send_single_response(connection.send('bindRequest', request, None))
-    connection.sasl_in_progress = False
-    if response[0]['result'] != 0:
-        raise Exception(response)
-
-    connection.bound = True
-
-    return True
-
+from impacket.examples.utils import init_ldap_session
 
 def create_empty_sd():
     sd = ldaptypes.SR_SECURITY_DESCRIPTOR()
@@ -471,46 +326,6 @@ def parse_identity(args):
 
     return domain, username, password, lmhash, nthash
 
-def init_ldap_connection(target, tls_version, args, domain, username, password, lmhash, nthash):
-    user = '%s\\%s' % (domain, username)
-    if tls_version is not None:
-        use_ssl = True
-        port = 636
-        tls = ldap3.Tls(validate=ssl.CERT_NONE, version=tls_version, ciphers='ALL:@SECLEVEL=0')
-    else:
-        use_ssl = False
-        port = 389
-        tls = None
-    ldap_server = ldap3.Server(target, get_info=ldap3.ALL, port=port, use_ssl=use_ssl, tls=tls)
-    if args.k:
-        ldap_session = ldap3.Connection(ldap_server)
-        ldap_session.bind()
-        ldap3_kerberos_login(ldap_session, target, username, password, domain, lmhash, nthash, args.aesKey, kdcHost=args.dc_ip)
-    elif args.hashes is not None:
-        ldap_session = ldap3.Connection(ldap_server, user=user, password=lmhash + ":" + nthash, authentication=ldap3.NTLM, auto_bind=True)
-    else:
-        ldap_session = ldap3.Connection(ldap_server, user=user, password=password, authentication=ldap3.NTLM, auto_bind=True)
-
-    return ldap_server, ldap_session
-
-
-def init_ldap_session(args, domain, username, password, lmhash, nthash):
-    if args.k:
-        target = get_machine_name(args, domain)
-    else:
-        if args.dc_ip is not None:
-            target = args.dc_ip
-        else:
-            target = domain
-
-    if args.use_ldaps is True:
-        try:
-            return init_ldap_connection(target, ssl.PROTOCOL_TLSv1_2, args, domain, username, password, lmhash, nthash)
-        except ldap3.core.exceptions.LDAPSocketOpenError:
-            return init_ldap_connection(target, ssl.PROTOCOL_TLSv1, args, domain, username, password, lmhash, nthash)
-    else:
-        return init_ldap_connection(target, None, args, domain, username, password, lmhash, nthash)
-
 
 def main():
     print(version.BANNER)
@@ -526,7 +341,7 @@ def main():
         lmhash = "aad3b435b51404eeaad3b435b51404ee"
 
     try:
-        ldap_server, ldap_session = init_ldap_session(args, domain, username, password, lmhash, nthash)
+        ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.aesKey, args.use_ldaps)
         rbcd = RBCD(ldap_server, ldap_session, args.delegate_to)
         if args.action == 'read':
             rbcd.read()

--- a/examples/rdp_check.py
+++ b/examples/rdp_check.py
@@ -546,14 +546,14 @@ if __name__ == '__main__':
        tls.close()
        logging.info("Access Granted")
 
-    # Init the example's logger theme
-    logger.init()
     print(version.BANNER)
 
     parser = argparse.ArgumentParser(add_help = True, description = "Test whether an account is valid on the target "
                                                                     "host using the RDP protocol.")
 
     parser.add_argument('target', action='store', help='[[domain/]username[:password]@]<targetName or address>')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
+    parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
 
     group = parser.add_argument_group('authentication')
 
@@ -563,6 +563,8 @@ if __name__ == '__main__':
         sys.exit(1)
  
     options = parser.parse_args()
+    # Init the example's logger theme
+    logger.init(options.ts, options.debug)
 
     domain, username, password, address = parse_target(options.target)
 

--- a/examples/reg.py
+++ b/examples/reg.py
@@ -528,8 +528,6 @@ class RegHandler:
 
 if __name__ == '__main__':
 
-    # Init the example's logger theme
-    logger.init()
     # Explicitly changing the stdout encoding format
     if sys.stdout.encoding is None:
         # Output is redirected to a file
@@ -540,6 +538,7 @@ if __name__ == '__main__':
 
     parser.add_argument('target', action='store', help='[[domain/]username[:password]@]<targetName or address>')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     subparsers = parser.add_subparsers(help='actions', dest='action')
 
     # A query command
@@ -648,13 +647,8 @@ if __name__ == '__main__':
         sys.exit(1)
 
     options = parser.parse_args()
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    # Init the example's logger theme
+    logger.init(options.ts, options.debug)
 
     domain, username, password, remoteName = parse_target(options.target)
 

--- a/examples/registry-read.py
+++ b/examples/registry-read.py
@@ -119,12 +119,12 @@ def walk(reg, keyName):
 
 
 def main():
-    # Init the example's logger theme
-    logger.init()
     print(version.BANNER)
 
     parser = argparse.ArgumentParser(add_help = True, description = "Reads data from registry hives.")
 
+    parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('hive', action='store', help='registry hive to open')
     subparsers = parser.add_subparsers(help='actions', dest='action')
     # A enum_key command
@@ -153,6 +153,8 @@ def main():
         sys.exit(1)
 
     options = parser.parse_args()
+    # Init the example's logger theme
+    logger.init(options.ts, options.debug)
 
     reg = winregistry.Registry(options.hive)
 

--- a/examples/regsecrets.py
+++ b/examples/regsecrets.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright (C) 2022 Fortra. All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+# Description:
+#   Performs various techniques to dump hashes from the
+#   remote machine without executing any agent there.
+#   For SAM and LSA Secrets (including cached creds)
+#   we try to read as much as we can from the registry
+#   and then we save the hives in the target system
+#   (%SYSTEMROOT%\\Temp dir) and read the rest of the
+#   data from there.
+#   For NTDS.dit we either:
+#       a. Get the domain users list and get its hashes
+#          and Kerberos keys using [MS-DRDS] DRSGetNCChanges()
+#          call, replicating just the attributes we need.
+#       b. Extract NTDS.dit via vssadmin executed  with the
+#          smbexec approach.
+#          It's copied on the temp dir and parsed remotely.
+#
+#   The script initiates the services required for its working
+#   if they are not available (e.g. Remote Registry, even if it is
+#   disabled). After the work is done, things are restored to the
+#   original state.
+#
+# Authors:
+#   Alberto Solino (@agsolino)
+#   Julien Egloff (@laxaa)
+#
+# References:
+#   Most of the work done by these guys. I just put all
+#   the pieces together, plus some extra magic.
+#
+#   - https://github.com/gentilkiwi/kekeo/tree/master/dcsync
+#   - https://moyix.blogspot.com.ar/2008/02/syskey-and-sam.html
+#   - https://moyix.blogspot.com.ar/2008/02/decrypting-lsa-secrets.html
+#   - https://moyix.blogspot.com.ar/2008/02/cached-domain-credentials.html
+#   - https://web.archive.org/web/20130901115208/www.quarkslab.com/en-blog+read+13
+#   - https://code.google.com/p/creddump/
+#   - https://lab.mediaservice.net/code/cachedump.rb
+#   - https://insecurety.net/?p=768
+#   - https://web.archive.org/web/20190717124313/http://www.beginningtoseethelight.org/ntsecurity/index.htm
+#   - https://www.exploit-db.com/docs/english/18244-active-domain-offline-hash-dump-&-forensic-analysis.pdf
+#   - https://www.passcape.com/index.php?section=blog&cmd=details&id=15
+#
+
+import argparse
+import codecs
+import logging
+import sys
+
+from impacket import version
+from impacket.examples import logger
+from impacket.examples.utils import parse_target
+from impacket.smbconnection import SMBConnection
+from impacket.examples.regsecrets import LSASecrets, RemoteOperations, SAMHashes
+
+from impacket.krb5.keytab import Keytab
+from binascii import unhexlify, hexlify
+
+class DumpSecrets:
+    def __init__(self, remoteName, username='', password='', domain='', options=None):
+        self.__remoteName = remoteName
+        self.__remoteHost = options.target_ip
+        self.__username = username
+        self.__password = password
+        self.__domain = domain
+        self.__lmhash = ''
+        self.__nthash = ''
+        self.__outputFileName = options.outputfile
+        self.__aesKey = options.aesKey
+        self.__smbConnection = None
+        self.__remoteOps = None
+        self.__SAMHashes = None
+        self.__LSASecrets = None
+        self.__bootkey = options.bootkey
+        self.__doKerberos = options.k
+        self.__history = options.history
+        self.__kdcHost = options.dc_ip
+        self.__nosam = options.nosam
+        self.__nocache = options.nocache
+        self.__nolsa = options.nolsa
+        self.__throttle = options.throttle
+
+        if options.hashes is not None:
+            self.__lmhash, self.__nthash = options.hashes.split(':')
+
+    def connect(self):
+        self.__smbConnection = SMBConnection(self.__remoteName, self.__remoteHost)
+        if self.__doKerberos:
+            self.__smbConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash,
+                                               self.__nthash, self.__aesKey, self.__kdcHost)
+        else:
+            self.__smbConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
+
+    def dump(self):
+        try:
+            bootKey = None
+            try:
+                self.connect()
+                self.__remoteOps  = RemoteOperations(self.__smbConnection, self.__doKerberos, self.__kdcHost)
+                self.__remoteOps.enableRegistry()
+            except Exception as e:
+                logging.error('RemoteOperations failed: %s' % str(e))
+            if not self.__bootkey:
+                try:
+                    bootKey = self.__remoteOps.getBootKey()
+                except Exception as e:
+                    logging.error('RemoteOperations failed: %s' % str(e))
+            else:
+                if self.__bootkey.startswith('0x'):
+                    self.__bootkey = self.__bootkey[2:]
+                bootKey = unhexlify(self.__bootkey)
+                logging.info('Target system bootKey: 0x%s' % hexlify(bootKey).decode('utf-8'))
+
+            if bootKey is None:
+                raise Exception('Failed to fetch bootKey')
+
+            if not self.__nosam:
+                try:
+                    self.__SAMHashes = SAMHashes(bootKey, remoteOps=self.__remoteOps, throttle=self.__throttle)
+                    self.__SAMHashes.dump()
+                    if self.__outputFileName is not None:
+                        self.__SAMHashes.export(self.__outputFileName)
+                except Exception as e:
+                    if logging.getLogger().level == logging.DEBUG:
+                        import traceback
+                        traceback.print_exc()
+                    logging.error('SAM hashes extraction failed: %s' % str(e))
+
+            try:
+                self.__LSASecrets = LSASecrets(bootKey, self.__remoteOps,
+                                                 history=self.__history, throttle=self.__throttle)
+                if not self.__nocache:
+                    self.__LSASecrets.dumpCachedHashes()
+                    if self.__outputFileName is not None:
+                        self.__LSASecrets.exportCached(self.__outputFileName)
+                if not self.__nolsa:
+                    self.__LSASecrets.dumpSecrets()
+                    if self.__outputFileName is not None:
+                        self.__LSASecrets.exportSecrets(self.__outputFileName)
+            except Exception as e:
+                if logging.getLogger().level == logging.DEBUG:
+                    import traceback
+                    traceback.print_exc()
+                logging.error('LSA hashes extraction failed: %s' % str(e))
+
+            self.cleanup()
+        except (Exception, KeyboardInterrupt) as e:
+            if logging.getLogger().level == logging.DEBUG:
+                import traceback
+                traceback.print_exc()
+            logging.error(e)
+            try:
+                self.cleanup()
+            except:
+                logging.info('Failed to perform cleanup...')
+                pass
+
+    def cleanup(self):
+        logging.info('Cleaning up... ')
+        if self.__remoteOps:
+            self.__remoteOps.finish()
+        self.__smbConnection.logoff()
+
+# Process command-line arguments.
+if __name__ == '__main__':
+    # Explicitly changing the stdout encoding format
+    if sys.stdout.encoding is None:
+        # Output is redirected to a file
+        sys.stdout = codecs.getwriter('utf8')(sys.stdout)
+
+    print(version.BANNER)
+
+    parser = argparse.ArgumentParser(add_help = True, description = "Performs various techniques to dump secrets from "
+                                                      "the remote machine without executing any agent there.")
+
+    parser.add_argument('target', action='store', help='[[domain/]username[:password]@]<targetName or address>')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
+    parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-system', action='store', help='SYSTEM hive to parse')
+    parser.add_argument('-bootkey', action='store', help='bootkey for SYSTEM hive')
+    parser.add_argument('-nosam', action='store_true', help='Do not retrieve SAM information', default=False)
+    parser.add_argument('-nocache', action='store_true', help='Do not retrieve MSCache information', default=False)
+    parser.add_argument('-nolsa', action='store_true', help='Do not retrieve LSASecrets', default=False)
+    parser.add_argument('-throttle', action='store', help='Throttle in seconds between operations', default=0, type=int)
+    parser.add_argument('-outputfile', action='store',
+                        help='base output filename. Extensions will be added for sam, secrets and cached')
+
+    group = parser.add_argument_group('display options')
+    group.add_argument('-history', action='store_true', help='Dump password history, and LSA secrets OldVal')
+
+    group = parser.add_argument_group('authentication')
+    group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
+    group.add_argument('-no-pass', action="store_true", help='don\'t ask for password (useful for -k)')
+    group.add_argument('-k', action="store_true", help='Use Kerberos authentication. Grabs credentials from ccache file '
+                             '(KRB5CCNAME) based on target parameters. If valid credentials cannot be found, it will use'
+                             ' the ones specified in the command line')
+    group.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key to use for Kerberos Authentication'
+                                                                            ' (128 or 256 bits)')
+    group.add_argument('-keytab', action="store", help='Read keys for SPN from keytab file')
+
+    group = parser.add_argument_group('connection')
+    group.add_argument('-dc-ip', action='store',metavar = "ip address",  help='IP Address of the domain controller. If '
+                                 'ommited it use the domain part (FQDN) specified in the target parameter')
+    group.add_argument('-target-ip', action='store', metavar="ip address",
+                       help='IP Address of the target machine. If omitted it will use whatever was specified as target. '
+                            'This is useful when target is the NetBIOS name and you cannot resolve it')
+
+    if len(sys.argv)==1:
+        parser.print_help()
+        sys.exit(1)
+
+    options = parser.parse_args()
+
+    # Init the example's logger theme
+    logger.init(options.ts)
+
+    if options.debug is True:
+        logging.getLogger().setLevel(logging.DEBUG)
+        # Print the Library's installation path
+        logging.debug(version.getInstallationPath())
+    else:
+        logging.getLogger().setLevel(logging.INFO)
+
+    domain, username, password, remoteName = parse_target(options.target)
+
+    if options.target_ip is None:
+        options.target_ip = remoteName
+
+    if domain is None:
+        domain = ''
+
+    if options.keytab is not None:
+        Keytab.loadKeysFromKeytab(options.keytab, username, domain, options)
+        options.k = True
+
+    if password == '' and username != '' and options.hashes is None and options.no_pass is False and options.aesKey is None:
+        from getpass import getpass
+
+        password = getpass("Password:")
+
+    if options.aesKey is not None:
+        options.k = True
+
+    dumper = DumpSecrets(remoteName, username, password, domain, options)
+    try:
+        dumper.dump()
+    except Exception as e:
+        if logging.getLogger().level == logging.DEBUG:
+            import traceback
+            traceback.print_exc()
+        logging.error(e)

--- a/examples/rpcdump.py
+++ b/examples/rpcdump.py
@@ -167,13 +167,12 @@ class RPCDump:
 
 # Process command-line arguments.
 if __name__ == '__main__':
-    # Init the example's logger theme
-    logger.init()
     print(version.BANNER)
 
     parser = argparse.ArgumentParser(add_help = True, description = "Dumps the remote RPC enpoints information via epmapper.")
     parser.add_argument('target', action='store', help='[[domain/]username[:password]@]<targetName or address>')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
 
     group = parser.add_argument_group('connection')
 
@@ -191,13 +190,8 @@ if __name__ == '__main__':
         sys.exit(1)
  
     options = parser.parse_args()
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    # Init the example's logger theme
+    logger.init(options.ts, options.debug)
 
     domain, username, password, remoteName = parse_target(options.target)
 

--- a/examples/rpcmap.py
+++ b/examples/rpcmap.py
@@ -39,7 +39,7 @@ import argparse
 
 from impacket.http import AUTH_BASIC
 from impacket.examples import logger, rpcdatabase
-from impacket.examples.utils import parse_credentials
+from impacket.examples.utils import parse_identity
 from impacket import uuid, version
 from impacket.dcerpc.v5.epm import KNOWN_UUIDS
 from impacket.dcerpc.v5 import transport, rpcrt, epm
@@ -324,26 +324,12 @@ if __name__ == '__main__':
     # Init the example's logger theme
     logger.init(options.ts, options.debug)
 
-    rpcdomain, rpcuser, rpcpass = parse_credentials(options.auth_rpc)
-    transportdomain, transportuser, transportpass = parse_credentials(options.auth_transport)
+    rpcdomain, rpcuser, rpcpass, _, _, _ = parse_identity(options.auth_rpc, options.hashes_rpc, options.no_pass, getpass_msg='Password for MSRPC communication:')
+    transportdomain, transportuser, transportpass, _, _, _ = parse_identity(options.auth_rpc, options.hashes_rpc, options.no_pass, getpass_msg='Password for RPC transport (SMB or HTTP):')
 
     if options.brute_opnums and options.brute_versions:
        logging.error("Specify only -brute-opnums or -brute-versions")
        sys.exit(1)
-
-    if rpcdomain is None:
-        rpcdomain = ''
-
-    if transportdomain is None:
-        transportdomain = ''
-
-    if rpcpass == '' and rpcuser != '' and options.hashes_rpc is None and options.no_pass is False:
-         from getpass import getpass
-         rpcpass = getpass("Password for MSRPC communication:")
-
-    if transportpass == '' and transportuser != '' and options.hashes_transport is None and options.no_pass is False:
-        from getpass import getpass
-        transportpass = getpass("Password for RPC transport (SMB or HTTP):")
 
     if options.uuid is not None:
         uuids = [uuid.string_to_uuidtup(options.uuid)]

--- a/examples/rpcmap.py
+++ b/examples/rpcmap.py
@@ -273,8 +273,6 @@ class RPCMap():
         print()
 
 if __name__ == '__main__':
-    # Init the example's logger theme
-    logger.init()
     print(version.BANNER)
 
     class SmartFormatter(argparse.HelpFormatter):
@@ -301,6 +299,7 @@ if __name__ == '__main__':
                                                                                  '(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)')
     parser.add_argument('-uuid', action='store', help='Test only this UUID')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
 
     group = parser.add_argument_group('ncacn-np-details')
 
@@ -322,13 +321,8 @@ if __name__ == '__main__':
         sys.exit(1)
  
     options = parser.parse_args()
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    # Init the example's logger theme
+    logger.init(options.ts, options.debug)
 
     rpcdomain, rpcuser, rpcpass = parse_credentials(options.auth_rpc)
     transportdomain, transportuser, transportpass = parse_credentials(options.auth_transport)

--- a/examples/sambaPipe.py
+++ b/examples/sambaPipe.py
@@ -200,8 +200,6 @@ class PIPEDREAM:
 
 # Process command-line arguments.
 if __name__ == '__main__':
-    # Init the example's logger theme
-    logger.init()
     print(version.BANNER)
 
     parser = argparse.ArgumentParser(add_help=True, description="Samba Pipe exploit")
@@ -209,6 +207,7 @@ if __name__ == '__main__':
     parser.add_argument('target', action='store', help='[[domain/]username[:password]@]<targetName or address>')
     parser.add_argument('-so', action='store', required = True, help='so filename to upload and load')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
 
     group = parser.add_argument_group('authentication')
 
@@ -238,13 +237,8 @@ if __name__ == '__main__':
         sys.exit(1)
 
     options = parser.parse_args()
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    # Init the example's logger theme
+    logger.init(options.ts, options.debug)
 
     domain, username, password, address = parse_target(options.target)
 

--- a/examples/samrdump.py
+++ b/examples/samrdump.py
@@ -237,14 +237,7 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # Init the example's logger theme
-    logger.init(options.ts)
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    logger.init(options.ts, options.debug)
 
     domain, username, password, remoteName = parse_target(options.target)
 

--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -468,14 +468,7 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # Init the example's logger theme
-    logger.init(options.ts)
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    logger.init(options.ts, options.debug)
 
     domain, username, password, remoteName = parse_target(options.target)
 

--- a/examples/services.py
+++ b/examples/services.py
@@ -249,9 +249,6 @@ class SVCCTL:
 
 # Process command-line arguments.
 if __name__ == '__main__':
-
-    # Init the example's logger theme
-    logger.init()
     # Explicitly changing the stdout encoding format
     if sys.stdout.encoding is None:
         # Output is redirected to a file
@@ -262,6 +259,7 @@ if __name__ == '__main__':
 
     parser.add_argument('target', action='store', help='[[domain/]username[:password]@]<targetName or address>')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     subparsers = parser.add_subparsers(help='actions', dest='action')
  
     # A start command
@@ -330,13 +328,8 @@ if __name__ == '__main__':
         sys.exit(1)
 
     options = parser.parse_args()
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    # Init the example's logger theme
+    logger.init(options.ts, options.debug)
 
     domain, username, password, remoteName = parse_target(options.target)
 

--- a/examples/smbclient.py
+++ b/examples/smbclient.py
@@ -31,8 +31,6 @@ from impacket import version
 from impacket.smbconnection import SMBConnection
 
 def main():
-    # Init the example's logger theme
-    logger.init()
     print(version.BANNER)
     parser = argparse.ArgumentParser(add_help = True, description = "SMB client implementation.")
 
@@ -40,6 +38,7 @@ def main():
     parser.add_argument('-inputfile', type=argparse.FileType('r'), help='input file with commands to execute in the mini shell')
     parser.add_argument('-outputfile', action='store', help='Output file to log smbclient actions in')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
 
     group = parser.add_argument_group('authentication')
 
@@ -68,13 +67,8 @@ def main():
         sys.exit(1)
 
     options = parser.parse_args()
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    # Init the example's logger theme
+    logger.init(options.ts, options.debug)
 
     domain, username, password, address = parse_target(options.target)
 

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -367,20 +367,13 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # Init the example's logger theme
-    logger.init(options.ts)
+    logger.init(options.ts, options.debug)
 
     if options.codec is not None:
         CODEC = options.codec
     else:
         if CODEC is None:
             CODEC = 'utf-8'
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
 
     domain, username, password, remoteName = parse_target(options.target)
 

--- a/examples/smbserver.py
+++ b/examples/smbserver.py
@@ -57,14 +57,7 @@ if __name__ == '__main__':
        logging.critical(str(e))
        sys.exit(1)
 
-    logger.init(options.ts)
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    logger.init(options.ts, options.debug)
 
     if options.comment is None:
         comment = ''

--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -1162,14 +1162,7 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # Init the example's logger theme
-    logger.init(options.ts)
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    logger.init(options.ts, options.debug)
 
     if options.domain is None:
         logging.critical('Domain should be specified!')

--- a/examples/tstool.py
+++ b/examples/tstool.py
@@ -536,9 +536,6 @@ class TSHandler:
     
 
 if __name__ == '__main__':
-
-    # Init the example's logger theme
-    logger.init()
     # Explicitly changing the stdout encoding format
     if sys.stdout.encoding is None:
         # Output is redirected to a file
@@ -549,6 +546,7 @@ if __name__ == '__main__':
 
     parser.add_argument('target', action='store', help='[[domain/]username[:password]@]<targetName or address>')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     subparsers = parser.add_subparsers(help='actions', dest='action')
 
     # qwinsta: Display information about Remote Desktop Services sessions.
@@ -624,18 +622,13 @@ if __name__ == '__main__':
 
     options = parser.parse_args()
 
+    # Init the example's logger theme
+    logger.init(options.ts, options.debug)
+
     if options.action is None:
         parser.print_help()
         LOG.error('Too few arguments...')
         sys.exit(1)
-
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
 
     domain, username, password, remoteName = parse_target(options.target)
 

--- a/examples/wmiexec.py
+++ b/examples/wmiexec.py
@@ -406,7 +406,7 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # Init the example's logger theme
-    logger.init(options.ts)
+    logger.init(options.ts, options.debug)
 
     if options.codec is not None:
         CODEC = options.codec
@@ -420,13 +420,6 @@ if __name__ == '__main__':
     if options.silentcommand and options.command == ' ':
         logging.error("-silentcommand switch and interactive shell not supported")
         sys.exit(1)
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
 
     if options.com_version is not None:
         try:

--- a/examples/wmipersist.py
+++ b/examples/wmipersist.py
@@ -166,8 +166,6 @@ class WMIPERSISTENCE:
 
 # Process command-line arguments.
 if __name__ == '__main__':
-    # Init the example's logger theme
-    logger.init()
     print(version.BANNER)
 
     parser = argparse.ArgumentParser(add_help = True, description = "Creates/Removes a WMI Event Consumer/Filter and "
@@ -175,6 +173,7 @@ if __name__ == '__main__':
 
     parser.add_argument('target', action='store', help='[domain/][username[:password]@]<address>')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-com-version', action='store', metavar = "MAJOR_VERSION:MINOR_VERSION", help='DCOM version, '
                         'format is MAJOR_VERSION:MINOR_VERSION e.g. 5.7')
     subparsers = parser.add_subparsers(help='actions', dest='action')
@@ -210,13 +209,8 @@ if __name__ == '__main__':
         sys.exit(1)
 
     options = parser.parse_args()
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    # Init the example's logger theme
+    logger.init(options.ts, options.debug)
 
     if options.com_version is not None:
         try:

--- a/examples/wmiquery.py
+++ b/examples/wmiquery.py
@@ -127,8 +127,6 @@ if __name__ == '__main__':
         def do_exit(self, line):
             return True
 
-    # Init the example's logger theme
-    logger.init()
     print(version.BANNER)
 
     parser = argparse.ArgumentParser(add_help = True, description = "Executes WQL queries and gets object descriptions "
@@ -137,6 +135,7 @@ if __name__ == '__main__':
     parser.add_argument('-namespace', action='store', default='//./root/cimv2', help='namespace name (default //./root/cimv2)')
     parser.add_argument('-file', type=argparse.FileType('r'), help='input file with commands to execute in the WQL shell')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-com-version', action='store', metavar = "MAJOR_VERSION:MINOR_VERSION", help='DCOM version, '
                         'format is MAJOR_VERSION:MINOR_VERSION e.g. 5.7')
 
@@ -161,13 +160,8 @@ if __name__ == '__main__':
         sys.exit(1)
  
     options = parser.parse_args()
-
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
+    # Init the example's logger theme
+    logger.init(options.ts, options.debug)
 
     if options.com_version is not None:
         try:

--- a/impacket/examples/logger.py
+++ b/impacket/examples/logger.py
@@ -16,6 +16,7 @@
 
 import logging
 import sys
+from impacket import version
 
 # This module can be used by scripts using the Impacket library 
 # in order to configure the root logger to output events 
@@ -53,12 +54,21 @@ class ImpacketFormatterTimeStamp(ImpacketFormatter):
   def formatTime(self, record, datefmt=None):
       return ImpacketFormatter.formatTime(self, record, datefmt="%Y-%m-%d %H:%M:%S")
 
-def init(ts=False):
+def init(ts=False, debug=False):
     # We add a StreamHandler and formatter to the root logger
     handler = logging.StreamHandler(sys.stdout)
-    if not ts:
-        handler.setFormatter(ImpacketFormatter())
-    else:
+
+    if ts:
         handler.setFormatter(ImpacketFormatterTimeStamp())
+    else:
+        handler.setFormatter(ImpacketFormatter())
+
     logging.getLogger().addHandler(handler)
-    logging.getLogger().setLevel(logging.INFO)
+
+    if debug is True:
+        logging.getLogger().setLevel(logging.DEBUG)
+        # Print the Library's installation path
+        logging.debug(version.getInstallationPath())
+    else:
+        logging.getLogger().setLevel(logging.INFO)
+        logging.getLogger('impacket.smbserver').setLevel(logging.ERROR)

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -480,6 +480,9 @@ class HTTPRelayServer(Thread):
                                                         authenticateMessage['lanman'], authenticateMessage['ntlm'])
                     self.client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
 
+                    if self.server.config.dumpHashes is True:
+                        LOG.info(ntlm_hash_data['hash_string'])
+
                     if self.server.config.outputFile is not None:
                         writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
                                               self.server.config.outputFile)

--- a/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
@@ -130,6 +130,9 @@ class RAWRelayServer(Thread):
                                                         authenticateMessage['lanman'], authenticateMessage['ntlm'])
                     self.client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
 
+                    if self.server.config.dumpHashes is True:
+                        LOG.info(ntlm_hash_data['hash_string'])
+
                     if self.server.config.outputFile is not None:
                         writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
                                               self.server.config.outputFile)

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -91,6 +91,11 @@ class SMBRelayServer(Thread):
         if self.config.outputFile is not None:
             smbConfig.set('global','jtr_dump_path',self.config.outputFile)
 
+        if self.config.dumpHashes is True:
+            smbConfig.set("global", "dump_hashes", "True")
+        else:
+            smbConfig.set("global", "dump_hashes", "False")
+        
         if self.config.SMBServerChallenge is not None:
             smbConfig.set('global', 'challenge', self.config.SMBServerChallenge)
 
@@ -372,6 +377,9 @@ class SMBRelayServer(Thread):
                                                     authenticateMessage['domain_name'], authenticateMessage['lanman'],
                                                     authenticateMessage['ntlm'])
                 client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
+
+                if self.server.getDumpHashes():
+                    LOG.info(ntlm_hash_data['hash_string'])
 
                 if self.server.getJTRdumpPath() != '':
                     writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
@@ -667,6 +675,9 @@ class SMBRelayServer(Thread):
                                                         authenticateMessage['lanman'], authenticateMessage['ntlm'])
                     client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
 
+                    if self.server.getDumpHashes():
+                        LOG.info(ntlm_hash_data['hash_string'])
+
                     if self.server.getJTRdumpPath() != '':
                         writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
                                               self.server.getJTRdumpPath())
@@ -741,6 +752,9 @@ class SMBRelayServer(Thread):
                 ntlm_hash_data = outputToJohnFormat('', sessionSetupData['Account'], sessionSetupData['PrimaryDomain'],
                                                     sessionSetupData['AnsiPwd'], sessionSetupData['UnicodePwd'])
                 client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
+
+                if self.server.getDumpHashes():
+                    LOG.info(ntlm_hash_data['hash_string'])
 
                 if self.server.getJTRdumpPath() != '':
                     writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],

--- a/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
@@ -270,6 +270,9 @@ class WCFRelayServer(Thread):
                                                 authenticateMessage['lanman'], authenticateMessage['ntlm'])
             self.client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
 
+            if self.server.config.dumpHashes is True:
+                LOG.info(ntlm_hash_data['hash_string'])
+
             if self.server.config.outputFile is not None:
                 writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
                                       self.server.config.outputFile)

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -38,6 +38,7 @@ class NTLMRelayxConfig:
         self.mode = None
         self.redirecthost = None
         self.outputFile = None
+        self.dumpHashes = False
         self.attacks = None
         self.lootdir = None
         self.randomtargets = False
@@ -132,6 +133,9 @@ class NTLMRelayxConfig:
 
     def setOutputFile(self, outputFile):
         self.outputFile = outputFile
+
+    def setdumpHashes(self, dumpHashes):
+        self.dumpHashes = dumpHashes
 
     def setTargets(self, target):
         self.target = target

--- a/impacket/examples/regsecrets.py
+++ b/impacket/examples/regsecrets.py
@@ -754,7 +754,7 @@ class LSASecrets():
             self.__secretItems.append(extrasecret)
             self.__perSecretCallback(LSASecrets.SECRET_TYPE.LSA, extrasecret)
 
-        elif re.match('^L\$_SQSA_(S-[0-9]-[0-9]-([0-9])+-([0-9])+-([0-9])+-([0-9])+-([0-9])+)$', upperName) is not None:
+        elif re.match(r'^L\$_SQSA_(S-[0-9]-[0-9]-([0-9])+-([0-9])+-([0-9])+-([0-9])+-([0-9])+)$', upperName) is not None:
             # Decode stored security questions
             sid = re.search(r'^L\$_SQSA_(S-[0-9]-[0-9]-([0-9])+-([0-9])+-([0-9])+-([0-9])+-([0-9])+)$', upperName).group(1)
             try:
@@ -789,18 +789,18 @@ class LSASecrets():
             else:
                 secret = 'Password of service %s: %s' % (sid, password)
 
-        elif re.match('^L\$([0-9A-Z]{3})-PRV-([0-9A-F]{32})$', upperName) is not None:
+        elif re.match(r'^L\$([0-9A-Z]{3})-PRV-([0-9A-F]{32})$', upperName) is not None:
             # Decode stored OpenGPG private key
-            keyid = re.search('^L\$([0-9A-Z]{3})-PRV-([0-9A-F]{32})$', upperName).group(2)
+            keyid = re.search(r'^L\$([0-9A-Z]{3})-PRV-([0-9A-F]{32})$', upperName).group(2)
             try:
                 b64key = secretItem.decode('utf-16le')
             except:
                 pass
             else:
                 secret = 'OpenGPG private key %s: \n%s' % (keyid, b64key)
-        elif re.match('^L\$([0-9A-Z]{3})-PUB-([0-9A-F]{32})$', upperName) is not None:
+        elif re.match(r'^L\$([0-9A-Z]{3})-PUB-([0-9A-F]{32})$', upperName) is not None:
             # Decode stored OpenGPG public key
-            keyid = re.search('^L\$([0-9A-Z]{3})-PUB-([0-9A-F]{32})$', upperName).group(2)
+            keyid = re.search(r'^L\$([0-9A-Z]{3})-PUB-([0-9A-F]{32})$', upperName).group(2)
             try:
                 b64key = secretItem.decode('utf-16le')
             except:
@@ -886,7 +886,7 @@ class LSASecrets():
 
             for valueType in valueTypeList:
                 try:
-                    value = self.__remoteOps.retrieveSubKey(f'SECURITY\\Policy\\Secrets\\{key}\{valueType}', '', throttle=self.__throttle)
+                    value = self.__remoteOps.retrieveSubKey(f'SECURITY\\Policy\\Secrets\\{key}\\{valueType}', '', throttle=self.__throttle)
                 except Exception as e:
                     if logging.getLogger().level == logging.DEBUG:
                         import traceback
@@ -922,7 +922,7 @@ class LSASecrets():
 
         for valueType in valueTypeList:
             try:
-                value = self.__remoteOps.retrieveSubKey(f'SECURITY\\Policy\\Secrets\\{key}\{valueType}', '', throttle=self.__throttle)
+                value = self.__remoteOps.retrieveSubKey(f'SECURITY\\Policy\\Secrets\\{key}\\{valueType}', '', throttle=self.__throttle)
             except Exception as e:
                 if logging.getLogger().level == logging.DEBUG:
                     import traceback

--- a/impacket/examples/regsecrets.py
+++ b/impacket/examples/regsecrets.py
@@ -1,0 +1,964 @@
+import hashlib
+import ntpath
+import logging
+import time
+import re
+import json
+import codecs
+from datetime import datetime
+from struct import unpack, pack
+from six import b
+
+from impacket import ntlm
+from impacket.ese import getUnixTime
+from impacket import LOG
+from impacket.dcerpc.v5 import transport, rrp, scmr, wkst
+from impacket.crypto import transformKey
+from impacket.system_errors import ERROR_NO_MORE_ITEMS
+from impacket.structure import hexdump
+from impacket.krb5 import constants
+from impacket.krb5.crypto import string_to_key
+
+from impacket.examples.secretsdump import  CryptoCommon, _print_helper, DOMAIN_ACCOUNT_F, SAM_KEY_DATA, SAM_KEY_DATA_AES, ARC4, DES, USER_ACCOUNT_V, SAM_HASH, SAM_HASH_AES, LSA_SECRET_XP, HMAC, MD4, MD5, LSA_SECRET, LSA_SECRET_BLOB, NL_RECORD, DPAPI_SYSTEM, NTDSHashes
+from binascii import unhexlify, hexlify
+
+# Helper to create files for exporting
+def openFile(fileName, mode='w+', openFileFunc=None):
+    if openFileFunc is not None:
+        return openFileFunc(fileName, mode)
+    else:
+        return codecs.open(fileName, mode, encoding='utf-8')
+
+class RemoteOperations:
+    def __init__(self, smbConnection, doKerberos, kdcHost=None):
+        self.__smbConnection = smbConnection
+        if self.__smbConnection is not None:
+            self.__smbConnection.setTimeout(5 * 60)
+        self.__serviceName = 'RemoteRegistry'
+        self.__stringBindingWinReg = r'ncacn_np:445[\pipe\winreg]'
+        self.__rrp = None
+        self.__regHandle = None
+
+        self.__samr = None
+
+        self.__drsr = None
+        self.__doKerberos = doKerberos
+        self.__kdcHost = kdcHost
+
+        self.__bootKey = b''
+        self.__disabled = False
+        self.__shouldStop = False
+        self.__started = False
+
+        self.__stringBindingSvcCtl = r'ncacn_np:445[\pipe\svcctl]'
+        self.__scmr = None
+        self.__tmpServiceName = None
+        self.__serviceDeleted = False
+
+
+    def __connectSvcCtl(self):
+        rpc = transport.DCERPCTransportFactory(self.__stringBindingSvcCtl)
+        rpc.set_smb_connection(self.__smbConnection)
+        self.__scmr = rpc.get_dce_rpc()
+        self.__scmr.connect()
+        self.__scmr.bind(scmr.MSRPC_UUID_SCMR)
+
+    def __connectWinReg(self):
+        rpc = transport.DCERPCTransportFactory(self.__stringBindingWinReg)
+        rpc.set_smb_connection(self.__smbConnection)
+        self.__rrp = rpc.get_dce_rpc()
+        self.__rrp.connect()
+        self.__rrp.bind(rrp.MSRPC_UUID_RRP)
+
+    def getMachineKerberosSalt(self):
+        """
+        Returns Kerberos salt for the current connection if
+        we have the correct information
+        """
+        if self.__smbConnection.getServerName() == '':
+            # Todo: figure out an RPC call that gives us the domain FQDN
+            # instead of the NETBIOS name as NetrWkstaGetInfo does
+            return b''
+        else:
+            host = self.__smbConnection.getServerName()
+            domain = self.__smbConnection.getServerDNSDomainName()
+            salt = b'%shost%s.%s' % (domain.upper().encode('utf-8'), host.lower().encode('utf-8'), domain.lower().encode('utf-8'))
+            return salt
+
+    def getMachineNameAndDomain(self):
+        if self.__smbConnection.getServerName() == '':
+            # No serverName.. this is either because we're doing Kerberos
+            # or not receiving that data during the login process.
+            # Let's try getting it through RPC
+            rpc = transport.DCERPCTransportFactory(r'ncacn_np:445[\pipe\wkssvc]')
+            rpc.set_smb_connection(self.__smbConnection)
+            dce = rpc.get_dce_rpc()
+            dce.connect()
+            dce.bind(wkst.MSRPC_UUID_WKST)
+            resp = wkst.hNetrWkstaGetInfo(dce, 100)
+            dce.disconnect()
+            return resp['WkstaInfo']['WkstaInfo100']['wki100_computername'][:-1], resp['WkstaInfo']['WkstaInfo100'][
+                                                                                      'wki100_langroup'][:-1]
+        else:
+            return self.__smbConnection.getServerName(), self.__smbConnection.getServerDomain()
+
+    def getDefaultLoginAccount(self):
+        try:
+            ans = rrp.hBaseRegOpenKey(self.__rrp, self.__regHandle, r'SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon')
+            keyHandle = ans['phkResult']
+            dataType, dataValue = rrp.hBaseRegQueryValue(self.__rrp, keyHandle, 'DefaultUserName')
+            username = dataValue[:-1]
+            dataType, dataValue = rrp.hBaseRegQueryValue(self.__rrp, keyHandle, 'DefaultDomainName')
+            domain = dataValue[:-1]
+            rrp.hBaseRegCloseKey(self.__rrp, keyHandle)
+            if len(domain) > 0:
+                return '%s\\%s' % (domain, username)
+            else:
+                return username
+        except:
+            return None
+
+    def getServiceAccount(self, serviceName):
+        try:
+            # Open the service
+            ans = scmr.hROpenServiceW(self.__scmr, self.__scManagerHandle, serviceName)
+            serviceHandle = ans['lpServiceHandle']
+            resp = scmr.hRQueryServiceConfigW(self.__scmr, serviceHandle)
+            account = resp['lpServiceConfig']['lpServiceStartName'][:-1]
+            scmr.hRCloseServiceHandle(self.__scmr, serviceHandle)
+            if account.startswith('.\\'):
+                account = account[2:]
+            return account
+        except Exception as e:
+            # Don't log if history service is not found, that should be normal
+            if serviceName.endswith("_history") is False:
+                LOG.error(e)
+            return None
+
+    def __checkServiceStatus(self):
+        # Open SC Manager
+        ans = scmr.hROpenSCManagerW(self.__scmr)
+        self.__scManagerHandle = ans['lpScHandle']
+        # Now let's open the service
+        ans = scmr.hROpenServiceW(self.__scmr, self.__scManagerHandle, self.__serviceName)
+        self.__serviceHandle = ans['lpServiceHandle']
+        # Let's check its status
+        ans = scmr.hRQueryServiceStatus(self.__scmr, self.__serviceHandle)
+        if ans['lpServiceStatus']['dwCurrentState'] == scmr.SERVICE_STOPPED:
+            LOG.info('Service %s is in stopped state'% self.__serviceName)
+            self.__shouldStop = True
+            self.__started = False
+        elif ans['lpServiceStatus']['dwCurrentState'] == scmr.SERVICE_RUNNING:
+            LOG.debug('Service %s is already running'% self.__serviceName)
+            self.__shouldStop = False
+            self.__started  = True
+        else:
+            raise Exception('Unknown service state 0x%x - Aborting' % ans['CurrentState'])
+
+        # Let's check its configuration if service is stopped, maybe it's disabled :s
+        if self.__started is False:
+            ans = scmr.hRQueryServiceConfigW(self.__scmr,self.__serviceHandle)
+            if ans['lpServiceConfig']['dwStartType'] == 0x4:
+                LOG.info('Service %s is disabled, enabling it'% self.__serviceName)
+                self.__disabled = True
+                scmr.hRChangeServiceConfigW(self.__scmr, self.__serviceHandle, dwStartType = 0x3)
+            LOG.info('Starting service %s' % self.__serviceName)
+            scmr.hRStartServiceW(self.__scmr,self.__serviceHandle)
+            time.sleep(1)
+
+    def enableRegistry(self):
+        self.__connectSvcCtl()
+        self.__checkServiceStatus()
+        self.__connectWinReg()
+
+    def __restore(self):
+        # First of all stop the service if it was originally stopped
+        if self.__shouldStop is True:
+            LOG.info('Stopping service %s' % self.__serviceName)
+            scmr.hRControlService(self.__scmr, self.__serviceHandle, scmr.SERVICE_CONTROL_STOP)
+        if self.__disabled is True:
+            LOG.info('Restoring the disabled state for service %s' % self.__serviceName)
+            scmr.hRChangeServiceConfigW(self.__scmr, self.__serviceHandle, dwStartType = 0x4)
+        if self.__serviceDeleted is False and self.__tmpServiceName is not None:
+            # Check again the service we created does not exist, starting a new connection
+            # Why?.. Hitting CTRL+C might break the whole existing DCE connection
+            try:
+                rpc = transport.DCERPCTransportFactory(r'ncacn_np:%s[\pipe\svcctl]' % self.__smbConnection.getRemoteHost())
+                if hasattr(rpc, 'set_credentials'):
+                    # This method exists only for selected protocol sequences.
+                    rpc.set_credentials(*self.__smbConnection.getCredentials())
+                    rpc.set_kerberos(self.__doKerberos, self.__kdcHost)
+                self.__scmr = rpc.get_dce_rpc()
+                self.__scmr.connect()
+                self.__scmr.bind(scmr.MSRPC_UUID_SCMR)
+                # Open SC Manager
+                ans = scmr.hROpenSCManagerW(self.__scmr)
+                self.__scManagerHandle = ans['lpScHandle']
+                # Now let's open the service
+                resp = scmr.hROpenServiceW(self.__scmr, self.__scManagerHandle, self.__tmpServiceName)
+                service = resp['lpServiceHandle']
+                scmr.hRDeleteService(self.__scmr, service)
+                scmr.hRControlService(self.__scmr, service, scmr.SERVICE_CONTROL_STOP)
+                scmr.hRCloseServiceHandle(self.__scmr, service)
+                scmr.hRCloseServiceHandle(self.__scmr, self.__serviceHandle)
+                scmr.hRCloseServiceHandle(self.__scmr, self.__scManagerHandle)
+                rpc.disconnect()
+            except Exception as e:
+                # If service is stopped it'll trigger an exception
+                # If service does not exist it'll trigger an exception
+                # So. we just wanna be sure we delete it, no need to
+                # show this exception message
+                pass
+
+    def finish(self):
+        if self.__regHandle is not None:
+            rrp.hBaseRegCloseKey(self.__rrp, self.__regHandle)
+        self.__restore()
+        if self.__rrp is not None:
+            self.__rrp.disconnect()
+        if self.__drsr is not None:
+            self.__drsr.disconnect()
+        if self.__samr is not None:
+            self.__samr.disconnect()
+        if self.__scmr is not None:
+            try:
+                self.__scmr.disconnect()
+            except Exception as e:
+                if str(e).find('STATUS_INVALID_PARAMETER') >= 0:
+                    pass
+                else:
+                    raise
+
+    def getBootKey(self):
+        bootKey = b''
+        self.openHKLMHandle()
+        for key in ['JD','Skew1','GBG','Data']:
+            LOG.debug('Retrieving class info for %s'% key)
+            ans = rrp.hBaseRegOpenKey(self.__rrp, self.__regHandle, 'SYSTEM\\CurrentControlSet\\Control\\Lsa\\%s' % key)
+            keyHandle = ans['phkResult']
+            ans = rrp.hBaseRegQueryInfoKey(self.__rrp, keyHandle)
+            bootKey = bootKey + b(ans['lpClassOut'][:-1])
+            rrp.hBaseRegCloseKey(self.__rrp, keyHandle)
+
+        transforms = [ 8, 5, 4, 2, 11, 9, 13, 3, 0, 6, 1, 12, 14, 10, 15, 7 ]
+
+        bootKey = unhexlify(bootKey)
+
+        for i in range(len(bootKey)):
+            self.__bootKey += bootKey[transforms[i]:transforms[i]+1]
+
+        LOG.info('Target system bootKey: 0x%s' % hexlify(self.__bootKey).decode('utf-8'))
+
+        return self.__bootKey
+
+    def openHKLMHandle(self):
+        if self.__regHandle is None:
+            ans = rrp.hOpenLocalMachine(self.__rrp)
+            self.__regHandle = ans['phKey']
+
+    def retrieveSubKey(self, subKey, value, throttle=0):
+        LOG.debug(f'[{datetime.now()}] Retrieving {subKey}\\{value}')
+        self.openHKLMHandle()
+        try:
+            ans = rrp.hBaseRegOpenKey(self.__rrp, self.__regHandle, subKey, dwOptions=rrp.REG_OPTION_BACKUP_RESTORE | rrp.REG_OPTION_OPEN_LINK,
+                                   samDesired=None)
+        except:
+            raise Exception(f"Can't open {subKey} subKey")
+        keyHandle = ans['phkResult']
+        value = rrp.hBaseRegQueryValue(self.__rrp, ans['phkResult'], value)
+        rrp.hBaseRegCloseKey(self.__rrp, keyHandle)
+        time.sleep(throttle)
+        return value
+
+    def enumSubKey(self, subKey, throttle=0):
+        LOG.debug(f'[{datetime.now()}] Enumerating keys {subKey}')
+        self.openHKLMHandle()
+        try:
+            ans = rrp.hBaseRegOpenKey(self.__rrp, self.__regHandle, subKey, dwOptions=rrp.REG_OPTION_BACKUP_RESTORE | rrp.REG_OPTION_OPEN_LINK,
+                                   samDesired=None)
+        except:
+            raise Exception(f"Can't open {subKey} subKey")
+        keyHandle = ans['phkResult']
+        i = 0
+        values = []
+        while True:
+            try:
+                key = rrp.hBaseRegEnumKey(self.__rrp, keyHandle, i)
+                i += 1
+                values.append(key['lpNameOut'][:-1])
+            except Exception:
+                break
+        rrp.hBaseRegCloseKey(self.__rrp, keyHandle)
+        time.sleep(throttle)
+        return values
+
+    def enumValues(self, subKey:str, throttle=0) -> dict:
+        LOG.debug(f'[{datetime.now()}] Enumerating values {subKey}')
+        self.openHKLMHandle()
+        try:
+            ans = rrp.hBaseRegOpenKey(self.__rrp, self.__regHandle, subKey, dwOptions=rrp.REG_OPTION_BACKUP_RESTORE | rrp.REG_OPTION_OPEN_LINK,
+                                   samDesired=None)
+        except:
+            raise Exception(f"Can't open {subKey} subKey")
+        keyHandle = ans['phkResult']
+        i = 0
+        values = dict()
+        while True:
+            try:
+                ans2 = rrp.hBaseRegEnumValue(self.__rrp, keyHandle, i)
+                lp_value_name = ans2['lpValueNameOut'][:-1]
+                if len(lp_value_name) == 0:
+                    lp_value_name = '(Default)'
+                lp_type = ans2['lpType']
+                lp_data = b''.join(ans2['lpData'])
+                values[lp_value_name] = self.__parse_lp_data(lp_type, lp_data)
+                i += 1
+            except rrp.DCERPCSessionError as e:
+                if e.get_error_code() == ERROR_NO_MORE_ITEMS:
+                    break
+        time.sleep(throttle)
+        return values
+
+    def __parse_lp_data(self, valueType, valueData):
+        try:
+            if valueType == rrp.REG_SZ or valueType == rrp.REG_EXPAND_SZ:
+                if type(valueData) is int:
+                    return None
+                else:
+                    return valueData.decode('utf-16le')[:-1]
+            elif valueType == rrp.REG_BINARY:
+                return valueData
+            elif valueType == rrp.REG_DWORD:
+                return unpack('<L', valueData)[0]
+            elif valueType == rrp.REG_QWORD:
+                return unpack('<Q', valueData)[0]
+            elif valueType == rrp.REG_NONE:
+                return valueData
+            elif valueType == rrp.REG_MULTI_SZ:
+                return valueData.decode('utf-16le')[:-2]
+            else:
+                print("Unknown Type 0x%x!" % valueType)
+                hexdump(valueData)
+        except Exception as e:
+            logging.debug('Exception thrown when printing reg value %s' % str(e))
+            print('Invalid data')
+            pass
+
+class SAMHashes():
+    def __init__(self, bootKey, perSecretCallback = lambda secret: _print_helper(secret), remoteOps:RemoteOperations=None, throttle=0):
+        self.__remoteOps = remoteOps
+        self.__hashedBootKey = b''
+        self.__bootKey = bootKey
+        self.__cryptoCommon = CryptoCommon()
+        self.__itemsFound = {}
+        self.__perSecretCallback = perSecretCallback
+        self.__throttle = throttle
+
+    def MD5(self, data):
+        md5 = hashlib.new('md5')
+        md5.update(data)
+        return md5.digest()
+
+    def getHBootKey(self):
+        LOG.debug('Calculating HashedBootKey from SAM')
+        QWERTY = b"!@#$%^&*()qwertyUIOPAzxcvbnmQQQQQQQQQQQQ)(*@&%\0"
+        DIGITS = b"0123456789012345678901234567890123456789\0"
+
+        F = self.__remoteOps.retrieveSubKey(r'SAM\SAM\Domains\Account', 'F', throttle=self.__throttle)[1]
+
+        domainData = DOMAIN_ACCOUNT_F(F)
+
+        if domainData['Key0'][0:1] == b'\x01':
+            samKeyData = SAM_KEY_DATA(domainData['Key0'])
+
+            rc4Key = self.MD5(samKeyData['Salt'] + QWERTY + self.__bootKey + DIGITS)
+            rc4 = ARC4.new(rc4Key)
+            self.__hashedBootKey = rc4.encrypt(samKeyData['Key'] + samKeyData['CheckSum'])
+
+            # Verify key with checksum
+            checkSum = self.MD5( self.__hashedBootKey[:16] + DIGITS + self.__hashedBootKey[:16] + QWERTY)
+
+            if checkSum != self.__hashedBootKey[16:]:
+                raise Exception('hashedBootKey CheckSum failed, Syskey startup password probably in use! :(')
+
+        elif domainData['Key0'][0:1] == b'\x02':
+            # This is Windows 2016 TP5 on in theory (it is reported that some W10 and 2012R2 might behave this way also)
+            samKeyData = SAM_KEY_DATA_AES(domainData['Key0'])
+
+            self.__hashedBootKey = self.__cryptoCommon.decryptAES(self.__bootKey,
+                                                                  samKeyData['Data'][:samKeyData['DataLen']], samKeyData['Salt'])
+
+    def __decryptHash(self, rid, cryptedHash, constant, newStyle = False):
+        # Section 2.2.11.1.1 Encrypting an NT or LM Hash Value with a Specified Key
+        # plus hashedBootKey stuff
+        Key1,Key2 = self.__cryptoCommon.deriveKey(rid)
+
+        Crypt1 = DES.new(Key1, DES.MODE_ECB)
+        Crypt2 = DES.new(Key2, DES.MODE_ECB)
+
+        if newStyle is False:
+            rc4Key = self.MD5( self.__hashedBootKey[:0x10] + pack("<L", rid) + constant )
+            rc4 = ARC4.new(rc4Key)
+            key = rc4.encrypt(cryptedHash['Hash'])
+        else:
+            key = self.__cryptoCommon.decryptAES(self.__hashedBootKey[:0x10], cryptedHash['Hash'], cryptedHash['Salt'])[:16]
+
+        decryptedHash = Crypt1.decrypt(key[:8]) + Crypt2.decrypt(key[8:])
+
+        return decryptedHash
+
+    def dump(self):
+        NTPASSWORD = b"NTPASSWORD\0"
+        LMPASSWORD = b"LMPASSWORD\0"
+
+        LOG.info('Dumping local SAM hashes (uid:rid:lmhash:nthash)')
+        self.getHBootKey()
+
+        usersKey = r'SAM\SAM\Domains\Account\Users'
+
+        # Enumerate all the RIDs
+        rids = self.__remoteOps.enumSubKey(usersKey, throttle=self.__throttle)
+        # Remove the Names item
+        try:
+            rids.remove('Names')
+        except:
+            pass
+
+        for rid in rids:
+            userAccount = USER_ACCOUNT_V(self.__remoteOps.retrieveSubKey(ntpath.join(usersKey, rid), 'V', throttle=self.__throttle)[1])
+            rid = int(rid, 16)
+
+            V = userAccount['Data']
+
+            userName = V[userAccount['NameOffset']:userAccount['NameOffset']+userAccount['NameLength']].decode('utf-16le')
+
+            if userAccount['NTHashLength'] == 0:
+                logging.error('SAM hashes extraction for user %s failed. The account doesn\'t have hash information.' % userName)
+                continue
+
+            encNTHash = b''
+            if V[userAccount['NTHashOffset']:][2:3] == b'\x01':
+                # Old Style hashes
+                newStyle = False
+                if userAccount['LMHashLength'] == 20:
+                    encLMHash = SAM_HASH(V[userAccount['LMHashOffset']:][:userAccount['LMHashLength']])
+                if userAccount['NTHashLength'] == 20:
+                    encNTHash = SAM_HASH(V[userAccount['NTHashOffset']:][:userAccount['NTHashLength']])
+            else:
+                # New Style hashes
+                newStyle = True
+                if userAccount['LMHashLength'] == 24:
+                    encLMHash = SAM_HASH_AES(V[userAccount['LMHashOffset']:][:userAccount['LMHashLength']])
+                encNTHash = SAM_HASH_AES(V[userAccount['NTHashOffset']:][:userAccount['NTHashLength']])
+
+            LOG.debug('NewStyle hashes is: %s' % newStyle)
+            if userAccount['LMHashLength'] >= 20:
+                lmHash = self.__decryptHash(rid, encLMHash, LMPASSWORD, newStyle)
+            else:
+                lmHash = b''
+
+            if encNTHash != b'':
+                ntHash = self.__decryptHash(rid, encNTHash, NTPASSWORD, newStyle)
+            else:
+                ntHash = b''
+
+            if lmHash == b'':
+                lmHash = ntlm.LMOWFv1('','')
+            if ntHash == b'':
+                ntHash = ntlm.NTOWFv1('','')
+
+            answer =  "%s:%d:%s:%s:::" % (userName, rid, hexlify(lmHash).decode('utf-8'), hexlify(ntHash).decode('utf-8'))
+            self.__itemsFound[rid] = answer
+            self.__perSecretCallback(answer)
+
+    def export(self, baseFileName, openFileFunc = None):
+        if len(self.__itemsFound) > 0:
+            items = sorted(self.__itemsFound)
+            fileName = baseFileName + '.sam'
+            fd = openFile(fileName, openFileFunc=openFileFunc)
+            for item in items:
+                fd.write(self.__itemsFound[item] + '\n')
+            fd.close()
+            return fileName
+
+class LSASecrets():
+    UNKNOWN_USER = '(Unknown User)'
+    class SECRET_TYPE:
+        LSA = 0
+        LSA_HASHED = 1
+        LSA_RAW = 2
+        LSA_KERBEROS = 3
+
+    def __init__(self, bootKey, remoteOps:RemoteOperations=None, history=False,
+                 perSecretCallback=lambda secretType, secret: _print_helper(secret), throttle=0):
+        self.__bootKey = bootKey
+        self.__LSAKey = b''
+        self.__NKLMKey = b''
+        self.__vistaStyle = True
+        self.__cryptoCommon = CryptoCommon()
+        self.__remoteOps = remoteOps
+        self.__cachedItems = []
+        self.__secretItems = []
+        self.__perSecretCallback = perSecretCallback
+        self.__history = history
+        self.__throttle = throttle
+
+    def MD5(self, data):
+        md5 = hashlib.new('md5')
+        md5.update(data)
+        return md5.digest()
+
+    def __sha256(self, key, value, rounds=1000):
+        sha = hashlib.sha256()
+        sha.update(key)
+        for i in range(rounds):
+            sha.update(value)
+        return sha.digest()
+
+    def __decryptSecret(self, key, value):
+        # [MS-LSAD] Section 5.1.2
+        plainText = b''
+
+        encryptedSecretSize = unpack('<I', value[:4])[0]
+        value = value[len(value)-encryptedSecretSize:]
+
+        key0 = key
+        for i in range(0, len(value), 8):
+            cipherText = value[:8]
+            tmpStrKey = key0[:7]
+            tmpKey = transformKey(tmpStrKey)
+            Crypt1 = DES.new(tmpKey, DES.MODE_ECB)
+            plainText += Crypt1.decrypt(cipherText)
+            key0 = key0[7:]
+            value = value[8:]
+            # AdvanceKey
+            if len(key0) < 7:
+                key0 = key[len(key0):]
+
+        secret = LSA_SECRET_XP(plainText)
+        return secret['Secret']
+
+    def __decryptHash(self, key, value, iv):
+        hmac_md5 = HMAC.new(key,iv,MD5)
+        rc4key = hmac_md5.digest()
+
+        rc4 = ARC4.new(rc4key)
+        data = rc4.encrypt(value)
+        return data
+
+    def __decryptLSA(self, value):
+        if self.__vistaStyle is True:
+            # ToDo: There could be more than one LSA Keys
+            record = LSA_SECRET(value)
+            tmpKey = self.__sha256(self.__bootKey, record['EncryptedData'][:32])
+            plainText = self.__cryptoCommon.decryptAES(tmpKey, record['EncryptedData'][32:])
+            record = LSA_SECRET_BLOB(plainText)
+            self.__LSAKey = record['Secret'][52:][:32]
+
+        else:
+            md5 = hashlib.new('md5')
+            md5.update(self.__bootKey)
+            for i in range(1000):
+                md5.update(value[60:76])
+            tmpKey = md5.digest()
+            rc4 = ARC4.new(tmpKey)
+            plainText = rc4.decrypt(value[12:60])
+            self.__LSAKey = plainText[0x10:0x20]
+
+    def __getLSASecretKey(self):
+        LOG.debug('Decrypting LSA Key')
+        # Let's try the key post XP
+        value = self.__remoteOps.retrieveSubKey(r'SECURITY\Policy\PolEKList', '', throttle=self.__throttle)
+        if value is None:
+            LOG.debug('PolEKList not found, trying PolSecretEncryptionKey')
+            # Second chance
+            value = self.__remoteOps.retrieveSubKey(r'SECURITY\Policy\PolSecretEncryptionKey', '', throttle=self.__throttle)
+            self.__vistaStyle = False
+            if value is None:
+                # No way :(
+                return None
+
+        self.__decryptLSA(value[1])
+
+    def __getNLKMSecret(self):
+        LOG.debug('Decrypting NL$KM')
+        value = self.__remoteOps.retrieveSubKey(r'SECURITY\Policy\Secrets\NL$KM\CurrVal', '', throttle=self.__throttle)
+        if value is None:
+            raise Exception("Couldn't get NL$KM value")
+        if self.__vistaStyle is True:
+            record = LSA_SECRET(value[1])
+            tmpKey = self.__sha256(self.__LSAKey, record['EncryptedData'][:32])
+            self.__NKLMKey = self.__cryptoCommon.decryptAES(tmpKey, record['EncryptedData'][32:])
+        else:
+            self.__NKLMKey = self.__decryptSecret(self.__LSAKey, value[1])
+
+    def __pad(self, data):
+        if (data & 0x3) > 0:
+            return data + (data & 0x3)
+        else:
+            return data
+
+    def dumpCachedHashes(self):
+
+        LOG.info('Dumping cached domain logon information (domain/username:hash)')
+
+        # Let's first see if there are cached entries
+        values = self.__remoteOps.enumValues(r'SECURITY\Cache', throttle=self.__throttle)
+        if values is None:
+            # No cache entries
+            return
+        try:
+            # Remove unnecessary value
+            del values['NL$Control']
+        except:
+            pass
+
+        iterationCount = 10240
+
+        if values.get('NL$IterationCount', None):
+            record = values.get('NL$IterationCount')
+            del values['NL$IterationCount']
+
+            if record > 10240:
+                iterationCount = record & 0xfffffc00
+            else:
+                iterationCount = record * 1024
+
+        self.__getLSASecretKey()
+        self.__getNLKMSecret()
+        LOG.debug(f'LsaSecretKey: 0x{hexlify(self.__LSAKey).decode()}')
+        LOG.debug(f'NKLM Secret: 0x{hexlify(self.__NKLMKey).decode()}')
+
+        for key, value in values.items():
+            LOG.debug(f'Looking into {key}')
+            record = NL_RECORD(value)
+            if record['IV'] != 16 * b'\x00':
+            #if record['UserLength'] > 0:
+                if record['Flags'] & 1 == 1:
+                    # Encrypted
+                    if self.__vistaStyle is True:
+                        plainText = self.__cryptoCommon.decryptAES(self.__NKLMKey[16:32], record['EncryptedData'], record['IV'])
+                    else:
+                        plainText = self.__decryptHash(self.__NKLMKey, record['EncryptedData'], record['IV'])
+                        pass
+                else:
+                    # Plain! Until we figure out what this is, we skip it
+                    #plainText = record['EncryptedData']
+                    continue
+                encHash = plainText[:0x10]
+                plainText = plainText[0x48:]
+                userName = plainText[:record['UserLength']].decode('utf-16le')
+                plainText = plainText[self.__pad(record['UserLength']) + self.__pad(record['DomainNameLength']):]
+                domainLong = plainText[:self.__pad(record['DnsDomainNameLength'])].decode('utf-16le')
+                timestamp = datetime.utcfromtimestamp(getUnixTime(record['LastWrite']))
+
+                if self.__vistaStyle is True:
+                    answer = "%s/%s:$DCC2$%s#%s#%s: (%s)" % (domainLong, userName, iterationCount, userName, hexlify(encHash).decode('utf-8'), timestamp)
+                else:
+                    answer = "%s/%s:%s:%s: (%s)" % (domainLong, userName, hexlify(encHash).decode('utf-8'), userName, timestamp)
+
+                self.__cachedItems.append(answer)
+                self.__perSecretCallback(LSASecrets.SECRET_TYPE.LSA_HASHED, answer)
+
+    def __printSecret(self, name, secretItem):
+        # Based on [MS-LSAD] section 3.1.1.4
+
+        # First off, let's discard NULL secrets.
+        if len(secretItem) == 0:
+            LOG.debug('Discarding secret %s, NULL Data' % name)
+            return
+
+        # We might have secrets with zero
+        if secretItem.startswith(b'\x00\x00'):
+            LOG.debug('Discarding secret %s, all zeros' % name)
+            return
+
+        upperName = name.upper()
+
+        LOG.info('%s ' % name)
+
+        secret = ''
+
+        if upperName.startswith('_SC_'):
+            # Service name, a password might be there
+            # Let's first try to decode the secret
+            try:
+                strDecoded = secretItem.decode('utf-16le')
+            except:
+                pass
+            else:
+                # We have to get the account the service
+                # runs under
+                if hasattr(self.__remoteOps, 'getServiceAccount'):
+                    account = self.__remoteOps.getServiceAccount(name[4:])
+                    if account is None:
+                        secret = self.UNKNOWN_USER + ':'
+                    else:
+                        secret =  "%s:" % account
+                else:
+                    # We don't support getting this info for local targets at the moment
+                    secret = self.UNKNOWN_USER + ':'
+                secret += strDecoded
+
+        elif upperName.startswith('DEFAULTPASSWORD'):
+            # defaults password for winlogon
+            # Let's first try to decode the secret
+            try:
+                strDecoded = secretItem.decode('utf-16le')
+            except:
+                pass
+            else:
+                # We have to get the account this password is for
+                if hasattr(self.__remoteOps, 'getDefaultLoginAccount'):
+                    account = self.__remoteOps.getDefaultLoginAccount()
+                    if account is None:
+                        secret = self.UNKNOWN_USER + ':'
+                    else:
+                        secret = "%s:" % account
+                else:
+                    # We don't support getting this info for local targets at the moment
+                    secret = self.UNKNOWN_USER + ':'
+                secret += strDecoded
+
+        elif upperName.startswith('ASPNET_WP_PASSWORD'):
+            try:
+                strDecoded = secretItem.decode('utf-16le')
+            except:
+                pass
+            else:
+                secret = 'ASPNET: %s' % strDecoded
+
+        elif upperName.startswith('DPAPI_SYSTEM'):
+            # Decode the DPAPI Secrets
+            dpapi = DPAPI_SYSTEM(secretItem)
+            secret = "dpapi_machinekey:0x{0}\ndpapi_userkey:0x{1}".format( hexlify(dpapi['MachineKey']).decode('latin-1'),
+                                                               hexlify(dpapi['UserKey']).decode('latin-1'))
+        elif upperName.startswith('$MACHINE.ACC'):
+            # compute MD4 of the secret.. yes.. that is the nthash? :-o
+            md4 = MD4.new()
+            md4.update(secretItem)
+            if hasattr(self.__remoteOps, 'getMachineNameAndDomain'):
+                machine, domain = self.__remoteOps.getMachineNameAndDomain()
+                printname = "%s\\%s$" % (domain, machine)
+                secret = "%s\\%s$:%s:%s:::" % (domain, machine, hexlify(ntlm.LMOWFv1('','')).decode('utf-8'),
+                                               hexlify(md4.digest()).decode('utf-8'))
+            else:
+                printname = "$MACHINE.ACC"
+                secret = "$MACHINE.ACC: %s:%s" % (hexlify(ntlm.LMOWFv1('','')).decode('utf-8'),
+                                                hexlify(md4.digest()).decode('utf-8'))
+            # Attempt to calculate and print Kerberos keys
+            if not self.__printMachineKerberos(secretItem, printname):
+                LOG.debug('Could not calculate machine account Kerberos keys, only printing plain password (hex encoded)')
+            # Always print plaintext anyway since this may be needed for some popular usecases
+            extrasecret = "%s:plain_password_hex:%s" % (printname, hexlify(secretItem).decode('utf-8'))
+            self.__secretItems.append(extrasecret)
+            self.__perSecretCallback(LSASecrets.SECRET_TYPE.LSA, extrasecret)
+
+        elif re.match('^L\$_SQSA_(S-[0-9]-[0-9]-([0-9])+-([0-9])+-([0-9])+-([0-9])+-([0-9])+)$', upperName) is not None:
+            # Decode stored security questions
+            sid = re.search(r'^L\$_SQSA_(S-[0-9]-[0-9]-([0-9])+-([0-9])+-([0-9])+-([0-9])+-([0-9])+)$', upperName).group(1)
+            try:
+                strDecoded = secretItem.decode('utf-16le')
+                strDecoded = json.loads(strDecoded)
+            except Exception as e:
+                pass
+            else:
+                output = []
+                if strDecoded['version'] == 1:
+                    if len(strDecoded['questions']) != 0:
+                        output.append(" - Version : %d" % strDecoded['version'])
+                        for qk in strDecoded['questions']:
+                            output.append(" | Question: %s" % qk['question'])
+                            output.append(" | |--> Answer: %s" % qk['answer'])
+                        output = '\n'.join(output)
+                        secret = 'Security questions for user %s: \n%s' % (sid, output)
+                    else:
+                        secret = 'Empty security questions for user %s.' % sid
+                else:
+                    LOG.warning("Unknown SQSA version (%s), please open an issue with the following data so we can add a parser for it." % str(strDecoded['version']))
+                    LOG.warning("Don't forget to remove sensitive content before sending the data in a Github issue.")
+                    secret = json.dumps(strDecoded, indent=4)
+
+        elif re.match('^SCM:{([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})}', upperName) is not None:
+            # Decode stored service password
+            sid = re.search('^SCM:{([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})}', upperName).group(1)
+            try:
+                password = secretItem.decode('utf-16le').rstrip('\x00')
+            except:
+                pass
+            else:
+                secret = 'Password of service %s: %s' % (sid, password)
+
+        elif re.match('^L\$([0-9A-Z]{3})-PRV-([0-9A-F]{32})$', upperName) is not None:
+            # Decode stored OpenGPG private key
+            keyid = re.search('^L\$([0-9A-Z]{3})-PRV-([0-9A-F]{32})$', upperName).group(2)
+            try:
+                b64key = secretItem.decode('utf-16le')
+            except:
+                pass
+            else:
+                secret = 'OpenGPG private key %s: \n%s' % (keyid, b64key)
+        elif re.match('^L\$([0-9A-Z]{3})-PUB-([0-9A-F]{32})$', upperName) is not None:
+            # Decode stored OpenGPG public key
+            keyid = re.search('^L\$([0-9A-Z]{3})-PUB-([0-9A-F]{32})$', upperName).group(2)
+            try:
+                b64key = secretItem.decode('utf-16le')
+            except:
+                pass
+            else:
+                secret = 'OpenGPG public key %s: \n%s' % (keyid, b64key)
+
+        if secret != '':
+            printableSecret = secret
+            self.__secretItems.append(secret)
+            self.__perSecretCallback(LSASecrets.SECRET_TYPE.LSA, printableSecret)
+        else:
+            # Default print, hexdump
+            printableSecret  = '%s:%s' % (name, hexlify(secretItem).decode('utf-8'))
+            self.__secretItems.append(printableSecret)
+            # If we're using the default callback (ourselves), we print the hex representation. If not, the
+            # user will need to decide what to do.
+            if self.__module__ == self.__perSecretCallback.__module__:
+                hexdump(secretItem)
+            self.__perSecretCallback(LSASecrets.SECRET_TYPE.LSA_RAW, printableSecret)
+
+    def __printMachineKerberos(self, rawsecret, machinename):
+        # Attempt to create Kerberos keys from machine account (if possible)
+        if hasattr(self.__remoteOps, 'getMachineKerberosSalt'):
+            salt = self.__remoteOps.getMachineKerberosSalt()
+            if salt == b'':
+                return False
+            else:
+                allciphers = [
+                    int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value),
+                    int(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value),
+                    int(constants.EncryptionTypes.des_cbc_md5.value)
+                ]
+                # Ok, so the machine account password is in raw UTF-16, BUT can contain any amount
+                # of invalid unicode characters.
+                # This took me (Dirk-jan) way too long to figure out, but apparently Microsoft
+                # implicitly replaces those when converting utf-16 to utf-8.
+                # When we use the same method we get the valid password -> key mapping :)
+                rawsecret = rawsecret.decode('utf-16-le', 'replace').encode('utf-8', 'replace')
+                for etype in allciphers:
+                    try:
+                        key = string_to_key(etype, rawsecret, salt, None)
+                    except Exception:
+                        LOG.debug('Exception', exc_info=True)
+                        raise
+                    typename = NTDSHashes.KERBEROS_TYPE[etype]
+                    secret = "%s:%s:%s" % (machinename, typename, hexlify(key.contents).decode('utf-8'))
+                    self.__secretItems.append(secret)
+                    self.__perSecretCallback(LSASecrets.SECRET_TYPE.LSA_KERBEROS, secret)
+                return True
+        else:
+            return False
+
+    def dumpSecrets(self):
+        LOG.info('Dumping LSA Secrets')
+
+        keys = self.__remoteOps.enumSubKey(r'SECURITY\Policy\Secrets', throttle=self.__throttle)
+
+        if keys is None:
+            # No entries
+            return
+        try:
+            # This key has no use for LSASecrets and is only used for MSCache decryption
+            keys.remove('NL$KM')
+        except:
+            pass
+
+        try:
+            # Remove unnecessary value
+            keys.remove('NL$Control')
+        except:
+            pass
+
+        if self.__LSAKey == b'':
+            self.__getLSASecretKey()
+
+        for key in keys:
+            LOG.debug(f'Looking into {key}')
+            valueTypeList = ['CurrVal']
+            # Check if old LSA secrets values are also need to be shown
+            if self.__history:
+                valueTypeList.append('OldVal')
+
+            for valueType in valueTypeList:
+                try:
+                    value = self.__remoteOps.retrieveSubKey(f'SECURITY\\Policy\\Secrets\\{key}\{valueType}', '', throttle=self.__throttle)
+                except Exception as e:
+                    if logging.getLogger().level == logging.DEBUG:
+                        import traceback
+                        traceback.print_exc()
+                    print(str(e))
+                    continue
+                if value is not None and value[1] != 0:
+                    if self.__vistaStyle is True:
+                        record = LSA_SECRET(value[1])
+                        tmpKey = self.__sha256(self.__LSAKey, record['EncryptedData'][:32])
+                        plainText = self.__cryptoCommon.decryptAES(tmpKey, record['EncryptedData'][32:])
+                        record = LSA_SECRET_BLOB(plainText)
+                        secret = record['Secret']
+                    else:
+                        secret = self.__decryptSecret(self.__LSAKey, value[1])
+
+                    # If this is an OldVal secret, let's append '_history' to be able to distinguish it and
+                    # also be consistent with NTDS history
+                    if valueType == 'OldVal':
+                        key += '_history'
+                    self.__printSecret(key, secret)
+
+    def getSecret(self, key):
+        LOG.info(f'Dumping LSA secret: {key}')
+
+        if self.__LSAKey == b'':
+            self.__getLSASecretKey()
+
+        valueTypeList = ['CurrVal']
+        # Check if old LSA secrets values are also need to be shown
+        if self.__history:
+            valueTypeList.append('OldVal')
+
+        for valueType in valueTypeList:
+            try:
+                value = self.__remoteOps.retrieveSubKey(f'SECURITY\\Policy\\Secrets\\{key}\{valueType}', '', throttle=self.__throttle)
+            except Exception as e:
+                if logging.getLogger().level == logging.DEBUG:
+                    import traceback
+                    traceback.print_exc()
+                print(str(e))
+                continue
+            if value is not None and value[1] != 0:
+                if self.__vistaStyle is True:
+                    record = LSA_SECRET(value[1])
+                    tmpKey = self.__sha256(self.__LSAKey, record['EncryptedData'][:32])
+                    plainText = self.__cryptoCommon.decryptAES(tmpKey, record['EncryptedData'][32:])
+                    record = LSA_SECRET_BLOB(plainText)
+                    secret = record['Secret']
+                else:
+                    secret = self.__decryptSecret(self.__LSAKey, value[1])
+
+                # If this is an OldVal secret, let's append '_history' to be able to distinguish it and
+                # also be consistent with NTDS history
+                if valueType == 'OldVal':
+                    key += '_history'
+                return secret
+
+    def exportSecrets(self, baseFileName, openFileFunc = None):
+        if len(self.__secretItems) > 0:
+            fileName = baseFileName + '.secrets'
+            fd = openFile(fileName, openFileFunc=openFileFunc)
+            for item in self.__secretItems:
+                fd.write(item + '\n')
+            fd.close()
+            return fileName
+
+    def exportCached(self, baseFileName, openFileFunc = None):
+        if len(self.__cachedItems) > 0:
+            fileName = baseFileName + '.cached'
+            fd = openFile(fileName, openFileFunc=openFileFunc)
+            for item in self.__cachedItems:
+                fd.write(item + '\n')
+            fd.close()
+            return fileName

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -1963,6 +1963,7 @@ class NTDSHashes:
         'pekList':b'ATTk590689',
         'supplementalCredentials':b'ATTk589949',
         'pwdLastSet':b'ATTq589920',
+        'instanceType':b'ATTj131073',
     }
 
     NAME_TO_ATTRTYP = {
@@ -2100,6 +2101,7 @@ class NTDSHashes:
             self.NAME_TO_INTERNAL['userAccountControl'] : 1,
             self.NAME_TO_INTERNAL['supplementalCredentials'] : 1,
             self.NAME_TO_INTERNAL['pekList'] : 1,
+            self.NAME_TO_INTERNAL['instanceType'] : 1,
 
         }
 
@@ -2121,7 +2123,7 @@ class NTDSHashes:
             elif record[self.NAME_TO_INTERNAL['pekList']] is not None:
                 peklist =  unhexlify(record[self.NAME_TO_INTERNAL['pekList']])
                 break
-            elif record[self.NAME_TO_INTERNAL['sAMAccountType']] in self.ACCOUNT_TYPES:
+            elif record[self.NAME_TO_INTERNAL['sAMAccountType']] in self.ACCOUNT_TYPES and record[self.NAME_TO_INTERNAL['instanceType']] & 4:    # "The object is writable on this directory":
                 # Okey.. we found some users, but we're not yet ready to process them.
                 # Let's just store them in a temp list
                 self.__tmpUsers.append(record)
@@ -2648,7 +2650,7 @@ class NTDSHashes:
                         if record is None:
                             break
                         try:
-                            if record[self.NAME_TO_INTERNAL['sAMAccountType']] in self.ACCOUNT_TYPES:
+                            if record[self.NAME_TO_INTERNAL['sAMAccountType']] in self.ACCOUNT_TYPES and record[self.NAME_TO_INTERNAL['instanceType']] & 4:    # "The object is writable on this directory"
                                 self.__decryptHash(record, outputFile=hashesOutputFile)
                                 if self.__justNTLM is False:
                                     self.__decryptSupplementalInfo(record, None, keysOutputFile, clearTextOutputFile)

--- a/impacket/examples/smbclient.py
+++ b/impacket/examples/smbclient.py
@@ -581,6 +581,9 @@ class MiniImpacketShell(cmd.Cmd):
             raise
         fh.close()
 
+    def complete_cat(self, text, line, begidx, endidx):
+        return self.complete_get(text, line, begidx, endidx, include=1)
+    
     def do_cat(self, filename):
         if self.tid is None:
             LOG.error("No share selected")

--- a/impacket/examples/utils.py
+++ b/impacket/examples/utils.py
@@ -255,3 +255,29 @@ def init_ldap_session(domain, username, password, lmhash, nthash, k, dc_ip, aesK
 # ----------
 
 EMPTY_LM_HASH = 'AAD3B435B51404EEAAD3B435B51404EE'
+import logging
+import sys
+def parse_identity(args):
+    domain, username, password = parse_credentials(args.identity)
+
+    if domain == '':
+        logging.critical('Domain should be specified!')
+        sys.exit(1)
+
+    if password == '' and username != '' and args.hashes is None and args.no_pass is False and args.aesKey is None:
+        from getpass import getpass
+        logging.info("No credentials supplied, supply password")
+        password = getpass("Password:")
+
+    if args.aesKey is not None:
+        args.k = True
+
+    if args.hashes is not None:
+        lmhash, nthash = args.hashes.split(':')
+        if lmhash == '':
+            lmhash = EMPTY_LM_HASH
+    else:
+        lmhash = ''
+        nthash = ''
+
+    return domain, username, password, lmhash, nthash

--- a/impacket/examples/utils.py
+++ b/impacket/examples/utils.py
@@ -60,3 +60,194 @@ def parse_credentials(credentials):
     domain, username, password = credential_regex.match(credentials).groups('')
 
     return domain, username, password
+
+# ----------
+
+from impacket.smbconnection import SMBConnection
+import ldap3
+import ssl
+from binascii import unhexlify
+from impacket.spnego import SPNEGO_NegTokenInit, TypesMech
+
+def _get_machine_name(dc_ip, domain):
+    if dc_ip is not None:
+        s = SMBConnection(dc_ip, dc_ip)
+    else:
+        s = SMBConnection(domain, domain)
+    try:
+        s.login('', '')
+    except Exception:
+        if s.getServerName() == '':
+            raise Exception('Error while anonymous logging into %s' % domain)
+    else:
+        s.logoff()
+    return s.getServerName()
+
+def _ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='', nthash='', aesKey='', kdcHost=None, TGT=None, TGS=None, useCache=True):
+    from pyasn1.codec.ber import encoder, decoder
+    from pyasn1.type.univ import noValue
+    """
+    logins into the target system explicitly using Kerberos. Hashes are used if RC4_HMAC is supported.
+    :param string user: username
+    :param string password: password for the user
+    :param string domain: domain where the account is valid for (required)
+    :param string lmhash: LMHASH used to authenticate using hashes (password is not used)
+    :param string nthash: NTHASH used to authenticate using hashes (password is not used)
+    :param string aesKey: aes256-cts-hmac-sha1-96 or aes128-cts-hmac-sha1-96 used for Kerberos authentication
+    :param string kdcHost: hostname or IP Address for the KDC. If None, the domain will be used (it needs to resolve tho)
+    :param struct TGT: If there's a TGT available, send the structure here and it will be used
+    :param struct TGS: same for TGS. See smb3.py for the format
+    :param bool useCache: whether or not we should use the ccache for credentials lookup. If TGT or TGS are specified this is False
+    :return: True, raises an Exception if error.
+    """
+
+    if lmhash != '' or nthash != '':
+        if len(lmhash) % 2:
+            lmhash = '0' + lmhash
+        if len(nthash) % 2:
+            nthash = '0' + nthash
+        try:  # just in case they were converted already
+            lmhash = unhexlify(lmhash)
+            nthash = unhexlify(nthash)
+        except TypeError:
+            pass
+
+    # Importing down here so pyasn1 is not required if kerberos is not used.
+    from impacket.krb5.ccache import CCache
+    from impacket.krb5.asn1 import AP_REQ, Authenticator, TGS_REP, seq_set
+    from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGS
+    from impacket.krb5 import constants
+    from impacket.krb5.types import Principal, KerberosTime, Ticket
+    import datetime
+
+    if TGT is not None or TGS is not None:
+        useCache = False
+
+    target = 'ldap/%s' % target
+    if useCache:
+        domain, user, TGT, TGS = CCache.parseFile(domain, user, target)
+
+    # First of all, we need to get a TGT for the user
+    userName = Principal(user, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
+    if TGT is None:
+        if TGS is None:
+            tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, password, domain, lmhash, nthash, aesKey, kdcHost)
+    else:
+        tgt = TGT['KDC_REP']
+        cipher = TGT['cipher']
+        sessionKey = TGT['sessionKey']
+
+    if TGS is None:
+        serverName = Principal(target, type=constants.PrincipalNameType.NT_SRV_INST.value)
+        tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey)
+    else:
+        tgs = TGS['KDC_REP']
+        cipher = TGS['cipher']
+        sessionKey = TGS['sessionKey']
+
+        # Let's build a NegTokenInit with a Kerberos REQ_AP
+
+    blob = SPNEGO_NegTokenInit()
+
+    # Kerberos
+    blob['MechTypes'] = [TypesMech['MS KRB5 - Microsoft Kerberos 5']]
+
+    # Let's extract the ticket from the TGS
+    tgs = decoder.decode(tgs, asn1Spec=TGS_REP())[0]
+    ticket = Ticket()
+    ticket.from_asn1(tgs['ticket'])
+
+    # Now let's build the AP_REQ
+    apReq = AP_REQ()
+    apReq['pvno'] = 5
+    apReq['msg-type'] = int(constants.ApplicationTagNumbers.AP_REQ.value)
+
+    opts = []
+    apReq['ap-options'] = constants.encodeFlags(opts)
+    seq_set(apReq, 'ticket', ticket.to_asn1)
+
+    authenticator = Authenticator()
+    authenticator['authenticator-vno'] = 5
+    authenticator['crealm'] = domain
+    seq_set(authenticator, 'cname', userName.components_to_asn1)
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    authenticator['cusec'] = now.microsecond
+    authenticator['ctime'] = KerberosTime.to_asn1(now)
+
+    encodedAuthenticator = encoder.encode(authenticator)
+
+    # Key Usage 11
+    # AP-REQ Authenticator (includes application authenticator
+    # subkey), encrypted with the application session key
+    # (Section 5.5.1)
+    encryptedEncodedAuthenticator = cipher.encrypt(sessionKey, 11, encodedAuthenticator, None)
+
+    apReq['authenticator'] = noValue
+    apReq['authenticator']['etype'] = cipher.enctype
+    apReq['authenticator']['cipher'] = encryptedEncodedAuthenticator
+
+    blob['MechToken'] = encoder.encode(apReq)
+
+    request = ldap3.operation.bind.bind_operation(connection.version, ldap3.SASL, user, None, 'GSS-SPNEGO', blob.getData())
+
+    # Done with the Kerberos saga, now let's get into LDAP
+    if connection.closed:  # try to open connection if closed
+        connection.open(read_server_info=False)
+
+    connection.sasl_in_progress = True
+    response = connection.post_send_single_response(connection.send('bindRequest', request, None))
+    connection.sasl_in_progress = False
+    if response[0]['result'] != 0:
+        raise Exception(response)
+
+    connection.bound = True
+
+    return True
+
+def _init_ldap_connection(target, tls_version, args, domain, username, password, lmhash, nthash, k, dc_ip, aesKey):
+    user = '%s\\%s' % (domain, username)
+    connect_to = target
+    if dc_ip is not None:
+        connect_to = dc_ip
+    if tls_version is not None:
+        use_ssl = True
+        port = 636
+        tls = ldap3.Tls(validate=ssl.CERT_NONE, version=tls_version)
+    else:
+        use_ssl = False
+        port = 389
+        tls = None
+    ldap_server = ldap3.Server(connect_to, get_info=ldap3.ALL, port=port, use_ssl=use_ssl, tls=tls)
+    if k:
+        ldap_session = ldap3.Connection(ldap_server)
+        ldap_session.bind()
+        _ldap3_kerberos_login(ldap_session, target, username, password, domain, lmhash, nthash, aesKey, kdcHost=dc_ip)
+    elif lmhash == '' and nthash == '':
+        ldap_session = ldap3.Connection(ldap_server, user=user, password=password, authentication=ldap3.NTLM, auto_bind=True)
+    else:
+        ldap_session = ldap3.Connection(ldap_server, user=user, password=lmhash + ":" + nthash, authentication=ldap3.NTLM, auto_bind=True)
+
+    return ldap_server, ldap_session
+
+def init_ldap_session(domain, username, password, lmhash, nthash, k, dc_ip, aesKey, use_ldaps):
+    """
+        k           (bool)  : use Kerberos authentication
+        dc_ip       (string): ip of the domain controller
+        use_ldaps   (boold) : SSL Ldap or Ldap
+    """
+    if k:
+        target = _get_machine_name(dc_ip, domain)
+    else:
+        if dc_ip is not None:
+            target = dc_ip
+        else:
+            target = domain
+
+    if use_ldaps is True:
+        try:
+            return _init_ldap_connection(target, ssl.PROTOCOL_TLSv1_2, domain, username, password, lmhash, nthash, k, dc_ip, aesKey)
+        except ldap3.core.exceptions.LDAPSocketOpenError:
+            return _init_ldap_connection(target, ssl.PROTOCOL_TLSv1, domain, username, password, lmhash, nthash, k, dc_ip, aesKey)
+    else:
+        return _init_ldap_connection(target, None, domain, username, password, lmhash, nthash, k, dc_ip, aesKey)

--- a/impacket/examples/utils.py
+++ b/impacket/examples/utils.py
@@ -83,7 +83,7 @@ def _get_machine_name(dc_ip, domain):
         s.logoff()
     return s.getServerName()
 
-def _ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='', nthash='', aesKey='', kdcHost=None, TGT=None, TGS=None, useCache=True):
+def ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='', nthash='', aesKey='', kdcHost=None, TGT=None, TGS=None, useCache=True):
     from pyasn1.codec.ber import encoder, decoder
     from pyasn1.type.univ import noValue
     """
@@ -222,7 +222,7 @@ def _init_ldap_connection(target, tls_version, args, domain, username, password,
     if k:
         ldap_session = ldap3.Connection(ldap_server)
         ldap_session.bind()
-        _ldap3_kerberos_login(ldap_session, target, username, password, domain, lmhash, nthash, aesKey, kdcHost=dc_ip)
+        ldap3_kerberos_login(ldap_session, target, username, password, domain, lmhash, nthash, aesKey, kdcHost=dc_ip)
     elif lmhash == '' and nthash == '':
         ldap_session = ldap3.Connection(ldap_server, user=user, password=password, authentication=ldap3.NTLM, auto_bind=True)
     else:

--- a/impacket/examples/utils.py
+++ b/impacket/examples/utils.py
@@ -251,3 +251,7 @@ def init_ldap_session(domain, username, password, lmhash, nthash, k, dc_ip, aesK
             return _init_ldap_connection(target, ssl.PROTOCOL_TLSv1, domain, username, password, lmhash, nthash, k, dc_ip, aesKey)
     else:
         return _init_ldap_connection(target, None, domain, username, password, lmhash, nthash, k, dc_ip, aesKey)
+
+# ----------
+
+EMPTY_LM_HASH = 'AAD3B435B51404EEAAD3B435B51404EE'

--- a/impacket/examples/utils.py
+++ b/impacket/examples/utils.py
@@ -255,29 +255,24 @@ def init_ldap_session(domain, username, password, lmhash, nthash, k, dc_ip, aesK
 # ----------
 
 EMPTY_LM_HASH = 'AAD3B435B51404EEAAD3B435B51404EE'
-import logging
-import sys
-def parse_identity(args):
-    domain, username, password = parse_credentials(args.identity)
+def parse_identity(credentials, hashes=None, no_pass=False, aesKey=None, k=False, getpass_msg='Password:'):
+    domain, username, password = parse_credentials(credentials)
 
-    if domain == '':
-        logging.critical('Domain should be specified!')
-        sys.exit(1)
+    if domain is None:
+        domain = ''
 
-    if password == '' and username != '' and args.hashes is None and args.no_pass is False and args.aesKey is None:
+    if password == '' and username != '' and hashes is None and no_pass is False and aesKey is None:
         from getpass import getpass
-        logging.info("No credentials supplied, supply password")
-        password = getpass("Password:")
+        password = getpass(getpass_msg)
 
-    if args.aesKey is not None:
-        args.k = True
+    if aesKey is not None:
+        k = True
 
-    if args.hashes is not None:
-        lmhash, nthash = args.hashes.split(':')
+    lmhash = ''
+    nthash = ''
+    if hashes is not None:
+        lmhash, nthash = hashes.split(':')
         if lmhash == '':
             lmhash = EMPTY_LM_HASH
-    else:
-        lmhash = ''
-        nthash = ''
 
-    return domain, username, password, lmhash, nthash
+    return domain, username, password, lmhash, nthash, k

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -4358,6 +4358,9 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
     def getJTRdumpPath(self):
         return self.__jtr_dump_path
 
+    def getDumpHashes(self):
+        return self.__dump_hashes
+
     def getAuthCallback(self):
         return self.auth_callback
 
@@ -4674,11 +4677,15 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
         if self.__serverConfig.has_option("global", "jtr_dump_path"):
             self.__jtr_dump_path = self.__serverConfig.get("global", "jtr_dump_path")
 
+        if self.__serverConfig.has_option("global", "dump_hashes"):
+            self.__dump_hashes = self.__serverConfig.getboolean("global", "dump_hashes")
+        else:
+            self.__dump_hashes = False
+
         if self.__serverConfig.has_option("global", "SMB2Support"):
             self.__SMB2Support = self.__serverConfig.getboolean("global", "SMB2Support")
         else:
             self.__SMB2Support = False
-
 
         if self.__serverConfig.has_option("global", "anonymous_logon"):
             self.__anonymousLogon = self.__serverConfig.getboolean("global", "anonymous_logon")


### PR DESCRIPTION
This PR aims to standardize some examples requirements and group them in a single _utils_ script that could be leveraged by existing and future examples.

### Shared Functionality

**Logging initialization**
* Added flags `-ts` and `-debug` to every example
* Created a single function to initialize logging and call it from all examples...
https://github.com/fortra/impacket/blob/8b4e3744b8f012b4d333fbd5c34b4879d3313ad2/impacket/examples/logger.py#L57

**LDAP Login**
* Extracted common LDAP login functions - calling them from examples that were redefining it
https://github.com/fortra/impacket/blob/8b4e3744b8f012b4d333fbd5c34b4879d3313ad2/impacket/examples/utils.py#L86
https://github.com/fortra/impacket/blob/8b4e3744b8f012b4d333fbd5c34b4879d3313ad2/impacket/examples/utils.py#L233

**Identity Parsing**
* Extracted identity parsing functionality and replaced it in examples that were needing it
https://github.com/fortra/impacket/blob/8b4e3744b8f012b4d333fbd5c34b4879d3313ad2/impacket/examples/utils.py#L258