### PR TITLE
Bugfix in directory listing funcionality on SMB3

### DIFF
--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -1802,7 +1802,7 @@ class SMB3:
             from impacket import smb
             while True:
                 try:
-                    res = self.queryDirectory(treeId, fileId, ntpath.basename(path), maxBufferSize=65535,
+                    res = self.queryDirectory(treeId, fileId, maxBufferSize=65535,
                                               informationClass=FILE_FULL_DIRECTORY_INFORMATION)
                     nextOffset = 1
                     while nextOffset != 0:

--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -1793,7 +1793,7 @@ class SMB3:
         fileId = None
         try:
             # ToDo, we're assuming it's a directory, we should check what the file type is
-            fileId = self.create(treeId, ntpath.dirname(path), FILE_READ_ATTRIBUTES | FILE_READ_DATA, FILE_SHARE_READ |
+            fileId = self.create(treeId, path, FILE_READ_ATTRIBUTES | FILE_READ_DATA, FILE_SHARE_READ |
                                  FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                                  FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT, FILE_OPEN, 0,
                                  createContexts=createContexts)

--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -1452,7 +1452,7 @@ class SMB3:
                 bytesWritten += self.write(treeId, fileId, data[bytesWritten:], offset+bytesWritten, bytesToWrite-bytesWritten, waitAnswer)
             return bytesWritten
 
-    def queryDirectory(self, treeId, fileId, searchString = '*', resumeIndex = 0, informationClass = FILENAMES_INFORMATION, maxBufferSize = None, enumRestart = False, singleEntry = False):
+    def queryDirectory(self, treeId, fileId, searchString = '*', resumeIndex = 0, informationClass = FILENAMES_INFORMATION, maxBufferSize = None):
         if (treeId in self._Session['TreeConnectTable']) is False:
             raise SessionError(STATUS_INVALID_PARAMETER)
         if (fileId in self._Session['OpenTable']) is False:


### PR DESCRIPTION
~~This PR contains 2 changes:~~

~~1. Removing `ntpath.basename(path)` from `queryDirectory()` parameters, which causes `listPath()` function only show the target directory itself (and not inner files/directories)~~
~~2. Removing `enumRestart` and `singleEntry` from `queryDirectory()` parameters list, since they are completely unused.~~
