### PR TITLE
LDAP encoding fixes

### DIFF
--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -28,6 +28,7 @@ import struct
 import socket
 from binascii import unhexlify
 import random
+import six
 
 from pyasn1.codec.ber import encoder, decoder
 from pyasn1.error import SubstrateUnderrunError
@@ -474,8 +475,13 @@ class LDAPConnection:
             raise(f"Decryption not implemented for {self.__auth_type} protocol")
         return data
 
+    #  searchFilter expects a string (not bytes), otherwise it will raise an exception
     def search(self, searchBase=None, scope=None, derefAliases=None, sizeLimit=0, timeLimit=0, typesOnly=False,
                searchFilter='(objectClass=*)', attributes=None, searchControls=None, perRecordCallback=None):
+
+        if not isinstance(searchFilter, six.text_type):
+            raise LDAPFilterInvalidException("searchFilter must be %s, got %s" % (six.text_type, type(searchFilter)))
+
         if searchBase is None:
             searchBase = self._baseDN
         if scope is None:
@@ -615,10 +621,6 @@ class LDAPConnection:
         return self.recv()
 
     def _parseFilter(self, filterStr):
-        try:
-            filterStr = filterStr.decode()
-        except AttributeError:
-            pass
         filterList = list(reversed(filterStr))
         searchFilter = self._consumeCompositeFilter(filterList)
         if filterList:  # we have not consumed the whole filter string

--- a/impacket/ldap/ldapasn1.py
+++ b/impacket/ldap/ldapasn1.py
@@ -137,6 +137,7 @@ class MessageID(univ.Integer):
 
 
 class LDAPString(univ.OctetString):
+    # LDAPString ::= OCTET STRING -- UTF-8 encoded, -- [ISO10646] characters
     encoding = 'utf-8'
 
 
@@ -157,11 +158,13 @@ class AttributeDescription(LDAPString):
 
 
 class AttributeValue(univ.OctetString):
-    pass
+    # AttributeValue ::= OCTET STRING
+    encoding = 'utf-8'
 
 
 class AssertionValue(univ.OctetString):
-    pass
+    # AssertionValue ::= OCTET STRING
+    encoding = 'utf-8'
 
 
 class MatchingRuleID(LDAPString):


### PR DESCRIPTION
LDAP queries containing non-ascii characters are failing (#1946) due to impacket's implementation of LDAP not defining key classes to use utf-8 encoding. This PR syncs those definitions with the ones in ldap3 (which specify the correct encoding).