### PR TITLE
Techdebt examples bootstrapping fixes

### DIFF
--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -483,7 +483,7 @@ if __name__ == '__main__':
                       ' a list of SPNs and/or sAMAccountNames to Kerberoast.')
         sys.exit(1)
 
-    userDomain, username, password, _, _, options.k = parse_identity(options.identity, options.hashes, options.no_pass, options.aesKey, options.k)
+    userDomain, username, password, _, _, options.k = parse_identity(options.target, options.hashes, options.no_pass, options.aesKey, options.k)
 
     if userDomain == '':
         logging.critical('userDomain should be specified!')

--- a/examples/findDelegation.py
+++ b/examples/findDelegation.py
@@ -109,7 +109,7 @@ class FindDelegation:
 
     def run(self):
         # Connect to LDAP
-        ldapConnection = ldap_login(self.__target, self.baseDN, self.__kdcIP, self.__kdcHost, self.__doKerberos, self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash, self.__aesKey, targetDomain=self.__targetDomain, fqdn=True)
+        ldapConnection = ldap_login(self.__target, self.baseDN, self.__kdcIP, self.__kdcHost, self.__doKerberos, self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash, self.__aesKey, target_domain=self.__targetDomain, fqdn=True)
         # updating "self.__target" as it may have changed in the ldap_login processing
         self.__target = ldapConnection._dstHost
 

--- a/examples/rpcmap.py
+++ b/examples/rpcmap.py
@@ -325,7 +325,7 @@ if __name__ == '__main__':
     logger.init(options.ts, options.debug)
 
     rpcdomain, rpcuser, rpcpass, _, _, _ = parse_identity(options.auth_rpc, options.hashes_rpc, options.no_pass, getpass_msg='Password for MSRPC communication:')
-    transportdomain, transportuser, transportpass, _, _, _ = parse_identity(options.auth_rpc, options.hashes_rpc, options.no_pass, getpass_msg='Password for RPC transport (SMB or HTTP):')
+    transportdomain, transportuser, transportpass, _, _, _ = parse_identity(options.auth_transport, options.hashes_transport, options.no_pass, getpass_msg='Password for RPC transport (SMB or HTTP):')
 
     if options.brute_opnums and options.brute_versions:
        logging.error("Specify only -brute-opnums or -brute-versions")


### PR DESCRIPTION
This PR fixes #1934

Besides those issues reported in `findDelegation.py` and `GetUserSPNs.py`, fixed another one in `rpcmap.py`; same auth parameter was parsed twice...