### PR TITLE
relax the too strict requirement on pyOpenSSL version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ charset_normalizer
 pyasn1>=0.2.3
 pyasn1_modules
 pycryptodomex
-pyOpenSSL==24.0.0
+pyOpenSSL>=24.0
 ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6
 ldapdomaindump>=0.9.0
 flask>=1.0

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     scripts=glob.glob(os.path.join('examples', '*.py')),
     data_files=data_files,
 
-    install_requires=['pyasn1>=0.2.3', 'pyasn1_modules', 'pycryptodomex', 'pyOpenSSL==24.0.0', 'six', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6',
+    install_requires=['pyasn1>=0.2.3', 'pyasn1_modules', 'pycryptodomex', 'pyOpenSSL>=24.0', 'six', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6',
                       'ldapdomaindump>=0.9.0', 'flask>=1.0', 'setuptools', 'charset_normalizer'],
     extras_require={':sys_platform=="win32"': ['pyreadline3'],
                     },


### PR DESCRIPTION
Hello, 
the requirement to have pyOpenSSL version exactly == 24.0.0 is too strict. 
I believe relaxing that to >=24.0 should be enough.

Michal Ambroz