### PR TITLE
Allow LDAP queries with non-ascii chars

### DIFF
--- a/impacket/ldap/ldapasn1.py
+++ b/impacket/ldap/ldapasn1.py
@@ -161,7 +161,7 @@ class AttributeValue(univ.OctetString):
 
 
 class AssertionValue(univ.OctetString):
-    pass
+    encoding = 'utf-8'
 
 
 class MatchingRuleID(LDAPString):


### PR DESCRIPTION
Currently querying with non-ascii chars is not possible because of the default encoding `latin-1`/`iso-8859-1`. This prevents queries like the german "Domänen Administratoren" or other non-ascii entities. To fix this, the search_filter's `AssertionValue` musst be encoded with `utf-8` instead of `latin-1`:
![image](https://github.com/user-attachments/assets/dde73ac4-823c-4d1a-83bf-a980d08e56b3)

Take this fix with a grain of salt. This change seems logical to me, but my knowledge about Asn1 is limited.
