### PR TITLE
smbclient.py add SMB share permissions check (issues #186)

### DIFF
--- a/examples/smbclient.py
+++ b/examples/smbclient.py
@@ -152,7 +152,6 @@ def main():
         else:
             smbClient.login(username, password, domain, lmhash, nthash)
 
-        # Если указан -check-access, проверяем права и выходим
         if options.check_access:
             if options.check_access.upper() == 'ALL':
                 logging.debug("Listing all shares")


### PR DESCRIPTION
This PR implements share permission checks as requested in #186.  

Changes:    
- READ/WRITE/DELETE access check
- New `-check-access` flag to verify share permissions  
- Supports `-no-write-check` to skip write/delete tests  

**Usage examples:**  
1. Check specific shares:  
   \`python3 examples/smbclient.py 'test:test@127.0.0.1' -check-access 'MY SHARE, IPC$'\`  

2. Check all available shares:  
   \`python3 examples/smbclient.py 'test:test@127.0.0.1' -check-access\`  

3. Skip write/delete checks (read-only):  
   \`python3 examples/smbclient.py 'test:test@127.0.0.1' -check-access -no-write-check\`  

Fixes (https://github.com/fortra/impacket/issues/186)