### PR TITLE
Added Support for LDAPS When Retrieving LAPS Password from Windows Server 2025

### DIFF
--- a/examples/GetLAPSPassword.py
+++ b/examples/GetLAPSPassword.py
@@ -78,6 +78,7 @@ class GetLAPSPassword:
         self.__kdcHost = cmdLineOptions.dc_host
         self.__targetComputer = cmdLineOptions.computer
         self.__outputFile = cmdLineOptions.outputfile
+        self.__ldaps_flag = cmdLineOptions.ldaps_flag
         self.__KDSCache = {}
 
         if cmdLineOptions.hashes is not None:
@@ -162,7 +163,7 @@ class GetLAPSPassword:
 
     def run(self):
         # Connect to LDAP
-        ldapConnection = ldap_login(self.__target, self.baseDN, self.__kdcIP, self.__kdcHost, self.__doKerberos, self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash, self.__aesKey)
+        ldapConnection = ldap_login(self.__target, self.baseDN, self.__kdcIP, self.__kdcHost, self.__doKerberos, self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash, self.__aesKey, self.__ldaps_flag)
         # updating "self.__target" as it may have changed in the ldap_login processing
         self.__target = ldapConnection._dstHost
 
@@ -271,6 +272,10 @@ if __name__ == '__main__':
     group.add_argument('-dc-host', action='store', metavar='hostname', help='Hostname of the domain controller to use. '
                                                                               'If ommited, the domain part (FQDN) '
                                                                               'specified in the account parameter will be used')
+    
+    group.add_argument('-ldaps', dest='ldaps_flag', action="store_true", help='Enable LDAPS (LDAP over SSL). '
+                                                                                'Required when querying a Windows Server 2025'
+                                                                                'domain controller with LDAPS enforced.')
 
     if len(sys.argv)==1:
         parser.print_help()

--- a/impacket/examples/utils.py
+++ b/impacket/examples/utils.py
@@ -259,7 +259,7 @@ def init_ldap_session(domain, username, password, lmhash, nthash, k, dc_ip, aesK
 
 from impacket.ldap import ldap
 import logging
-def ldap_login(target, base_dn, kdc_ip, kdc_host, do_kerberos, username, password, domain, lmhash, nthash, aeskey, target_domain=None, fqdn=False):
+def ldap_login(target, base_dn, kdc_ip, kdc_host, do_kerberos, username, password, domain, lmhash, nthash, aeskey, ldaps_flag, target_domain=None, fqdn=False):
     if kdc_host is not None and (target_domain is None or domain == target_domain):
         target = kdc_host
     else:
@@ -274,10 +274,13 @@ def ldap_login(target, base_dn, kdc_ip, kdc_host, do_kerberos, username, passwor
         if do_kerberos:
             logging.info('Getting machine hostname')
             target = _get_machine_name(target, fqdn)
+    
+    # Added ldaps flag & placed check for ldaps if flag is enabled.
+    url = 'ldaps://%s' if ldaps_flag else 'ldap://%s'
 
     # Connect to LDAP
     try:
-        ldapConnection = ldap.LDAPConnection('ldap://%s' % target, base_dn, kdc_ip)
+        ldapConnection = ldap.LDAPConnection(url % target, base_dn, kdc_ip)
         if do_kerberos is not True:
             ldapConnection.login(username, password, domain, lmhash, nthash)
         else:

--- a/impacket/examples/utils.py
+++ b/impacket/examples/utils.py
@@ -259,7 +259,7 @@ def init_ldap_session(domain, username, password, lmhash, nthash, k, dc_ip, aesK
 
 from impacket.ldap import ldap
 import logging
-def ldap_login(target, base_dn, kdc_ip, kdc_host, do_kerberos, username, password, domain, lmhash, nthash, aeskey, ldaps_flag, target_domain=None, fqdn=False):
+def ldap_login(target, base_dn, kdc_ip, kdc_host, do_kerberos, username, password, domain, lmhash, nthash, aeskey, ldaps_flag=False, target_domain=None, fqdn=False):
     if kdc_host is not None and (target_domain is None or domain == target_domain):
         target = kdc_host
     else:


### PR DESCRIPTION
### Description
Added support for LDAPS in GetLAPSPassword.py to ensure compatibility with Windows Server 2025, which enforces LDAPS over LDAP. Introduced a boolean flag `-ldaps` to enable LDAPS support when retrieving LAPS passwords.
This PR addresses and resolves: https://github.com/fortra/impacket/issues/1880
### Configuration

impacket version: v0.130.dev
Python version: 3.13.2
Target OS: Windows Server 2025 Datacenter Evaluation 24H2
Attacking OS: Kali
### Debug Output With Command String
```┌──(venv)─(kali㉿kali)-[~/Desktop/impacket (2)/examples]
└─$ python3 GetLAPSPassword.py -dc-ip 192.168.164.129 "TESTLAB.local/Administrator:<Password>" -debug -ldaps
Impacket v0.13.0.dev0+20250401.172759.352695f1 - Copyright Fortra, LLC and its affiliated companies

[+] Impacket Library Installation Path: /home/kali/Desktop/impacket (2)/examples/venv/lib/python3.13/site-packages/impacket-0.13.0.dev0+20250401.172759.352695f1-py3.13.egg/impacket
[*] Using LDAPS
[+] Connecting to 192.168.164.129, port 636, SSL True
[+] Total of records returned 4
[+] Connecting to ncacn_ip_tcp:192.168.164.129[49682]
[+] Connected
[+] Successfully bound
[+] Calling MS-GKDI GetKey
Host     	LAPS Username  LAPS Password   LAPS Password Expiration  LAPSv2
-----------  -------------  --------------  ------------------------  ------
CLIENT-PC1$  Administrator  6Yg[RfHz%@50x+  2025-05-06 08:59:59   	True   
  ```
### Screenshot
![impacket](https://github.com/user-attachments/assets/26312b28-b917-48e0-b0d0-f861d566fee9)

