### PR TITLE
Techdebt examples bootstrapping target domain fixes

### DIFF
--- a/impacket/examples/utils.py
+++ b/impacket/examples/utils.py
@@ -70,7 +70,7 @@ from binascii import unhexlify
 from impacket.spnego import SPNEGO_NegTokenInit, TypesMech
 
 def _get_machine_name(machine, fqdn=False):
-    s = SMBConnection(machine)
+    s = SMBConnection(machine, machine)
     try:
         s.login('', '')
     except Exception:

--- a/impacket/examples/utils.py
+++ b/impacket/examples/utils.py
@@ -260,13 +260,16 @@ def init_ldap_session(domain, username, password, lmhash, nthash, k, dc_ip, aesK
 from impacket.ldap import ldap
 import logging
 def ldap_login(target, base_dn, kdc_ip, kdc_host, do_kerberos, username, password, domain, lmhash, nthash, aeskey, target_domain=None, fqdn=False):
-    if kdc_host is not None and domain == target_domain:
+    if kdc_host is not None and (target_domain is None or domain == target_domain):
         target = kdc_host
     else:
-        if kdc_ip is not None and domain == target_domain:
+        if kdc_ip is not None and (target_domain is None or domain == target_domain):
             target = kdc_ip
         else:
-            target = target_domain
+            if target_domain is not None:
+                target = target_domain
+            else:
+                target = domain
 
         if do_kerberos:
             logging.info('Getting machine hostname')


### PR DESCRIPTION
This PR fixes #1936

Basically 2 main fixes were pushed:
* target definition / resolution logic in `ldap_login` function (this is the issue reported in #1936) -> https://github.com/fortra/impacket/commit/c63d1486816361e1cbea308206080e3bdf09ca5b
* some examples (`GetLAPSPassword`, `GetNPUsers`, `GetADUsers` and `GetADComputers`) are not defining `-target-domain` parameter and are calling same function than those that do define it (`GetUserSPNs` and `findDelegation`) - these scenarios has been better handled in `ldap_login` function -> https://github.com/fortra/impacket/commit/91be51e5b9ce4fd9a9bd83816779b443fbd5a908