### PR TITLE
Update utils.py to fix -dc-host when ntlm is disabled

### DIFF
--- a/impacket/examples/utils.py
+++ b/impacket/examples/utils.py
@@ -238,7 +238,7 @@ def _init_ldap_connection(target, tls_version, domain, username, password, lmhas
 def init_ldap_session(domain, username, password, lmhash, nthash, k, dc_ip, dc_host, aesKey, use_ldaps):
     if k:
         if dc_host is not None:
-            target = _get_machine_name(dc_host)
+            target = dc_host
         elif dc_ip is not None:
             target = _get_machine_name(dc_ip)
         else:


### PR DESCRIPTION
The pr #1940 added the -dc-host option to some examples like:

* dacledit.py
* owneredit.py
* rbcd.py

But when running -dc-host the script does not work and returns status not supported suggesting that -dc-host should be used, even though -dc-host is present.

![image](https://github.com/user-attachments/assets/e25086e9-52f0-4fa5-8073-794811184e46)

This bug happens because "utils.py" calls the _get_machine_name regardless if -dc-host was passed.

``` def init_ldap_session(domain, username, password, lmhash, nthash, k, dc_ip, dc_host, aesKey, use_ldaps):
    if k:
        if dc_host is not None:
            target = _get_machine_name(dc_host) # gets called here anyway
        elif dc_ip is not None:
            target = _get_machine_name(dc_ip)
        else:
            target = _get_machine_name(domain)
``` 
This pr fix that by updating target with the -dc-host param value if dc_host is not None and thus the script works again in domains where ntlm is disabled

![image](https://github.com/user-attachments/assets/fa4dc775-4b33-4563-9468-193849f6009f)
