### PR TITLE
Switch getUnixTimestamp to cross platform code

### DIFF
--- a/impacket/dcerpc/v5/tsts.py
+++ b/impacket/dcerpc/v5/tsts.py
@@ -27,7 +27,7 @@
 #
 
 import struct
-from datetime import datetime
+from datetime import datetime, timedelta
 from ldap3.protocol.formatters.formatters import format_sid
 
 from impacket.dcerpc.v5 import transport
@@ -179,7 +179,7 @@ class TS_CHAR(STR):
 class SYSTEM_TIMESTAMP(NDRHYPER):
     def __getitem__(self, key):
         if key == 'Data':
-            return datetime.fromtimestamp(getUnixTime(int(str(self.fields[key]))))
+            return datetime(1601, 1, 1) + timedelta(microseconds=int(str(self.fields[key])) // 10)
         else:
             return NDR.__getitem__(self,key)
 


### PR DESCRIPTION
This PR switches the following line of code from the getUnixTime function:

```python
return datetime.fromtimestamp(getUnixTime(int(str(self.fields[key]))))
```

To a cross platform independant oneliner:

```python
return datetime(1601, 1, 1) + timedelta(microseconds=int(str(self.fields[key])) // 10)
```

It was mentionned as an issue on NetExec for people using it on Windows, which would be the same for people using Impacket on Windows:

https://github.com/Pennyw0rth/NetExec/issues/827

And it mitigates it:

<img width="1213" height="171" alt="image" src="https://github.com/user-attachments/assets/c04570fd-324c-4866-b8a9-3a28d274f345" />
