### PR TITLE
Fix sequenceNumber calculation

### DIFF
--- a/impacket/spnego.py
+++ b/impacket/spnego.py
@@ -457,8 +457,6 @@ class SPNEGOCipher:
                 answer[16:], 
                 self.__sequence, 
                 self.__serverSealingHandle)
-    
-        self.__sequence += 1
 
         return signature, answer
     


### PR DESCRIPTION
Hi @gabrielg5 @anadrianmanrique 

Thanks for merging last PR #1919. While testing the integration of this PR in Impacket, I noticed a bug on LDAP search requests on a domain controller with LDAP signing enforced with a bind request made through NTLM-sasl. The server always return a Notice of Disconnection at the second LDAP search request in the LDAP session.

This is because the sequence number is incremented when decrypting data.  

I doubled the LDAP `ldapConnection.search` function in `GetUserSPNs.py` to showcase the fix:
![image](https://github.com/user-attachments/assets/393a3f83-fea4-41cc-b0f7-0b0bb3064f70)

Before: 
![image](https://github.com/user-attachments/assets/8febe830-3a4d-4b40-b74c-2b31fda6f5af)

After:
![image](https://github.com/user-attachments/assets/2683be16-2546-4e87-ab54-cd63bc4b2066)

