### PR TITLE
[MSSQL] Fix regression: Connection establishment

### DIFF
--- a/impacket/examples/ntlmrelayx/clients/mssqlrelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/mssqlrelayclient.py
@@ -51,6 +51,8 @@ class MYMSSQL(MSSQL):
             # Creates a TLS context
             context = ssl.SSLContext()
             context.set_ciphers('ALL:@SECLEVEL=0')
+            context.minimum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
+            context.verify_mode = ssl.CERT_NONE
             
             # Here comes the important part, MSSQL server does not expect a raw TLS socket
             # Instead it expects TDS packets to be sent in which TLS data is embedded

--- a/impacket/examples/ntlmrelayx/clients/mssqlrelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/mssqlrelayclient.py
@@ -50,6 +50,7 @@ class MYMSSQL(MSSQL):
             LOG.info("Encryption required, switching to TLS")
             # Creates a TLS context
             context = ssl.SSLContext()
+            context.set_ciphers('ALL:@SECLEVEL=0')
             
             # Here comes the important part, MSSQL server does not expect a raw TLS socket
             # Instead it expects TDS packets to be sent in which TLS data is embedded

--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -737,6 +737,8 @@ class MSSQL:
         # Creates a TLS context
         context = ssl.SSLContext()
         context.set_ciphers('ALL:@SECLEVEL=0')
+        context.minimum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
+        context.verify_mode = ssl.CERT_NONE
         
         # Here comes the important part, MSSQL server does not expect a raw TLS socket
         # Instead it expects TDS packets to be sent in which TLS data is embedded

--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -736,6 +736,7 @@ class MSSQL:
         LOG.info("Encryption required, switching to TLS")
         # Creates a TLS context
         context = ssl.SSLContext()
+        context.set_ciphers('ALL:@SECLEVEL=0')
         
         # Here comes the important part, MSSQL server does not expect a raw TLS socket
         # Instead it expects TDS packets to be sent in which TLS data is embedded


### PR DESCRIPTION
This commit broke `mssqlclient.py` for me: https://github.com/fortra/impacket/commit/a60a1f17be047061e14682b4cf4aa27d578796d9

With the commit a connection to a Microsoft SQL Server 2012 is not possible anymore, during connection establishment (TLS client hello) the server does not respond. The only difference between the packets in the old impacket version I tested ( abfaea2b ) and the commit above is that a tlsv1 client hello is now used, wheres before it was a tlsv1.2 client hello.

This commit reintroduces the explicit setting of the ciphers, which seems to fix this. I am not sure if this is platform dependent which TLS record layer is used, I am testing on Debian 12 with Python 3.11.2 and OpenSSL 3.0.16-1~deb12u1.