### PR TITLE
Ensure that the provided key starts with the '0x' prefix before stripping the first 2 characters

### DIFF
--- a/examples/dpapi.py
+++ b/examples/dpapi.py
@@ -164,7 +164,10 @@ class DPAPI:
                     print('Decrypted key: 0x%s' % hexlify(decryptedKey).decode('latin-1'))
                     return
             elif self.options.key and self.options.sid:
-                key = unhexlify(self.options.key[2:])
+                if self.options.key[:2].upper() == '0X':
+                    key = unhexlify(self.options.key[2:])
+                else:
+                    key = unhexlify(self.options.key)
                 key1, key2 = deriveKeysFromUserkey(self.options.sid, key)
                 decryptedKey = mk.decrypt(key1)
                 if decryptedKey:


### PR DESCRIPTION
Hello there,

Proposing this change to avoid the decryption silently failing when an user provides an NT hash as the decryption key (-key parameter) without the 0x prefix.

This example from a recent HTB box fails silently on master:
```Python
┌─[sylvain@debian]─[~/AppSecNotes/CTF/HTB/Machines/Windows/XXXX/work]                 
└──╼ $dpapi.py masterkey -file 556a2412-1275-4ccf-b721-e6a0b4f90407 -sid 'S-1-5-21-1487982659-182905078
3-2281216199-1107' -key 'B261B5F931285CE8EA01A8613F09200B'                                             
Impacket v0.13.0.dev0+20250516.105908.a63c6522 - Copyright Fortra, LLC and its affiliated companies    
                                                                                                       
[MASTERKEYFILE]                                                                                        
Version     :        2 (2)                                                                             
Guid        : 556a2412-1275-4ccf-b721-e6a0b4f90407                                                     
Flags       :        0 (0)                                                                             
Policy      : 4ccf1275 (1288639093)                                                                    
MasterKeyLen: 00000088 (136)                                                                           
BackupKeyLen: 00000068 (104)                                                                           
CredHistLen : 00000000 (0)                                                                             
DomainKeyLen: 00000174 (372)                                                                           
                                                                                                       
Cannot decrypt (specify -key or -sid whenever applicable)
```

I found the stripping to be a bit aggressive given that providing an NT hash is a valid approach and it didn't show any error. It now works fine in both cases, without the '0x' prefix:
```Python
┌─[sylvain@debian]─[~/AppSecNotes/CTF/HTB/Machines/Windows/XXXX/work]
└──╼ $dpapi.py masterkey -file 556a2412-1275-4ccf-b721-e6a0b4f90407 -sid 'S-1-5-21-1487982659-1829050783-2281216199-1107' -key 'B261B5F931285CE8EA01A8613F09200B'
Impacket v0.13.0.dev0+20250516.105908.a63c6522 - Copyright Fortra, LLC and its affiliated companies 

[MASTERKEYFILE]
Version     :        2 (2)
Guid        : 556a2412-1275-4ccf-b721-e6a0b4f90407
Flags       :        0 (0)
Policy      : 4ccf1275 (1288639093)
MasterKeyLen: 00000088 (136)
BackupKeyLen: 00000068 (104)
CredHistLen : 00000000 (0)
DomainKeyLen: 00000174 (372)

Decrypted key with key provided + SID
Decrypted key: 0xd9a570722fbaf7149f9f9d691b0e137b7413c1414c452f9c77d6d8a8ed9efe3ecae990e047debe4ab8cc879e8ba99b31cdb7abad28408d8d9cbfdcaf319e9c84
```

And with it:
```Python
┌─[sylvain@debian]─[~/AppSecNotes/CTF/HTB/Machines/Windows/XXXX/work]
└──╼ $dpapi.py masterkey -file 556a2412-1275-4ccf-b721-e6a0b4f90407 -sid 'S-1-5-21-1487982659-1829050783-2281216199-1107' -key '0XB261B5F931285CE8EA01A8613F09200B'
Impacket v0.13.0.dev0+20250516.105908.a63c6522 - Copyright Fortra, LLC and its affiliated companies 

[MASTERKEYFILE]
Version     :        2 (2)
Guid        : 556a2412-1275-4ccf-b721-e6a0b4f90407
Flags       :        0 (0)
Policy      : 4ccf1275 (1288639093)
MasterKeyLen: 00000088 (136)
BackupKeyLen: 00000068 (104)
CredHistLen : 00000000 (0)
DomainKeyLen: 00000174 (372)

Decrypted key with key provided + SID
Decrypted key: 0xd9a570722fbaf7149f9f9d691b0e137b7413c1414c452f9c77d6d8a8ed9efe3ecae990e047debe4ab8cc879e8ba99b31cdb7abad28408d8d9cbfdcaf319e9c84
```

Tested only on python3.13 but given how minor the change is, I genuinely don't expect any difference.

Thanks for your time and work