### PR TITLE
NTLMRelayX: Shown client IP when realying successful

### DIFF
--- a/impacket/examples/ntlmrelayx/clients/__init__.py
+++ b/impacket/examples/ntlmrelayx/clients/__init__.py
@@ -16,6 +16,7 @@
 #   Alberto Solino (@agsolino)
 #
 import os, sys, pkg_resources
+from threading import Lock
 from impacket import LOG
 
 PROTOCOL_CLIENTS = {}
@@ -25,6 +26,8 @@ PROTOCOL_CLIENTS = {}
 # writing a plugin for protocol clients:
 # PROTOCOL_CLIENT_CLASS = "<name of the class for the plugin>"
 # PLUGIN_NAME must be the protocol name that will be matched later with the relay targets (e.g. SMB, LDAP, etc)
+client_idx = 0
+lock = Lock()
 class ProtocolClient:
     PLUGIN_NAME = 'PROTOCOL'
     def __init__(self, serverConfig, target, targetPort, extendedSecurity=True):
@@ -40,6 +43,10 @@ class ProtocolClient:
         self.extendedSecurity = extendedSecurity
         self.session = None
         self.sessionData = {}
+        with lock:
+            global client_idx
+            client_idx += 1
+            self.client_id = client_idx
 
     def initConnection(self):
         raise RuntimeError('Virtual Function')

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -68,8 +68,8 @@ class HTTPRelayServer(Thread):
             try:
                 http.server.SimpleHTTPRequestHandler.__init__(self,request, client_address, server)
             except Exception as e:
-                LOG.debug("Exception:", exc_info=True)
-                LOG.error(str(e))
+                LOG.debug("(HTTP): Exception:", exc_info=True)
+                LOG.error("(HTTP): %s" % str(e))
 
         def handle_one_request(self):
             try:
@@ -77,8 +77,8 @@ class HTTPRelayServer(Thread):
             except KeyboardInterrupt:
                 raise
             except Exception as e:
-                LOG.debug("HTTPD(%s): Exception:" % self.server.server_address[1], exc_info=True)
-                LOG.error('HTTPD(%s): Exception in HTTP request handler: %s' % (self.server.server_address[1], e))
+                LOG.debug("(HTTP): Exception:", exc_info=True)
+                LOG.error('(HTTP): Exception in HTTP request handler: %s' % e)
 
         def log_message(self, format, *args):
             return
@@ -160,7 +160,7 @@ class HTTPRelayServer(Thread):
                     _, blob = typeX.split('NTLM')
                     token = base64.b64decode(blob.strip())
                 except Exception:
-                    LOG.debug("Exception:", exc_info=True)
+                    LOG.debug("(HTTP): Exception:", exc_info=True)
                     self.do_AUTHHEAD(message = b'NTLM', proxy=proxy)
                 else:
                     messageType = struct.unpack('<L',token[len('NTLMSSP\x00'):len('NTLMSSP\x00')+4])[0]
@@ -183,7 +183,7 @@ class HTTPRelayServer(Thread):
 
         def do_PROPFIND(self):
 
-            LOG.info('HTTPD(%s): Client requested path: %s' % (self.server.server_address[1], self.path.lower()))
+            LOG.info('(HTTP): Client requested path: %s' % self.path.lower())
 
             proxy = False
             if (".jpg" in self.path) or (".JPG" in self.path):
@@ -252,14 +252,14 @@ class HTTPRelayServer(Thread):
                 self.do_SMBREDIRECT()
                 return
 
-            LOG.info('HTTPD(%s): Client requested path: %s' % (self.server.server_address[1], self.path.lower()))
+            LOG.info('(HTTP): Client requested path: %s' % self.path.lower())
 
             # Serve WPAD if:
             # - The client requests it
             # - A WPAD host was provided in the command line options
             # - The client has not exceeded the wpad_auth_num threshold yet
             if self.path.lower() == '/wpad.dat' and self.server.config.serve_wpad and self.should_serve_wpad(self.client_address[0]):
-                LOG.info('HTTPD(%s): Serving PAC file to client %s' % (self.server.server_address[1], self.client_address[0]))
+                LOG.info('(HTTP): Serving PAC file to client %s' % self.client_address[0])
                 self.serve_wpad()
                 return
 
@@ -301,7 +301,7 @@ class HTTPRelayServer(Thread):
                 if self.challengeMessage is False:
                     return False
             else:
-                LOG.error('Protocol Client for %s not found!' % self.target.scheme.upper())
+                LOG.error('(HTTP): Protocol Client for %s not found!' % self.target.scheme.upper())
                 return False
 
             # Calculate auth
@@ -368,13 +368,11 @@ class HTTPRelayServer(Thread):
                         self.server.config.target.reloadTargets(full_reload=True)
                         self.target = self.server.config.target.getTarget(identity=self.authUser)
                     else:
-                        LOG.info("HTTPD(%s): Connection from %s@%s controlled, but there are no more targets left!" % (
-                            self.server.server_address[1], self.authUser, self.client_address[0]))
+                        LOG.info("(HTTP): Connection from %s@%s controlled, but there are no more targets left!" % (self.authUser, self.client_address[0]))
                         self.send_not_found()
                         return
 
