### PR TITLE
several bugfixes in smb protocol

### DIFF
--- a/impacket/smb.py
+++ b/impacket/smb.py
@@ -1092,7 +1092,7 @@ class SMBSetFileBasicInfo(Structure):
         ('LastAccessTime','<q'),
         ('LastWriteTime','<q'),
         ('ChangeTime','<q'),
-        ('ExtFileAttributes','<H'),
+        ('ExtFileAttributes','<L'),
         ('Reserved','<L'),
     )
 

--- a/impacket/smb.py
+++ b/impacket/smb.py
@@ -621,10 +621,11 @@ class SharedDevice:
 
 # Contains information about the shared file/directory
 class SharedFile:
-    def __init__(self, ctime, atime, mtime, filesize, allocsize, attribs, shortname, longname):
-        self.__ctime = ctime
-        self.__atime = atime
-        self.__mtime = mtime
+    def __init__(self, ctime, atime, wtime, mtime, filesize, allocsize, attribs, shortname, longname):
+        self.__ctime = ctime # CreateTime ([MS-CIFS] 2.2.8.1.4 SMB_FIND_FILE_DIRECTORY_INFO)
+        self.__atime = atime # LastAccessTime ([MS-CIFS] 2.2.8.1.4 SMB_FIND_FILE_DIRECTORY_INFO)
+        self.__wtime = wtime # LastWriteTime ([MS-CIFS] 2.2.8.1.4 SMB_FIND_FILE_DIRECTORY_INFO)
+        self.__mtime = mtime # LastAttrChangeTime ([MS-CIFS] 2.2.8.1.4 SMB_FIND_FILE_DIRECTORY_INFO)
         self.__filesize = filesize
         self.__allocsize = allocsize
         self.__attribs = attribs
@@ -648,6 +649,12 @@ class SharedFile:
 
     def get_ctime_epoch(self):
         return self.__convert_smbtime(self.__ctime)
+
+    def get_wtime(self):
+        return self.__wtime
+
+    def get_wtime_epoch(self):
+        return self.__convert_smbtime(self.__wtime)
 
     def get_mtime(self):
         return self.__mtime
@@ -3970,7 +3977,7 @@ class SMB(object):
                 filename = record['FileName'].decode('utf-16le') if self.__flags2 & SMB.FLAGS2_UNICODE else \
                                                                         record['FileName'].decode('cp437')
 
-                fileRecord = SharedFile(record['CreationTime'], record['LastAccessTime'], record['LastChangeTime'],
+                fileRecord = SharedFile(record['CreationTime'], record['LastAccessTime'], record['LastWriteTime'], record['LastChangeTime'],
                                   record['EndOfFile'], record['AllocationSize'], record['ExtFileAttributes'],
                                   shortname, filename)
                 files.append(fileRecord)

--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -1809,7 +1809,7 @@ class SMB3:
                         fileInfo = smb.SMBFindFileFullDirectoryInfo(smb.SMB.FLAGS2_UNICODE)
                         fileInfo.fromString(res)
                         files.append(smb.SharedFile(fileInfo['CreationTime'], fileInfo['LastAccessTime'],
-                                                    fileInfo['LastChangeTime'], fileInfo['EndOfFile'],
+                                                    fileInfo['LastWriteTime'], fileInfo['LastChangeTime'], fileInfo['EndOfFile'],
                                                     fileInfo['AllocationSize'], fileInfo['ExtFileAttributes'],
                                                     fileInfo['FileName'].decode('utf-16le'),
                                                     fileInfo['FileName'].decode('utf-16le')))

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -791,7 +791,7 @@ class SMBConnection:
                 # if share access mode is none, let's the underlying API deals with it
                 return self._SMBConnection.stor_file(shareName, pathName, callback)
             else:
-                return self._SMBConnection.stor_file(shareName, pathName, callback, shareAccessMode)
+                return self._SMBConnection.stor_file(shareName, pathName, callback, shareAccessMode=shareAccessMode)
         except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 


### PR DESCRIPTION
This PR fixes following issues:

1. The `stor_file()` method used in `putFile()` function of the `SMBConnection` class, has a different parameter order than in `smb.py` and `smb3.py`. Passing `shareAccessMode` positionally causes it to be misassigned. To fix this, the `shareAccessMode` parameter should be explicitly named when calling `stor_file()`.
2. The `ExtFileAttributes` field of `SMBSetFileBasicInfo` structure in `smb.py` is **4 bytes** (not 2 bytes) due to CIFS documentation [here](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/021549da-ef78-4282-ae93-7ae93acaba97).
3. Add missing `LastWriteTime` field to `SharedFile` object.