### PR TITLE
fix #581,#1817

### DIFF
--- a/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
@@ -23,6 +23,7 @@ import sys
 from struct import unpack
 from impacket import LOG
 from ldap3 import Server, Connection, ALL, NTLM, MODIFY_ADD, Tls
+from ldap3.core.exceptions import LDAPSocketOpenError
 import ssl
 from ldap3.operation import bind
 try:
@@ -173,8 +174,14 @@ class LDAPSRelayClient(LDAPRelayClient):
         LDAPRelayClient.__init__(self, serverConfig, target, targetPort, extendedSecurity)
 
     def initConnection(self):
-        tls_config = Tls(ciphers='ALL', version=ssl.PROTOCOL_TLSv1)
-        self.server = Server("ldaps://%s:%s" % (self.targetHost, self.targetPort), get_info=ALL, tls=tls_config)
-        self.session = Connection(self.server, user="a", password="b", authentication=NTLM)
-        self.session.open(False)
+        try:
+            tls_config = Tls(ciphers='ALL:@SECLEVEL=0', version=ssl.PROTOCOL_TLSv1_2)
+            self.server = Server("ldaps://%s:%s" % (self.targetHost, self.targetPort), get_info=ALL, tls=tls_config)
+            self.session = Connection(self.server, user="a", password="b", authentication=NTLM)
+            self.session.open(False)
+        except LDAPSocketOpenError:
+            tls_config = Tls(ciphers='ALL:@SECLEVEL=0', version=ssl.PROTOCOL_TLSv1)
+            self.server = Server("ldaps://%s:%s" % (self.targetHost, self.targetPort), get_info=ALL, tls=tls_config)
+            self.session = Connection(self.server, user="a", password="b", authentication=NTLM)
+            self.session.open(False)
         return True

--- a/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
@@ -22,7 +22,8 @@
 import sys
 from struct import unpack
 from impacket import LOG
-from ldap3 import Server, Connection, ALL, NTLM, MODIFY_ADD
+from ldap3 import Server, Connection, ALL, NTLM, MODIFY_ADD, Tls
+import ssl
 from ldap3.operation import bind
 try:
     from ldap3.core.results import RESULT_SUCCESS, RESULT_STRONGER_AUTH_REQUIRED
@@ -172,7 +173,8 @@ class LDAPSRelayClient(LDAPRelayClient):
         LDAPRelayClient.__init__(self, serverConfig, target, targetPort, extendedSecurity)
 
     def initConnection(self):
-        self.server = Server("ldaps://%s:%s" % (self.targetHost, self.targetPort), get_info=ALL)
+        tls_config = Tls(ciphers='ALL', version=ssl.PROTOCOL_TLSv1)
+        self.server = Server("ldaps://%s:%s" % (self.targetHost, self.targetPort), get_info=ALL, tls=tls_config)
         self.session = Connection(self.server, user="a", password="b", authentication=NTLM)
         self.session.open(False)
         return True


### PR DESCRIPTION
Fix the issue [#581 ](https://github.com/fortra/impacket/issues/581), [#1817 ](https://github.com/fortra/impacket/issues/1817) where the Python ssl library, starting from Python 3.10, no longer supports lower versions of TLS, in order to ensure compatibility with LDAPs relaying. 

### Configuration  
impacket version: master after 0612d078953a974267f229b0dd96cc2cbce620d6
Python version:  3.11.0
Target OS:  local Win10, target Win2019 with WebClient running, DC Win2012

### Debug Output With Command String  
```
> coercer coerce -u <user> -p <pass> -d <domain> -t <victim_ip> -l rly --auth-type http --filter-protocol-name MS-EFS

> python3 ntlmrelayx.py -t ldaps://<dc_ip> --delegate-access --smb-port 8445
[*] Servers started, waiting for connections
[*] HTTPD(80): Client requested path: /epp/pipe/srvsvc
[*] HTTPD(80): Client requested path: /epp/pipe/srvsvc
[*] HTTPD(80): Connection from 192.168.121.119 controlled, attacking target ldaps://192.168.121.112
[-] HTTPD(80): Exception while Negotiating NTLM with ldaps://192.168.121.112: "socket ssl wrapping error: [WinError 10054] 远程主机强迫关闭了一个现有的连接。"
[-] HTTPD(80): Negotiating NTLM with ldaps://192.168.121.112 failed
[*] HTTPD(80): Client requested path: /epp/pipe
[*] HTTPD(80): Client requested path: /epp/pipe
[*] HTTPD(80): Connection from 192.168.121.119 controlled, attacking target ldaps://192.168.121.112
[-] HTTPD(80): Exception while Negotiating NTLM with ldaps://192.168.121.112: "socket ssl wrapping error: [WinError 10054] 远程主机强迫关闭了一个现有的连接。"
[-] HTTPD(80): Negotiating NTLM with ldaps://192.168.121.112 failed
```

### Fix
This bug is caused by python 3.10 changes the minimum openssl version that's linked to python，[ldap3 not working with Python 3.10 #993](https://github.com/cannatag/ldap3/issues/993)。 So set `tls_config` while `LDAPSRelayClient.initConnection()`。