-                LOG.info("HTTPD(%s): Connection from %s@%s controlled, attacking target %s://%s" % (
-                    self.server.server_address[1], self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+                LOG.info("(HTTP): Connection from %s@%s controlled, attacking target %s://%s" % (self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
 
                 self.relayToHost = True
                 self.do_REDIRECT()
@@ -388,31 +386,27 @@ class HTTPRelayServer(Thread):
                             self.server.config.target.reloadTargets(full_reload=True)
                             self.target = self.server.config.target.getTarget(multiRelay=False)
                         else:
-                            LOG.info("HTTPD(%s): Connection from %s controlled, but there are no more targets left!" % (
-                                self.server.server_address[1], self.client_address[0]))
+                            LOG.info("(HTTP): Connection from %s controlled, but there are no more targets left!" % self.client_address[0])
                             self.send_not_found()
                             return
 
-                    LOG.info("HTTPD(%s): Connection from %s controlled, attacking target %s://%s" % (
-                        self.server.server_address[1], self.client_address[0], self.target.scheme, self.target.netloc))
+                    LOG.info("(HTTP): Connection from %s controlled, attacking target %s://%s" % (self.client_address[0], self.target.scheme, self.target.netloc))
 
                 try:
                     ntlm_negotiate_response = self.do_ntlm_negotiate(token, proxy=proxy)
                 except Exception as e:
-                    LOG.error('HTTPD(%d): Exception while Negotiating NTLM with %s://%s: "%s"' % (self.server.server_address[1], self.target.scheme, self.target.netloc, str(e)))
+                    LOG.error('(HTTP): Exception while Negotiating NTLM with %s://%s: "%s"' % (self.target.scheme, self.target.netloc, str(e)))
                     ntlm_negotiate_response = False
 
                 if not ntlm_negotiate_response:
                     # Connection failed
                     if self.server.config.disableMulti:
-                        LOG.error('HTTPD(%s): Negotiating NTLM with %s://%s failed' % (self.server.server_address[1],
-                                  self.target.scheme, self.target.netloc))
+                        LOG.error('(HTTP): Negotiating NTLM with %s://%s failed' % (self.target.scheme, self.target.netloc))
                         self.server.config.target.registerTarget(self.target)
                         self.send_not_found()
                         return
                     else:
-                        LOG.error('HTTPD(%s): Negotiating NTLM with %s://%s failed. Skipping to next target' % (
-                            self.server.server_address[1], self.target.scheme, self.target.netloc))
+                        LOG.error('(HTTP): Negotiating NTLM with %s://%s failed. Skipping to next target' % (self.target.scheme, self.target.netloc))
 
                         self.server.config.target.registerTarget(self.target, gotUsername=self.authUser)
                         self.target = self.server.config.target.getTarget(identity=self.authUser)
@@ -422,13 +416,11 @@ class HTTPRelayServer(Thread):
                                 self.server.config.target.reloadTargets(full_reload=True)
                                 self.target = self.server.config.target.getTarget(identity=self.authUser)
                             else:
-                                LOG.info( "HTTPD(%s): Connection from %s@%s controlled, but there are no more targets left!" %
-                                    (self.server.server_address[1], self.authUser, self.client_address[0]))
+                                LOG.info("(HTTP): Connection from %s@%s controlled, but there are no more targets left!" % (self.authUser, self.client_address[0]))
                                 self.send_not_found()
                                 return
 
-                        LOG.info("HTTPD(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
-                            self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+                        LOG.info("(HTTP): Connection from %s@%s controlled, attacking target %s://%s" % (self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
 
                         self.do_REDIRECT()
 
@@ -441,8 +433,7 @@ class HTTPRelayServer(Thread):
                     target = '%s://%s@%s' % (self.target.scheme, self.authUser.replace("/", '\\'), self.target.netloc)
 
                 if not self.do_ntlm_auth(token, authenticateMessage):
-                    LOG.error("Authenticating against %s://%s as %s FAILED" % (self.target.scheme, self.target.netloc,
-                                                                               self.authUser))
+                    LOG.error("(HTTP): Authenticating against %s://%s as %s FAILED" % (self.target.scheme, self.target.netloc, self.authUser))
                     if self.server.config.disableMulti:
                         self.send_not_found()
                         return
@@ -458,16 +449,14 @@ class HTTPRelayServer(Thread):
                                 self.server.config.target.reloadTargets(full_reload=True)
                                 self.target = self.server.config.target.getTarget(identity=self.authUser)
                             else:
-                                LOG.info("HTTPD(%s): Connection from %s@%s controlled, but there are no more targets left!" %
-                                    (self.server.server_address[1], self.authUser, self.client_address[0]))
+                                LOG.info("(HTTP): Connection from %s@%s controlled, but there are no more targets left!" % (self.authUser, self.client_address[0]))
                                 self.send_not_found()
                                 return
 
                         self.send_not_found()  # Stop relaying at first login fail, this matches the behavior of smbrelayserver
 
                         # Uncomment lines below to keep relaying after login failures
-                        # LOG.info("HTTPD(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
-                        #     self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+                        # LOG.info("(HTTP): Connection from %s@%s controlled, attacking target %s://%s" % (self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
 
                         # self.do_REDIRECT()
                     else:
@@ -475,8 +464,7 @@ class HTTPRelayServer(Thread):
                         self.do_AUTHHEAD(b'NTLM', proxy=proxy)
                 else:
                     # Relay worked, do whatever we want here...
-                    LOG.info("HTTPD(%s): Authenticating against %s://%s as %s SUCCEED" % (self.server.server_address[1],
-                        self.target.scheme, self.target.netloc, self.authUser))
+                    LOG.info("(HTTP): Authenticating connection from %s@%s against %s://%s SUCCEED [%s]" % (self.authUser, self.client_address[0], self.target.scheme, self.target.netloc, self.client.client_id))
 
                     ntlm_hash_data = outputToJohnFormat(self.challengeMessage['challenge'],
                                                         authenticateMessage['user_name'],
@@ -485,7 +473,7 @@ class HTTPRelayServer(Thread):
                     self.client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
 
                     if self.server.config.dumpHashes is True:
-                        LOG.info(ntlm_hash_data['hash_string'])
+                        LOG.info("(HTTP): %s" % ntlm_hash_data['hash_string'])
 
                     if self.server.config.outputFile is not None:
                         writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
@@ -511,8 +499,7 @@ class HTTPRelayServer(Thread):
                                 self.server.config.target.reloadTargets(full_reload=True)
                                 self.target = self.server.config.target.getTarget(identity=self.authUser)
                             else:
-                                LOG.info("HTTPD(%s): Connection from %s@%s controlled, but there are no more targets left!" % (
-                                    self.server.server_address[1], self.authUser, self.client_address[0]))
+                                LOG.info("(HTTP): Connection from %s@%s controlled, but there are no more targets left!" % (self.authUser, self.client_address[0]))
                                 # Return Multi-Status status code to WebDAV servers
                                 if self.command == "PROPFIND":
                                     self.send_multi_status(content)
@@ -528,8 +515,7 @@ class HTTPRelayServer(Thread):
                                 return
 
                         # We have the next target, let's keep relaying...
-                        LOG.info("HTTPD(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
-                            self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+                        LOG.info("(HTTP): Connection from %s@%s controlled, attacking target %s://%s" % (self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
                         self.do_REDIRECT()
 
         def do_attack(self):
@@ -547,7 +533,7 @@ class HTTPRelayServer(Thread):
                                                                                self.authUser)
                 clientThread.start()
             else:
-                LOG.error('HTTPD(%s): No attack configured for %s' % (self.server.server_address[1], self.target.scheme.upper()))
+                LOG.error('(HTTP): No attack configured for %s' % self.target.scheme.upper())
 
     def __init__(self, config):
         Thread.__init__(self)

--- a/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
@@ -65,10 +65,10 @@ class RAWRelayServer(Thread):
                 self.server.config.target = TargetsProcessor(singleTarget='SMB://%s:445/' % client_address[0])
             self.target = self.server.config.target.getTarget()
             if self.target is None:
-                LOG.info("RAW: Received connection from %s, but there are no more targets left!" % client_address[0])
+                LOG.info("(RAW): Received connection from %s, but there are no more targets left!" % client_address[0])
                 return
 
-            LOG.info("RAW: Received connection from %s, attacking target %s://%s" % (client_address[0] ,self.target.scheme, self.target.netloc))
+            LOG.info("(RAW): Received connection from %s, attacking target %s://%s" % (client_address[0] ,self.target.scheme, self.target.netloc))
 
             super().__init__(request, client_address, server)
 
@@ -79,7 +79,7 @@ class RAWRelayServer(Thread):
 
             if not self.do_ntlm_negotiate(ntlm_negotiate):
                 # Connection failed
-                LOG.error('Negotiating NTLM with %s://%s failed. Skipping to next target',
+                LOG.error('(RAW): Negotiating NTLM with %s://%s failed. Skipping to next target',
                           self.target.scheme, self.target.netloc)
                 self.server.config.target.registerTarget(self.target)
 
@@ -101,12 +101,12 @@ class RAWRelayServer(Thread):
                     self.request.sendall(struct.pack('?', False))
 
                     if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
-                        LOG.error("Authenticating against %s://%s as %s\\%s FAILED" % (
+                        LOG.error("(RAW): Authenticating against %s://%s as %s\\%s FAILED" % (
                             self.target.scheme, self.target.netloc,
                             authenticateMessage['domain_name'].decode('utf-16le'),
                             authenticateMessage['user_name'].decode('utf-16le')))
                     else:
-                        LOG.error("Authenticating against %s://%s as %s\\%s FAILED" % (
+                        LOG.error("(RAW): Authenticating against %s://%s as %s\\%s FAILED" % (
                             self.target.scheme, self.target.netloc,
                             authenticateMessage['domain_name'].decode('ascii'),
                             authenticateMessage['user_name'].decode('ascii')))
@@ -116,13 +116,13 @@ class RAWRelayServer(Thread):
                     self.request.sendall(struct.pack('?', True))
 
                     if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
-                        LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED" % (
-                            self.target.scheme, self.target.netloc, authenticateMessage['domain_name'].decode('utf-16le'),
-                            authenticateMessage['user_name'].decode('utf-16le')))
+                        LOG.info("(RAW): Authenticating connection from %s/%s@%s against %s://%s SUCCEED [%s]" % (
+                            authenticateMessage['domain_name'].decode('utf-16le'), authenticateMessage['user_name'].decode('utf-16le'),
+                            self.client_address[0], self.target.scheme, self.target.netloc, self.client.client_id))
                     else:
-                        LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED" % (
-                            self.target.scheme, self.target.netloc, authenticateMessage['domain_name'].decode('ascii'),
-                            authenticateMessage['user_name'].decode('ascii')))
+                        LOG.info("(RAW): Authenticating connection from %s/%s@%s against %s://%s SUCCEED [%s]" % (
+                            authenticateMessage['domain_name'].decode('ascii'), authenticateMessage['user_name'].decode('ascii'),
+                            self.client_address[0], self.target.scheme, self.target.netloc, self.client.client_id))
 
                     ntlm_hash_data = outputToJohnFormat(self.challengeMessage['challenge'],
                                                         authenticateMessage['user_name'],
@@ -131,7 +131,7 @@ class RAWRelayServer(Thread):
                     self.client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
 
                     if self.server.config.dumpHashes is True:
-                        LOG.info(ntlm_hash_data['hash_string'])
+                        LOG.info("(RAW): %s" % ntlm_hash_data['hash_string'])
 
                     if self.server.config.outputFile is not None:
                         writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
@@ -162,7 +162,7 @@ class RAWRelayServer(Thread):
                 if self.challengeMessage is False:
                     return False
             else:
-                LOG.error('Protocol Client for %s not found!' % self.target.scheme.upper())
+                LOG.error('(RAW): Protocol Client for %s not found!' % self.target.scheme.upper())
                 return False
 
             return True
@@ -198,7 +198,7 @@ class RAWRelayServer(Thread):
                                                                                self.authUser)
                 clientThread.start()
             else:
-                LOG.error('No attack configured for %s' % self.target.scheme.upper())
+                LOG.error('(RAW): No attack configured for %s' % self.target.scheme.upper())
 
     def __init__(self, config):
         Thread.__init__(self)

--- a/impacket/examples/ntlmrelayx/servers/rpcrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/rpcrelayserver.py
@@ -118,27 +118,27 @@ class RPCRelayServer(Thread):
                     data = self.transport.recv()
                     if data is None:
                         # No data: connection closed
-                        LOG.debug('RPC: Connection closed by client')
+                        LOG.debug('(RPC): Connection closed by client')
                         return
                     response = self.handle_single_request(data)
                     # if not response:
                     # Nothing more to say, close connection
                     #    return
                     if response:
-                        LOG.debug('RPC: Sending packet of type %s' % msrpc_message_type[response['type']])
+                        LOG.debug('(RPC): Sending packet of type %s' % msrpc_message_type[response['type']])
                         self.transport.send(response)
             except KeyboardInterrupt:
                 raise
             except ConnectionResetError:
-                LOG.error("Connection reset.")
+                LOG.error("(RPC): Connection reset.")
             except Exception as e:
-                LOG.debug("Exception:", exc_info=True)
-                LOG.error('Exception in RPC request handler: %s' % e)
+                LOG.debug("(RPC): Exception:", exc_info=True)
+                LOG.error('(RPC): Exception in RPC request handler: %s' % e)
 
         def handle_single_request(self, data):
             self.request_header = MSRPCHeader(data)
             req_type = self.request_header['type']
-            LOG.debug('RPC: Received packet of type %s' % msrpc_message_type[req_type])
+            LOG.debug('(RPC): Received packet of type %s' % msrpc_message_type[req_type])
             if req_type in (MSRPC_BIND, MSRPC_ALTERCTX):
                 self.request_pdu_data = MSRPCRelayBind(self.request_header['pduData'])
             elif req_type == MSRPC_AUTH3:
@@ -149,15 +149,15 @@ class RPCRelayServer(Thread):
                 # This is a RPC request, we try to answer it the best we can.
                 return self.transport.processRequest(data)
             else:
-                LOG.error('Packet type received not supported (yet): %a' % msrpc_message_type[req_type])
+                LOG.error('(RPC): Packet type received not supported (yet): %a' % msrpc_message_type[req_type])
                 return self.send_error(MSRPC_STATUS_CODE_NCA_S_UNSUPPORTED_TYPE)
 
             if self.request_header['auth_len'] <= 0:
                 if req_type == MSRPC_BIND:
                     # Let's answer to the bind anyway, maybe a second request with authentication comes later
-                    LOG.debug('Answering to a BIND without authentication')
+                    LOG.debug('(RPC): Answering to a BIND without authentication')
                     return self.transport.processRequest(data)
-                LOG.error('Packet is no BIND and does not contain authentication')
+                LOG.error('(RPC): Packet is no BIND and does not contain authentication')
                 return self.send_error(MSRPC_STATUS_CODE_RPC_S_BINDING_HAS_NO_AUTH)
 
             self.request_sec_trailer = SEC_TRAILER(self.request_header['sec_trailer'])
@@ -165,7 +165,7 @@ class RPCRelayServer(Thread):
             auth_type = self.request_sec_trailer['auth_type']
             if auth_type == RPC_C_AUTHN_NONE:
                 # What should we do here :(
-                LOG.error('Packet contains "None" authentication')
+                LOG.error('(RPC): Packet contains "None" authentication')
                 return self.send_error(MSRPC_STATUS_CODE_RPC_S_BINDING_HAS_NO_AUTH)
             elif auth_type == RPC_C_AUTHN_GSS_NEGOTIATE:
                 if req_type == MSRPC_AUTH3:
@@ -196,15 +196,15 @@ class RPCRelayServer(Thread):
                 self.target = self.server.config.target.getTarget(multiRelay=False)
                 if self.target is None:
                     if self.server.config.keepRelaying:
-                        LOG.info("No target left: keepRelaying active, reloading targets.")
+                        LOG.info("(RPC): No target left: keepRelaying active, reloading targets.")
                         self.server.config.target.reloadTargets(full_reload=True)
                         self.target = self.server.config.target.getTarget(multiRelay=False)
-                        LOG.info("RPCD: Received connection from %s, attacking target %s://%s" % (self.client_address[0], self.target.scheme, self.target.netloc))
+                        LOG.info("(RPC): Received connection from %s, attacking target %s://%s" % (self.client_address[0], self.target.scheme, self.target.netloc))
                     else:
-                        LOG.info("No target left")
+                        LOG.info("(RPC): No target left")
                         return self.send_error(MSRPC_STATUS_CODE_RPC_S_ACCESS_DENIED)
                 else:
-                    LOG.info("RPCD: Received connection from %s, attacking target %s://%s" % (self.client_address[0], self.target.scheme, self.target.netloc))
+                    LOG.info("(RPC): Received connection from %s, attacking target %s://%s" % (self.client_address[0], self.target.scheme, self.target.netloc))
 
                 try:
                     self.do_ntlm_negotiate(token)  # Computes the challenge message
@@ -214,9 +214,9 @@ class RPCRelayServer(Thread):
                 except Exception as e:
                     # Connection failed
                     if self.target is None:
-                        LOG.error('Negotiating NTLM failed, and no target left')
+                        LOG.error('(RPC): Negotiating NTLM failed, and no target left')
                     else:
-                        LOG.error('Negotiating NTLM with %s://%s failed.', self.target.scheme, self.target.netloc)
+                        LOG.error('(RPC): Negotiating NTLM with %s://%s failed.', self.target.scheme, self.target.netloc)
                         self.server.config.target.registerTarget(self.target)
                     return self.send_error(MSRPC_STATUS_CODE_RPC_S_ACCESS_DENIED)
 
@@ -230,7 +230,7 @@ class RPCRelayServer(Thread):
                 # Only skip to next if the login actually failed, not if it was just anonymous login
                 if authenticateMessage['user_name'] == b'':
                     # Anonymous login
-                    LOG.error('Empty username ... just waiting')
+                    LOG.error('(RPC): Empty username ... just waiting')
                     return None
                     # LOG.error('Empty username ... answering with %s' % rpc_status_codes[MSRPC_STATUS_CODE_RPC_S_ACCESS_DENIED])
                     # return self.send_error(MSRPC_STATUS_CODE_RPC_S_ACCESS_DENIED)
@@ -240,15 +240,13 @@ class RPCRelayServer(Thread):
 
                     # Relay worked, do whatever we want here...
                     if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
-                        LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED" % (
-                            self.target.scheme, self.target.netloc,
-                            authenticateMessage['domain_name'].decode('utf-16le'),
-                            authenticateMessage['user_name'].decode('utf-16le')))
+                        LOG.info("(RPC): Authenticating connection from %s/%s@%s against %s://%s SUCCEED [%s]" % (
+                            authenticateMessage['domain_name'].decode('utf-16le'), authenticateMessage['user_name'].decode('utf-16le'),
+                            self.client_address[0], self.target.scheme, self.target.netloc, self.client.client_id))
                     else:
-                        LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED" % (
-                            self.target.scheme, self.target.netloc, authenticateMessage['domain_name'].decode('ascii'),
-                            authenticateMessage['user_name'].decode('ascii')))
-
+                        LOG.info("(RPC): Authenticating connection from %s/%s@%s against %s://%s SUCCEED [%s]" % (
+                            authenticateMessage['domain_name'].decode('ascii'), authenticateMessage['user_name'].decode('ascii'),
+                            self.client_address[0], self.target.scheme, self.target.netloc, self.client.client_id))
 
                     ntlm_hash_data = outputToJohnFormat(self.challengeMessage['challenge'],
                                                         authenticateMessage['user_name'],
@@ -267,12 +265,12 @@ class RPCRelayServer(Thread):
                     return self.send_error(MSRPC_STATUS_CODE_RPC_S_ACCESS_DENIED)
                 except Exception as e:
                     if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
-                        LOG.error("Authenticating against %s://%s as %s\\%s FAILED" % (
+                        LOG.error("(RPC): Authenticating against %s://%s as %s\\%s FAILED" % (
                             self.target.scheme, self.target.netloc,
                             authenticateMessage['domain_name'].decode('utf-16le'),
                             authenticateMessage['user_name'].decode('utf-16le')))
                     else:
-                        LOG.error("Authenticating against %s://%s as %s\\%s FAILED" % (
+                        LOG.error("(RPC): Authenticating against %s://%s as %s\\%s FAILED" % (
                             self.target.scheme, self.target.netloc,
                             authenticateMessage['domain_name'].decode('ascii'),
                             authenticateMessage['user_name'].decode('ascii')))
@@ -299,7 +297,7 @@ class RPCRelayServer(Thread):
                     self.challengeMessage['TargetInfoFields_len'] = len(av_pairs.getData())
                     self.challengeMessage['TargetInfoFields_max_len'] = len(av_pairs.getData())
             else:
-                LOG.error('Protocol Client for %s not found!' % self.target.scheme.upper())
+                LOG.error('(RPC): Protocol Client for %s not found!' % self.target.scheme.upper())
                 raise Exception('Protocol Client for %s not found!' % self.target.scheme.upper())
 
         def bind(self, challengeMessage=b''):
@@ -410,7 +408,7 @@ class RPCRelayServer(Thread):
                                                                                       self.auth_user)
                 clientThread.start()
             else:
-                LOG.error('No attack configured for %s' % self.target.scheme.upper())
+                LOG.error('(RPC): No attack configured for %s' % self.target.scheme.upper())
 
     def __init__(self, config):
         Thread.__init__(self)

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -53,7 +53,7 @@ def auth_callback(smbServer, connData, domain_name, user_name, host_name):
     if not user:
         user = "unknown"
 
-    LOG.info(f"Received connection from {user} at {host_name}, connection will be relayed after re-authentication")
+    LOG.info(f"(SMB): Received connection from {user} at {host_name}, connection will be relayed after re-authentication")
 
 
 class SMBRelayServer(Thread):
@@ -157,15 +157,15 @@ class SMBRelayServer(Thread):
                     self.config.target.reloadTargets(full_reload=True)
                     self.target = self.targetprocessor.getTarget(multiRelay=False)
                 else:
-                    LOG.info('SMBD-%s: Connection from %s controlled, but there are no more targets left!' % (connId, connData['ClientIP']))
+                    LOG.info('(SMB): Connection from %s controlled, but there are no more targets left!' % connData['ClientIP'])
                     return [SMB2Error()], None, STATUS_BAD_NETWORK_NAME
 
-            LOG.info("SMBD-%s: Received connection from %s, attacking target %s://%s" % (connId, connData['ClientIP'], self.target.scheme, self.target.netloc))
+            LOG.info("(SMB): Received connection from %s, attacking target %s://%s" % (connData['ClientIP'], self.target.scheme, self.target.netloc))
 
             try:
                 if self.config.mode.upper() == 'REFLECTION':
                     # Force standard security when doing reflection
-                    LOG.debug("Downgrading to standard security")
+                    LOG.debug("(SMB): Downgrading to standard security")
                     extSec = False
                     #recvPacket['Flags2'] += (~smb.SMB.FLAGS2_EXTENDED_SECURITY)
                 else:
@@ -173,7 +173,7 @@ class SMBRelayServer(Thread):
                 # Init the correct client for our target
                 client = self.init_client(extSec)
             except Exception as e:
-                LOG.error("Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
+                LOG.error("(SMB): Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
                 self.targetprocessor.registerTarget(self.target, False, self.authUser)
             else:
                 connData['SMBClient'] = client
@@ -307,7 +307,7 @@ class SMBRelayServer(Thread):
             try:
                 challengeMessage = self.do_ntlm_negotiate(client, token)
             except Exception as e:
-                LOG.debug("Exception:", exc_info=True)
+                LOG.debug("(SMB): Exception:", exc_info=True)
                 # Log this target as processed for this client
                 self.targetprocessor.registerTarget(self.target, False, self.authUser)
                 # Raise exception again to pass it on to the SMB server
@@ -361,12 +361,12 @@ class SMBRelayServer(Thread):
 
             if errorCode != STATUS_SUCCESS:
                 #Log this target as processed for this client
-                LOG.error("Authenticating against %s://%s as %s FAILED" % (self.target.scheme, self.target.netloc, self.authUser))
+                LOG.error("(SMB): Authenticating against %s://%s as %s FAILED" % (self.target.scheme, self.target.netloc, self.authUser))
                 self.targetprocessor.registerTarget(self.target, False, self.authUser)
                 client.killConnection()
             else:
                 # We have a session, create a thread and do whatever we want
-                LOG.info("Authenticating against %s://%s as %s SUCCEED" % (self.target.scheme, self.target.netloc, self.authUser))
+                LOG.info("(SMB): Authenticating connection from %s@%s against %s://%s SUCCEED [%s]" % (self.authUser, connData['ClientIP'], self.target.scheme, self.target.netloc, client.client_id))
                 # Log this target as processed for this client
 
                 if not self.config.isADCSAttack:
@@ -379,7 +379,7 @@ class SMBRelayServer(Thread):
                 client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
 
                 if self.server.getDumpHashes():
-                    LOG.info(ntlm_hash_data['hash_string'])
+                    LOG.info("(SMB): %s" % ntlm_hash_data['hash_string'])
 
                 if self.server.getJTRdumpPath() != '':
                     writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
@@ -438,14 +438,14 @@ class SMBRelayServer(Thread):
                     self.target = self.targetprocessor.getTarget(multiRelay=False)
                 else:
                     # No more targets to process, just let the victim to fail later
-                    LOG.info('SMBD-%s: Connection from %s@%s controlled, but there are no more targets left!' % (connId, self.authUser, connData['ClientIP']))
+                    LOG.info('(SMB): Connection from %s@%s controlled, but there are no more targets left!' % (self.authUser, connData['ClientIP']))
                     return self.origsmb2TreeConnect (connId, smbServer, recvPacket)
 
-            LOG.info('SMBD-%s: Connection from %s@%s controlled, attacking target %s://%s' % (connId, self.authUser, connData['ClientIP'], self.target.scheme, self.target.netloc))
+            LOG.info('(SMB): Connection from %s@%s controlled, attacking target %s://%s' % (self.authUser, connData['ClientIP'], self.target.scheme, self.target.netloc))
 
             if self.config.mode.upper() == 'REFLECTION':
                 # Force standard security when doing reflection
-                LOG.debug("Downgrading to standard security")
+                LOG.debug("(SMB): Downgrading to standard security")
                 extSec = False
                 #recvPacket['Flags2'] += (~smb.SMB.FLAGS2_EXTENDED_SECURITY)
             else:
@@ -453,7 +453,7 @@ class SMBRelayServer(Thread):
             # Init the correct client for our target
             client = self.init_client(extSec)
         except Exception as e:
-            LOG.error("Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
+            LOG.error("(SMB): Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
             self.targetprocessor.registerTarget(self.target, False, self.authUser)
         else:
             connData['relayToHost'] = True
@@ -512,10 +512,10 @@ class SMBRelayServer(Thread):
                     self.config.target.reloadTargets(full_reload=True)
                     self.target = self.targetprocessor.getTarget(multiRelay=False)
                 else:
-                    LOG.info('SMBD-%s: Connection from %s controlled, but there are no more targets left!' % (connId, connData['ClientIP']))
+                    LOG.info('(SMB): Connection from %s controlled, but there are no more targets left!' % connData['ClientIP'])
                     return [smb.SMBCommand(smb.SMB.SMB_COM_NEGOTIATE)], None, STATUS_BAD_NETWORK_NAME
 
-            LOG.info("SMBD-%s: Received connection from %s, attacking target %s://%s" % (connId, connData['ClientIP'], self.target.scheme, self.target.netloc))
+            LOG.info("(SMB): Received connection from %s, attacking target %s://%s" % (connData['ClientIP'], self.target.scheme, self.target.netloc))
 
             try:
                 if recvPacket['Flags2'] & smb.SMB.FLAGS2_EXTENDED_SECURITY == 0:
@@ -523,7 +523,7 @@ class SMBRelayServer(Thread):
                 else:
                     if self.config.mode.upper() == 'REFLECTION':
                         # Force standard security when doing reflection
-                        LOG.debug("Downgrading to standard security")
+                        LOG.debug("(SMB): Downgrading to standard security")
                         extSec = False
                         recvPacket['Flags2'] += (~smb.SMB.FLAGS2_EXTENDED_SECURITY)
                     else:
@@ -532,8 +532,7 @@ class SMBRelayServer(Thread):
                 # Init the correct client for our target
                 client = self.init_client(extSec)
             except Exception as e:
-                LOG.error(
-                    "Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
+                LOG.error("(SMB): Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
                 self.targetprocessor.registerTarget(self.target, False, self.authUser)
             else:
                 connData['SMBClient'] = client
@@ -544,7 +543,7 @@ class SMBRelayServer(Thread):
             if (recvPacket['Flags2'] & smb.SMB.FLAGS2_EXTENDED_SECURITY) != 0:
                 if self.config.mode.upper() == 'REFLECTION':
                     # Force standard security when doing reflection
-                    LOG.debug("Downgrading to standard security")
+                    LOG.debug("(SMB): Downgrading to standard security")
                     recvPacket['Flags2'] += (~smb.SMB.FLAGS2_EXTENDED_SECURITY)
 
         return self.origSmbComNegotiate(connId, smbServer, SMBCommand, recvPacket)
@@ -652,7 +651,7 @@ class SMBRelayServer(Thread):
                     packet['ErrorCode']   = errorCode >> 16
                     packet['ErrorClass']  = errorCode & 0xff
 
-                    LOG.error("Authenticating against %s://%s as %s FAILED" % (self.target.scheme, self.target.netloc, self.authUser))
+                    LOG.error("(SMB): Authenticating against %s://%s as %s FAILED" % (self.target.scheme, self.target.netloc, self.authUser))
 
                     #Log this target as processed for this client
                     self.targetprocessor.registerTarget(self.target, False, self.authUser)
@@ -662,7 +661,7 @@ class SMBRelayServer(Thread):
                     return None, [packet], errorCode
                 else:
                     # We have a session, create a thread and do whatever we want
-                    LOG.info("Authenticating against %s://%s as %s SUCCEED" % (self.target.scheme, self.target.netloc, self.authUser))
+                    LOG.info("(SMB): Authenticating connection from %s@%s against %s://%s SUCCEED [%s]" % (self.authUser, connData['ClientIP'], self.target.scheme, self.target.netloc, client.client_id))
 
                     # Log this target as processed for this client
                     self.targetprocessor.registerTarget(self.target, True, self.authUser)
@@ -674,7 +673,7 @@ class SMBRelayServer(Thread):
                     client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
 
                     if self.server.getDumpHashes():
-                        LOG.info(ntlm_hash_data['hash_string'])
+                        LOG.info("(SMB): %s" % ntlm_hash_data['hash_string'])
 
                     if self.server.getJTRdumpPath() != '':
                         writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
@@ -742,7 +741,7 @@ class SMBRelayServer(Thread):
             else:
                 # We have a session, create a thread and do whatever we want
                 self.authUser = ('%s/%s' % (sessionSetupData['PrimaryDomain'], sessionSetupData['Account'])).upper()
-                LOG.info("Authenticating against %s://%s as %s SUCCEED" % (self.target.scheme, self.target.netloc, self.authUser))
+                LOG.info("(SMB): Authenticating connection from %s@%s against %s://%s SUCCEED [%s]" % (self.authUser, connData['ClientIP'], self.target.scheme, self.target.netloc, client.client_id))
 
                 # Log this target as processed for this client
                 self.targetprocessor.registerTarget(self.target, True, self.authUser)
@@ -752,7 +751,7 @@ class SMBRelayServer(Thread):
                 client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
 
                 if self.server.getDumpHashes():
-                    LOG.info(ntlm_hash_data['hash_string'])
+                    LOG.info("(SMB): %s" % ntlm_hash_data['hash_string'])
 
                 if self.server.getJTRdumpPath() != '':
                     writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
@@ -801,14 +800,14 @@ class SMBRelayServer(Thread):
                     self.target = self.targetprocessor.getTarget(multiRelay=False)
                 else:
                     # No more targets to process, just let the victim to fail later
-                    LOG.info('SMBD-%s: Connection from %s@%s controlled, but there are no more targets left!' % (connId, self.authUser, connData['ClientIP']))
+                    LOG.info('(SMB): Connection from %s@%s controlled, but there are no more targets left!' % (self.authUser, connData['ClientIP']))
                     return self.origsmbComTreeConnectAndX (connId, smbServer, recvPacket)
 
-            LOG.info('SMBD-%s: Connection from %s@%s controlled, attacking target %s://%s' % ( connId, self.authUser, connData['ClientIP'], self.target.scheme, self.target.netloc))
+            LOG.info('(SMB): Connection from %s@%s controlled, attacking target %s://%s' % (self.authUser, connData['ClientIP'], self.target.scheme, self.target.netloc))
 
             if self.config.mode.upper() == 'REFLECTION':
                 # Force standard security when doing reflection
-                LOG.debug("Downgrading to standard security")
+                LOG.debug("(SMB): Downgrading to standard security")
                 extSec = False
                 recvPacket['Flags2'] += (~smb.SMB.FLAGS2_EXTENDED_SECURITY)
             else:
@@ -816,7 +815,7 @@ class SMBRelayServer(Thread):
             # Init the correct client for our target
             client = self.init_client(extSec)
         except Exception as e:
-            LOG.error("Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
+            LOG.error("(SMB): Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
             self.targetprocessor.registerTarget(self.target, False, self.authUser)
         else:
             connData['relayToHost'] = True
@@ -921,7 +920,7 @@ class SMBRelayServer(Thread):
             clientThread = self.config.attacks[self.target.scheme.upper()](self.config, client.session, self.authUser)
             clientThread.start()
         else:
-            LOG.error('No attack configured for %s' % self.target.scheme.upper())
+            LOG.error('(SMB): No attack configured for %s' % self.target.scheme.upper())
 
     def _start(self):
         self.server.daemon_threads=True

--- a/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
@@ -71,9 +71,9 @@ class WCFRelayServer(Thread):
                 self.server.config.target = TargetsProcessor(singleTarget='SMB://%s:445/' % client_address[0])
             self.target = self.server.config.target.getTarget()
             if self.target is None:
-                LOG.info("WCF: Received connection from %s, but there are no more targets left!" % client_address[0])
+                LOG.info("(WCF): Received connection from %s, but there are no more targets left!" % client_address[0])
                 return
-            LOG.info("WCF: Received connection from %s, attacking target %s://%s" % (
+            LOG.info("(WCF): Received connection from %s, attacking target %s://%s" % (
                 client_address[0], self.target.scheme, self.target.netloc))
 
             socketserver.BaseRequestHandler.__init__(self, request, client_address, server)
@@ -91,55 +91,55 @@ class WCFRelayServer(Thread):
         def handle(self):
             version_code = self.recvall(1)
             if version_code != b'\x00':
-                LOG.error("WCF: wrong VersionRecord code")
+                LOG.error("(WCF): wrong VersionRecord code")
                 return
             version = self.recvall(2)  # should be \x01\x00 but we don't care
             if version != b'\x01\x00':
-                LOG.error("WCF: wrong VersionRecord version")
+                LOG.error("(WCF): wrong VersionRecord version")
                 return
 
             mode_code = self.recvall(1)
             if mode_code != b'\x01':
-                LOG.error("WCF: wrong ModeRecord code")
+                LOG.error("(WCF): wrong ModeRecord code")
                 return
             mode = self.recvall(1)  # we don't care
 
             via_code = self.recvall(1)
             if via_code != b'\x02':
-                LOG.error("WCF: wrong ViaRecord code")
+                LOG.error("(WCF): wrong ViaRecord code")
                 return
             via_len = self.recvall(1)
             via_len = struct.unpack("B", via_len)[0]
             via = self.recvall(via_len).decode("utf-8")
 
             if not via.startswith("net.tcp://"):
-                LOG.error("WCF: the Via URL '" + via + "' does not start with 'net.tcp://'. "
+                LOG.error("(WCF): the Via URL '" + via + "' does not start with 'net.tcp://'. "
                                                        "Only NetTcpBinding is currently supported!")
                 return
 
             known_encoding_code = self.recvall(1)
             if known_encoding_code != b'\x03':
-                LOG.error("WCF: wrong KnownEncodingRecord code")
+                LOG.error("(WCF): wrong KnownEncodingRecord code")
                 return
             encoding = self.recvall(1)  # we don't care
 
             upgrade_code = self.recvall(1)
             if upgrade_code != b'\x09':
-                LOG.error("WCF: wrong UpgradeRequestRecord code")
+                LOG.error("(WCF): wrong UpgradeRequestRecord code")
                 return
             upgrade_len = self.recvall(1)
             upgrade_len = struct.unpack("B", upgrade_len)[0]
             upgrade = self.recvall(upgrade_len).decode("utf-8")
 
             if upgrade != "application/negotiate":
-                LOG.error("WCF: upgrade '" + upgrade + "' is not 'application/negotiate'. Only Negotiate is supported!")
+                LOG.error("(WCF): upgrade '" + upgrade + "' is not 'application/negotiate'. Only Negotiate is supported!")
                 return
             self.request.sendall(b'\x0a')
 
             while True:
                 handshake_in_progress = self.recvall(5)
                 if not handshake_in_progress[0] == 0x16:
-                    LOG.error("WCF: Wrong handshake_in_progress message")
+                    LOG.error("(WCF): Wrong handshake_in_progress message")
                     return
 
                 securityBlob_len = struct.unpack(">H", handshake_in_progress[3:5])[0]
@@ -160,7 +160,7 @@ class WCFRelayServer(Thread):
                                 mechStr = MechTypes[mechType]
                             else:
                                 mechStr = hexlify(mechType)
-                            LOG.debug("Unsupported MechType '%s'" % mechStr)
+                            LOG.debug("(WCF): Unsupported MechType '%s'" % mechStr)
                             # We don't know the token, we answer back again saying
                             # we just support NTLM.
                             respToken = SPNEGO_NegTokenResp()
@@ -188,12 +188,12 @@ class WCFRelayServer(Thread):
                     break
 
             if not token.startswith(b"NTLMSSP\0\1"):  # NTLMSSP_NEGOTIATE: message type 1
-                LOG.error("WCF: Wrong NTLMSSP_NEGOTIATE message")
+                LOG.error("(WCF): Wrong NTLMSSP_NEGOTIATE message")
                 return
 
             if not self.do_ntlm_negotiate(token):
                 # Connection failed
-                LOG.error('Negotiating NTLM with %s://%s failed. Skipping to next target',
+                LOG.error('(WCF): Negotiating NTLM with %s://%s failed. Skipping to next target',
                           self.target.scheme, self.target.netloc)
                 self.server.config.target.registerTarget(self.target)
                 return
@@ -222,7 +222,7 @@ class WCFRelayServer(Thread):
                 error_len = struct.unpack(">H", handshake_done[3:5])[0]
                 error_msg = self.recvall(error_len)
                 hresult = hex(struct.unpack('>I', error_msg[4:8])[0])
-                LOG.error("WCF: Received handshake_error message: " + hresult)
+                LOG.error("(WCF): Received handshake_error message: " + hresult)
                 return
 
             ntlmssp_auth_len = struct.unpack(">H", handshake_done[3:5])[0]
@@ -234,7 +234,7 @@ class WCFRelayServer(Thread):
                 ntlmssp_auth = blob['ResponseToken']
 
             if not ntlmssp_auth.startswith(b"NTLMSSP\0\3"):  # NTLMSSP_AUTH: message type 3
-                LOG.error("WCF: Wrong NTLMSSP_AUTH message")
+                LOG.error("(WCF): Wrong NTLMSSP_AUTH message")
                 return
 
             authenticateMessage = ntlm.NTLMAuthChallengeResponse()
@@ -242,12 +242,12 @@ class WCFRelayServer(Thread):
 
             if not self.do_ntlm_auth(ntlmssp_auth, authenticateMessage):
                 if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
-                    LOG.error("Authenticating against %s://%s as %s\\%s FAILED" % (
+                    LOG.error("(WCF): Authenticating against %s://%s as %s\\%s FAILED" % (
                         self.target.scheme, self.target.netloc,
                         authenticateMessage['domain_name'].decode('utf-16le'),
                         authenticateMessage['user_name'].decode('utf-16le')))
                 else:
-                    LOG.error("Authenticating against %s://%s as %s\\%s FAILED" % (
+                    LOG.error("(WCF): Authenticating against %s://%s as %s\\%s FAILED" % (
                         self.target.scheme, self.target.netloc,
                         authenticateMessage['domain_name'].decode('ascii'),
                         authenticateMessage['user_name'].decode('ascii')))
@@ -255,14 +255,13 @@ class WCFRelayServer(Thread):
 
             # Relay worked, do whatever we want here...
             if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
-                LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED" % (
-                    self.target.scheme, self.target.netloc,
-                    authenticateMessage['domain_name'].decode('utf-16le'),
-                    authenticateMessage['user_name'].decode('utf-16le')))
+                LOG.info("(WCF): Authenticating connection from %s/%s@%s against %s://%s SUCCEED [%s]" % (
+                    authenticateMessage['domain_name'].decode('utf-16le'), authenticateMessage['user_name'].decode('utf-16le'),
+                    self.client_address[0], self.target.scheme, self.target.netloc, self.client.client_id))
             else:
-                LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED" % (
-                    self.target.scheme, self.target.netloc, authenticateMessage['domain_name'].decode('ascii'),
-                    authenticateMessage['user_name'].decode('ascii')))
+                LOG.info("(WCF): Authenticating connection from %s/%s@%s against %s://%s SUCCEED [%s]" % (
+                    authenticateMessage['domain_name'].decode('ascii'), authenticateMessage['user_name'].decode('ascii'),
+                    self.client_address[0], self.target.scheme, self.target.netloc, self.client.client_id))
 
             ntlm_hash_data = outputToJohnFormat(self.challengeMessage['challenge'],
                                                 authenticateMessage['user_name'],
@@ -271,7 +270,7 @@ class WCFRelayServer(Thread):
             self.client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
 
             if self.server.config.dumpHashes is True:
-                LOG.info(ntlm_hash_data['hash_string'])
+                LOG.info("(WCF): %s" % ntlm_hash_data['hash_string'])
 
             if self.server.config.outputFile is not None:
                 writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
@@ -302,7 +301,7 @@ class WCFRelayServer(Thread):
                 if self.challengeMessage is False:
                     return False
             else:
-                LOG.error('Protocol Client for %s not found!' % self.target.scheme.upper())
+                LOG.error('(WCF): Protocol Client for %s not found!' % self.target.scheme.upper())
                 return False
 
             return True
@@ -339,7 +338,7 @@ class WCFRelayServer(Thread):
                                                                                       self.authUser)
                 clientThread.start()
             else:
-                LOG.error('No attack configured for %s' % self.target.scheme.upper())
+                LOG.error('(WCF): No attack configured for %s' % self.target.scheme.upper())
 
     def __init__(self, config):
         Thread.__init__(self)


### PR DESCRIPTION
This PR implements https://github.com/fortra/impacket/issues/1217 (and superseeds https://github.com/fortra/impacket/pull/1401)

It basically does:
* Showing client IP when logging that a connection has been successfully relayed
  * Shows an autoincremental id next to this message (*)
* Standardized relay server logging prefixes. Now it shows the protocol: HTTP, SMB, RPC, WCF, RAW

(*) This id will be later referenced in an upcoming PR I'll be submitting soon. We'll be prefixing each attack logging with session information, simplifying debugging