### PR TITLE
SAMR UnicodeChangePasswordUser issue fix when using high code point unicode characters

### DIFF
--- a/impacket/dcerpc/v5/samr.py
+++ b/impacket/dcerpc/v5/samr.py
@@ -2835,12 +2835,14 @@ def hSamrUnicodeChangePasswordUser2(dce, serverName='\x00', userName='', oldPass
 
     samUser = SAMPR_USER_PASSWORD()
     try:
-        samUser['Buffer'] = b'A'*(512-len(newPassword)*2) + newPassword.encode('utf-16le')
+        encoded_password = newPassword.encode('utf-16le')
     except UnicodeDecodeError:
         import sys
-        samUser['Buffer'] = b'A'*(512-len(newPassword)*2) + newPassword.decode(sys.getfilesystemencoding()).encode('utf-16le')
+        encoded_password = newPassword.decode(sys.getfilesystemencoding()).encode('utf-16le')
 
-    samUser['Length'] = len(newPassword)*2
+    samUser['Buffer'] = b'A' * (512 - len(encoded_password)) + encoded_password
+
+    samUser['Length'] = len(encoded_password)
     pwdBuff = samUser.getData()
 
     rc4 = ARC4.new(oldPwdHashNT)

--- a/tests/dcerpc/test_samr.py
+++ b/tests/dcerpc/test_samr.py
@@ -2272,7 +2272,7 @@ class SAMRTests(DCERPCTests):
 
         oldPwd = 'ADMIN'
         oldPwdHashNT = ntlm.NTOWFv1(oldPwd)
-        newPwd = "".join([random.choice(string.ascii_letters) for i in range(15)])
+        newPwd = "".join([random.choice(string.ascii_letters) for i in range(15)]) + "❤️🤷‍♂️😈"
         newPwdHashNT = ntlm.NTOWFv1(newPwd)
 
         try:
@@ -2285,8 +2285,9 @@ class SAMRTests(DCERPCTests):
         request['ServerName'] = ''
         request['UserName'] = self.test_account
         samUser = samr.SAMPR_USER_PASSWORD()
-        samUser['Buffer'] = b'A'*(512-len(newPwd)*2) + newPwd.encode('utf-16le')
-        samUser['Length'] = len(newPwd)*2
+        encoded_password = newPwd.encode('utf-16le')
+        samUser['Buffer'] = b'A'*(512-len(encoded_password)) + encoded_password
+        samUser['Length'] = len(encoded_password)
         pwdBuff = samUser.getData()
 
         rc4 = ARC4.new(oldPwdHashNT)


### PR DESCRIPTION
This PR fixes issues (described in #1876) in samr.py, specifically in UnicodeChangePasswordUser.
Using high code point unicode characters such as most emojis will make the method fail.