### PR TITLE
Removed invalid structure parameters

### DIFF
--- a/impacket/smb.py
+++ b/impacket/smb.py
@@ -916,7 +916,7 @@ class SMBFindFileBothDirectoryInfo(AsciiOrUnicodeStructure):
         ('ExtFileAttributes','<L=0'),
     )
     AsciiStructure = (
-        ('FileNameLength','<L-FileName','len(FileName)'),
+        ('FileNameLength','<L-FileName'),
         ('EaSize','<L=0'),
         ('ShortNameLength','<B=0'),
         ('Reserved','<B=0'),
@@ -924,7 +924,7 @@ class SMBFindFileBothDirectoryInfo(AsciiOrUnicodeStructure):
         ('FileName',':'),
     )
     UnicodeStructure = (
-        ('FileNameLength','<L-FileName','len(FileName)*2'),
+        ('FileNameLength','<L-FileName'),
         ('EaSize','<L=0'),
         ('ShortNameLength','<B=0'),
         ('Reserved','<B=0'),
@@ -946,14 +946,14 @@ class SMBFindFileIdFullDirectoryInfo(AsciiOrUnicodeStructure):
         ('ExtFileAttributes','<L=0'),
     )
     AsciiStructure = (
-        ('FileNameLength','<L-FileName','len(FileName)'),
+        ('FileNameLength','<L-FileName'),
         ('EaSize','<L=0'),
         ('Reserved', '<L=0'),
         ('FileID','<q=0'),
         ('FileName','z'),
     )
     UnicodeStructure = (
-        ('FileNameLength','<L-FileName','len(FileName)*2'),
+        ('FileNameLength','<L-FileName'),
         ('EaSize','<L=0'),
         ('Reserved','<L=0'),
         ('FileID','<q=0'),
@@ -974,7 +974,7 @@ class SMBFindFileIdBothDirectoryInfo(AsciiOrUnicodeStructure):
         ('ExtFileAttributes','<L=0'),
     )
     AsciiStructure = (
-        ('FileNameLength','<L-FileName','len(FileName)'),
+        ('FileNameLength','<L-FileName'),
         ('EaSize','<L=0'),
         ('ShortNameLength','<B=0'),
         ('Reserved','<B=0'),
@@ -984,7 +984,7 @@ class SMBFindFileIdBothDirectoryInfo(AsciiOrUnicodeStructure):
         ('FileName','z'),
     )
     UnicodeStructure = (
-        ('FileNameLength','<L-FileName','len(FileName)*2'),
+        ('FileNameLength','<L-FileName'),
         ('EaSize','<L=0'),
         ('ShortNameLength','<B=0'),
         ('Reserved','<B=0'),
@@ -1008,11 +1008,11 @@ class SMBFindFileDirectoryInfo(AsciiOrUnicodeStructure):
         ('ExtFileAttributes','<L=0'),
     )
     AsciiStructure = (
-        ('FileNameLength','<L-FileName','len(FileName)'),
+        ('FileNameLength','<L-FileName'),
         ('FileName','z'),
     )
     UnicodeStructure = (
-        ('FileNameLength','<L-FileName','len(FileName)*2'),
+        ('FileNameLength','<L-FileName'),
         ('FileName',':'),
     )
 
@@ -1023,11 +1023,11 @@ class SMBFindFileNamesInfo(AsciiOrUnicodeStructure):
         ('FileIndex','<L=0'),
     )
     AsciiStructure = (
-        ('FileNameLength','<L-FileName','len(FileName)'),
+        ('FileNameLength','<L-FileName'),
         ('FileName','z'),
     )
     UnicodeStructure = (
-        ('FileNameLength','<L-FileName','len(FileName)*2'),
+        ('FileNameLength','<L-FileName'),
         ('FileName',':'),
     )
 
@@ -1045,12 +1045,12 @@ class SMBFindFileFullDirectoryInfo(AsciiOrUnicodeStructure):
         ('ExtFileAttributes','<L=0'),
     )
     AsciiStructure = (
-        ('FileNameLength','<L-FileName','len(FileName)'),
+        ('FileNameLength','<L-FileName'),
         ('EaSize','<L'),
         ('FileName','z'),
     )
     UnicodeStructure = (
-        ('FileNameLength','<L-FileName','len(FileName)*2'),
+        ('FileNameLength','<L-FileName'),
         ('EaSize','<L'),
         ('FileName',':'),
     )
@@ -1070,11 +1070,11 @@ class SMBFindInfoStandard(AsciiOrUnicodeStructure):
         ('ExtFileAttributes','<H=0'),
     )
     AsciiStructure = (
-        ('FileNameLength','<B-FileName','len(FileName)'),
+        ('FileNameLength','<B-FileName'),
         ('FileName','z'),
     )
     UnicodeStructure = (
-        ('FileNameLength','<B-FileName','len(FileName)*2'),
+        ('FileNameLength','<B-FileName'),
         ('FileName',':'),
     )
 
@@ -1302,7 +1302,7 @@ class SMBQueryFileAllInfo(Structure):
         ('Directory','<B'),
         ('Reserved','<H=0'),
         ('EaSize','<L=0'),
-        ('FileNameLength','<L-FileName','len(FileName)'),
+        ('FileNameLength','<L-FileName'),
         ('FileName',':'),
     )
 


### PR DESCRIPTION
Related to [#1876](https://github.com/fortra/impacket/issues/1876)
Several smb structures contain a FileNameLength field which is specified by 3 parameters. However for the third parameter to be ever used, the second parameter has to have a specific syntax, this was not the case.
This PR removes the third parameter from those fields, it shouldn't have any splash damage as they were not being used

Additional Info
structure.py specifies that formats with a '_' in their values will use a third parameter: https://github.com/fortra/impacket/blob/ae0ec300f8a43c8554fa99a6566815c2bef21549/impacket/structure.py#L73

however all the offending structures have the following format '?-field' with ? being any struct size specifier (B|H|L):https://github.com/fortra/impacket/blob/ae0ec300f8a43c8554fa99a6566815c2bef21549/impacket/structure.py#L69
so they don't need a third parameter.

If we inspect structure.py, the only time were functions are being evaluated is when format either contains '_' or '=', it wasn't the case in the modified structures:
https://github.com/fortra/impacket/blob/ae0ec300f8a43c8554fa99a6566815c2bef21549/impacket/structure.py#L203-L210
https://github.com/fortra/impacket/blob/ae0ec300f8a43c8554fa99a6566815c2bef21549/impacket/structure.py#L307-L313