### PR TITLE
Fix 2 critical bugs in ntlmrelayx

### DIFF
--- a/examples/goldenPac.py
+++ b/examples/goldenPac.py
@@ -68,11 +68,6 @@ from impacket.structure import Structure
 # HELPER FUNCTIONS
 ################################################################################
 
-def getFileTime(t):
-    t *= 10000000
-    t += 116444736000000000
-    return t
-
 class RemComMessage(Structure):
     structure = (
         ('Command','4096s=""'),
@@ -462,7 +457,7 @@ class MS14_068:
         # 1) KERB_VALIDATION_INFO
         aTime = timegm(strptime(str(authTime), '%Y%m%d%H%M%SZ'))
 
-        unixTime = getFileTime(aTime)
+        unixTime = smb.POSIXtoFT(aTime)
 
         kerbdata = KERB_VALIDATION_INFO()
 

--- a/examples/karmaSMB.py
+++ b/examples/karmaSMB.py
@@ -73,7 +73,7 @@ from impacket.smb import FILE_OVERWRITE, FILE_OVERWRITE_IF, FILE_WRITE_DATA, FIL
 from impacket.nt_errors import STATUS_USER_SESSION_DELETED, STATUS_SUCCESS, STATUS_ACCESS_DENIED, STATUS_NO_MORE_FILES, \
     STATUS_OBJECT_PATH_NOT_FOUND
 from impacket.smbserver import SRVSServer, decodeSMBString, findFirst2, STATUS_SMB_BAD_TID, encodeSMBString, \
-    getFileTime, queryPathInformation
+    queryPathInformation
 
 
 class KarmaSMBServer(Thread):
@@ -423,10 +423,10 @@ class KarmaSMBServer(Thread):
             infoRecord['EaSize']            = 0
             infoRecord['EndOfFile']         = size
             infoRecord['AllocationSize']    = size
-            infoRecord['CreationTime']      = getFileTime(ctime)
-            infoRecord['LastAccessTime']    = getFileTime(atime)
-            infoRecord['LastWriteTime']     = getFileTime(mtime)
-            infoRecord['LastChangeTime']    = getFileTime(mtime)
+            infoRecord['CreationTime']      = smb.POSIXtoFT(ctime)
+            infoRecord['LastAccessTime']    = smb.POSIXtoFT(atime)
+            infoRecord['LastWriteTime']     = smb.POSIXtoFT(mtime)
+            infoRecord['LastChangeTime']    = smb.POSIXtoFT(mtime)
             infoRecord['ShortName']         = b'\x00'*24
             #infoRecord['FileName']          = os.path.basename(origName).encode('utf-16le')
             infoRecord['FileName']          = origName.encode('utf-16le')

--- a/impacket/examples/__init__.py
+++ b/impacket/examples/__init__.py
@@ -14,6 +14,7 @@ def _insecure_create_default_context(purpose=ssl.Purpose.SERVER_AUTH, *, cafile=
     context = ssl._create_default_context(purpose=purpose, cafile=cafile, capath=capath, cadata=cadata)
     context.minimum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
     context.set_ciphers("ALL:@SECLEVEL=0")
+    context.check_hostname = False
     context.verify_mode = ssl.CERT_NONE
     return context
 

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -43,7 +43,7 @@ from impacket.smbserver import SMBSERVER, outputToJohnFormat, writeJohnOutputToF
 from impacket.spnego import ASN1_AID, MechTypes, ASN1_SUPPORTED_MECH
 from impacket.examples.ntlmrelayx.servers.socksserver import activeConnections
 from impacket.examples.ntlmrelayx.utils.targetsutils import TargetsProcessor
-from impacket.smbserver import getFileTime, decodeSMBString, encodeSMBString
+from impacket.smbserver import decodeSMBString, encodeSMBString
 from impacket.smb3structs import SMB2Error
 
 def auth_callback(smbServer, connData, domain_name, user_name, host_name):
@@ -212,8 +212,8 @@ class SMBRelayServer(Thread):
         respSMBCommand['MaxTransactSize'] = 65536
         respSMBCommand['MaxReadSize'] = 65536
         respSMBCommand['MaxWriteSize'] = 65536
-        respSMBCommand['SystemTime'] = getFileTime(calendar.timegm(time.gmtime()))
-        respSMBCommand['ServerStartTime'] = getFileTime(calendar.timegm(time.gmtime()))
+        respSMBCommand['SystemTime'] = smb.POSIXtoFT(calendar.timegm(time.gmtime()))
+        respSMBCommand['ServerStartTime'] = smb.POSIXtoFT(calendar.timegm(time.gmtime()))
         respSMBCommand['SecurityBufferOffset'] = 0x80
 
         blob = SPNEGO_NegTokenInit()

--- a/impacket/examples/ntlmrelayx/servers/socksplugins/smb.py
+++ b/impacket/examples/ntlmrelayx/servers/socksplugins/smb.py
@@ -32,14 +32,13 @@ from impacket.ntlm import NTLMAuthChallengeResponse, NTLMSSP_NEGOTIATE_SIGN
 from impacket.smb import NewSMBPacket, SMBCommand, SMB, SMBExtended_Security_Data, \
     SMBExtended_Security_Parameters, SMBNTLMDialect_Parameters, SMBNTLMDialect_Data, \
     SMBSessionSetupAndX_Extended_Response_Parameters, SMBSessionSetupAndX_Extended_Response_Data, \
-    SMBSessionSetupAndX_Extended_Parameters, SMBSessionSetupAndX_Extended_Data
+    SMBSessionSetupAndX_Extended_Parameters, SMBSessionSetupAndX_Extended_Data, POSIXtoFT
 from impacket.spnego import SPNEGO_NegTokenInit, TypesMech, SPNEGO_NegTokenResp, ASN1_AID
 from impacket.smb3 import SMB2Packet, SMB2_FLAGS_SERVER_TO_REDIR, SMB2_NEGOTIATE, SMB2Negotiate_Response, \
     SMB2_SESSION_SETUP, SMB2SessionSetup_Response, SMB2SessionSetup, SMB2_LOGOFF, SMB2Logoff_Response, \
     SMB2_DIALECT_WILDCARD, SMB2_FLAGS_SIGNED, SMB2_SESSION_FLAG_IS_GUEST
 from impacket.spnego import MechTypes, ASN1_SUPPORTED_MECH
 from impacket.smb import SMB_DIALECT
-from impacket.smbserver import getFileTime
 
 # Besides using this base class you need to define one global variable when
 # writing a plugin:
@@ -274,8 +273,8 @@ class SMBSocksRelay(SocksRelay):
             respSMBCommand['MaxTransactSize'] = 65536
             respSMBCommand['MaxReadSize'] = 65536
             respSMBCommand['MaxWriteSize'] = 65536
-            respSMBCommand['SystemTime'] = getFileTime(calendar.timegm(time.gmtime()))
-            respSMBCommand['ServerStartTime'] = getFileTime(calendar.timegm(time.gmtime()))
+            respSMBCommand['SystemTime'] = POSIXtoFT(calendar.timegm(time.gmtime()))
+            respSMBCommand['ServerStartTime'] = POSIXtoFT(calendar.timegm(time.gmtime()))
             respSMBCommand['SecurityBufferOffset'] = 0x80
 
             blob = SPNEGO_NegTokenInit()


### PR DESCRIPTION
# Description
The last few days 2 commits were introduced which completely broke ntlmrelayx and karmaSMB.


This PR fixes:
- import errors introduced in 20002f79e54e77652be8a15f6e8933c1b7d91a66 because `getFileTime` was removed from smbserver.py, which broke ntlmrelayx and karmaSMB because it was imported there (and in other places)
- The SSL context settings which broke relaying against LDAPS, which were introduced in 849c74b7b966aacb1eb5218808754324cd8dcd00

The SSL context settings are just incompatible, which resulted in ntlmrelay breaking when trying to authenticate against LDAP with TLS.

I would highly recommend adding a lint pipeline that checks for things such as missing or broken imports. If you need help with that either copy our lint pipeline from [here](https://github.com/Pennyw0rth/NetExec/blob/main/.github/workflows/lint.yml) and configure rule [I002](https://docs.astral.sh/ruff/rules/#isort-i) or hit me up.

# Screenshots
Import error fixes before:
<img width="1582" height="408" alt="image" src="https://github.com/user-attachments/assets/b45dddcb-bf83-4e3d-a793-1ad11b4ddd5b" />
After:
<img width="1575" height="446" alt="image" src="https://github.com/user-attachments/assets/bbdf4f21-7a64-4392-96ec-7cf6242b3b21" />

SSL settings before:
<img width="1586" height="551" alt="image" src="https://github.com/user-attachments/assets/9fef878a-053b-45f5-b7d1-6ec79e666f4c" />
After:
<img width="1586" height="780" alt="image" src="https://github.com/user-attachments/assets/8e46b1c1-5893-403b-a652-c7b2270440cb" />
