### PR TITLE
Fix smbexec getting stuck

### DIFF
--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -56,7 +56,7 @@ from impacket import version, smbserver
 from impacket.dcerpc.v5 import transport, scmr
 from impacket.krb5.keytab import Keytab
 
-OUTPUT_FILENAME = '__output'
+OUTPUT_FILENAME = '__output_' + ''.join([random.choice(string.ascii_letters) for i in range(8)])
 SMBSERVER_DIR   = '__tmp'
 DUMMY_SHARE     = 'TMP'
 CODEC = sys.stdout.encoding


### PR DESCRIPTION
When attempting to run two instances of smbexec on the same target simultaneously, or when a single command's output occupies smbexec.py for a long time, the tool may fail to function properly due to the **hardcoded** `OUTPUT_FILENAME`. Modifying it to use a random filename resolves the issue.

Credit: DEVCORE RedTeam internship program 2nd