### PR TITLE
Fixes for NMB Protocol

### DIFF
--- a/impacket/nmb.py
+++ b/impacket/nmb.py
@@ -512,7 +512,7 @@ class NetBIOS:
     # Creates a NetBIOS instance without specifying any default NetBIOS domain nameserver.
     # All queries will be sent through the servport.
     def __init__(self, servport = NETBIOS_NS_PORT):
-        self.__servport = NETBIOS_NS_PORT
+        self.__servport = servport
         self.__nameserver = None
         self.__broadcastaddr = BROADCAST_ADDR
         self.mac = b'00-00-00-00-00-00'

--- a/impacket/nmb.py
+++ b/impacket/nmb.py
@@ -330,6 +330,7 @@ class NBNodeStatusResponse(NBNSResourceRecord):
         res = pack('!B', self.num_names )
         for i in range(0, self.num_names):
             res += self.entries[i].getData()
+        res += self.statistics.getData() # (RFC 1002) 4.2.18.  NODE STATUS RESPONSE
 
 class NBPositiveNameQueryResponse(NBNSResourceRecord):
     def __init__(self, data = 0):

--- a/impacket/nmb.py
+++ b/impacket/nmb.py
@@ -517,7 +517,7 @@ class NetBIOS:
         self.__broadcastaddr = BROADCAST_ADDR
         self.mac = b'00-00-00-00-00-00'
 
-    def _setup_connection(self, dstaddr, timeout=None):
+    def _setup_connection(self, dstaddr):
         port = rand.randint(10000, 60000)
         af, socktype, proto, _canonname, _sa = socket.getaddrinfo(dstaddr, port, socket.AF_INET, socket.SOCK_DGRAM)[0]
         s = socket.socket(af, socktype, proto)

--- a/tests/SMB_RPC/test_nmb.py
+++ b/tests/SMB_RPC/test_nmb.py
@@ -10,17 +10,93 @@
 #
 import pytest
 import unittest
+from binascii import unhexlify
 from tests import RemoteTestCase
 
 from impacket import nmb
 from impacket.structure import hexdump
 
 
-@pytest.mark.remote
-class NMBTests(RemoteTestCase, unittest.TestCase):
+class NMBLocalTests(unittest.TestCase):
 
     def setUp(self):
-        super(NMBTests, self).setUp()
+        self.machine = 'WIN-VB75FK4K1S0'
+        self.serverName = 'WIN-VB75FK4K1S0'
+
+    def test_encodedecodename(self):
+        name = 'THISISAVERYLONGLONGNAME'
+        encoded = nmb.encode_name(name, nmb.TYPE_SERVER, None)
+        decoded = nmb.decode_name(encoded)
+
+        self.assertEqual(name[:15], decoded[1].strip())
+
+    def test_getnetbiosname(self):
+        # Arrange
+        name = 'WIN-VB75FK4K1S0'
+        mock = unhexlify('f97384000000000100000000204648454a454f434e46474543444844464547454c4445454c444246444441414100002100010000000000650357494e2d56423735464b344b31533000040057494e2d56423735464b344b315330200400574f524b47524f555020202020202000840000155d01230800000000000000000000000000000000000000000000000000000000000000000000000000000000')
+        def send_hook(request, destaddr, timeout):
+            return nmb.NAME_SERVICE_PACKET(mock)
+        n = nmb.NetBIOS()
+        n.send = send_hook
+
+        res = n.getnetbiosname(self.machine) # Act
+
+        self.assertEqual(name, res) # Assert
+
+    def test_getnodestatus(self):
+        # Arrange
+        name1 = b'WIN-VB75FK4K1S0'
+        name2 = b'WIN-VB75FK4K1S0'
+        name3 = b'WORKGROUP      '
+        mock = unhexlify('f97384000000000100000000204648454a454f434e46474543444844464547454c4445454c444246444441414100002100010000000000650357494e2d56423735464b344b31533000040057494e2d56423735464b344b315330200400574f524b47524f555020202020202000840000155d01230800000000000000000000000000000000000000000000000000000000000000000000000000000000')
+        def send_hook(request, destaddr, timeout):
+            return nmb.NAME_SERVICE_PACKET(mock)
+        n = nmb.NetBIOS()
+        n.send = send_hook
+
+        resp = n.getnodestatus(self.serverName.upper(), self.machine) # Act
+
+        # Assert
+        self.assertEqual(resp[0]['NAME'], name1)
+        self.assertEqual(resp[1]['NAME'], name2)
+        self.assertEqual(resp[2]['NAME'], name3)
+
+    def test_gethostbyname(self):
+        # Arrange
+        addr = '10.0.1.1'
+        name = 'WIN-VB75FK4K1S0'
+        mock = unhexlify('f97485000000000100000000204648454a454f434e46474543444844464547454c4445454c44424644444141410000200001000493e0000600000a000101')
+        def send_hook(request, destaddr, timeout):
+            return nmb.NAME_SERVICE_PACKET(mock)
+        n = nmb.NetBIOS()
+        n.send = send_hook
+        n.set_nameserver(name)
+
+        resp = n.gethostbyname(name, nmb.TYPE_SERVER) # Act
+
+        self.assertEqual(addr, str(resp.entries[0])) # Assert
+
+    def test_name_query_request(self):
+        # Arrange
+        addr = "10.0.1.1"
+        name = "WIN-VB75FK4K1S0"
+        mock = unhexlify('f97485000000000100000000204648454a454f434e46474543444844464547454c4445454c44424644444141410000200001000493e0000600000a000101')
+        def send_hook(request, destaddr, timeout):
+            return nmb.NAME_SERVICE_PACKET(mock)
+        n = nmb.NetBIOS()
+        n.send = send_hook
+
+        resp = n.name_query_request(name, addr) # Act
+
+        self.assertEqual(addr, str(resp.entries[0])) # Assert
+
+
+
+@pytest.mark.remote
+class NMBRemoteTests(RemoteTestCase, unittest.TestCase):
+
+    def setUp(self):
+        super(NMBRemoteTests, self).setUp()
         self.set_transport_config()
 
     def create_connection(self):


### PR DESCRIPTION
This PR fixes some issues in NetBIOS protocol:

1. Add missing field to marshaling process in `NBNodeStatusResponse()` structure. In order to _RFC1002_, the **NODE STATUS RESPONSE** structure contains `statistics` field in the end.
2. Some code improvements in parameters
3. Use mocks in nmb tests, to work locally regardless of remote (expired) environment(s)