### PR TITLE
smbserver: gracefully exit on KeyboardInterrupt

### DIFF
--- a/examples/smbserver.py
+++ b/examples/smbserver.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # Impacket - Collection of Python classes for working with network protocols.
 #
-# Copyright Fortra, LLC and its affiliated companies 
+# Copyright Fortra, LLC and its affiliated companies
 #
 # All rights reserved.
 #
@@ -30,7 +30,7 @@ if __name__ == '__main__':
     print(version.BANNER)
 
     parser = argparse.ArgumentParser(add_help = True, description = "This script will launch a SMB Server and add a "
-                                     "share specified as an argument. You need to be root in order to bind to port 445. "
+                                     "share specified as an argument. Usually, you need to be root in order to bind to port 445. "
                                      "For optional authentication, it is possible to specify username and password or the NTLM hash. "
                                      "Example: smbserver.py -comment 'My share' TMP /tmp")
 
@@ -98,4 +98,8 @@ if __name__ == '__main__':
     server.setSMBChallenge('')
 
     # Rock and roll
-    server.start()
+    try:
+        server.start()
+    except KeyboardInterrupt:
+        print("\nInterrupted, exiting...")
+        sys.exit(130)


### PR DESCRIPTION
Currently, whenever the `smbserver.py` example script is terminated with ctrl+c, a traceback is shown.

This is ugly, let's exit gracefully on `KeyboardInterrupt`. :smile: 

(The unrelated minor change in the wording of the sentence concerning root is because you can as well have something like `net.ipv4.ip_unprivileged_port_start=0` set and do not require root.)