### PR TITLE
rdp_check support IPv6

### DIFF
--- a/examples/rdp_check.py
+++ b/examples/rdp_check.py
@@ -25,7 +25,7 @@
 from struct import pack, unpack
 
 from impacket.examples import logger
-from impacket.examples.utils import parse_target, get_socket
+from impacket.examples.utils import parse_target, get_connected_socket
 from impacket.structure import Structure
 from impacket.spnego import GSSAPI, ASN1_SEQUENCE, ASN1_OCTET_STRING, asn1decode, asn1encode
 
@@ -383,7 +383,7 @@ if __name__ == '__main__':
        tpdu['Code'] = TDPU_CONNECTION_REQUEST
        tpkt['TPDU'] = tpdu.getData()
 
-       s = get_socket(host, 3389, ipv6)
+       s = get_connected_socket(host, 3389, ipv6)
        s.sendall(tpkt.getData())
        pkt = s.recv(8192)
        tpkt.fromString(pkt)

--- a/examples/rdp_check.py
+++ b/examples/rdp_check.py
@@ -383,15 +383,15 @@ if __name__ == '__main__':
        tpdu['Code'] = TDPU_CONNECTION_REQUEST
        tpkt['TPDU'] = tpdu.getData()
 
+       address = (host, 3389)
        if ipv6:
             s = socket.socket(socket.AF_INET6)
             # scope_id (after %) can be present or not - if not, default: 0
             host_ipv6_parts = host.split('%')
             scope_id = int(host_ipv6_parts[1]) if len(host_ipv6_parts) == 2 else 0
-            address = (host, 3389, 0, scope_id)
+            address = address + (0, scope_id)
        else:
             s = socket.socket()
-            address = (host, 3389)
 
        s.connect(address)
        s.sendall(tpkt.getData())

--- a/examples/rdp_check.py
+++ b/examples/rdp_check.py
@@ -25,7 +25,7 @@
 from struct import pack, unpack
 
 from impacket.examples import logger
-from impacket.examples.utils import parse_target
+from impacket.examples.utils import parse_target, get_socket
 from impacket.structure import Structure
 from impacket.spnego import GSSAPI, ASN1_SEQUENCE, ASN1_OCTET_STRING, asn1decode, asn1encode
 
@@ -383,17 +383,7 @@ if __name__ == '__main__':
        tpdu['Code'] = TDPU_CONNECTION_REQUEST
        tpkt['TPDU'] = tpdu.getData()
 
-       address = (host, 3389)
-       if ipv6:
-            s = socket.socket(socket.AF_INET6)
-            # scope_id (after %) can be present or not - if not, default: 0
-            host_ipv6_parts = host.split('%')
-            scope_id = int(host_ipv6_parts[1]) if len(host_ipv6_parts) == 2 else 0
-            address = address + (0, scope_id)
-       else:
-            s = socket.socket()
-
-       s.connect(address)
+       s = get_socket(host, 3389, ipv6)
        s.sendall(tpkt.getData())
        pkt = s.recv(8192)
        tpkt.fromString(pkt)

--- a/examples/rdp_check.py
+++ b/examples/rdp_check.py
@@ -23,6 +23,7 @@
 #
 
 from struct import pack, unpack
+import ipaddress
 
 from impacket.examples import logger
 from impacket.examples.utils import parse_target
@@ -382,9 +383,11 @@ if __name__ == '__main__':
        tpdu['VariablePart'] = rdp_neg.getData()
        tpdu['Code'] = TDPU_CONNECTION_REQUEST
        tpkt['TPDU'] = tpdu.getData()
-   
-       s = socket.socket()
-       s.connect((host,3389))
+
+       host_ip = ipaddress.ip_address(host)
+       s = socket.socket(socket.AF_INET if host_ip.version == 4 else socket.AF_INET6)
+       address = (host, 3389) if host_ip.version == 4 else (host, 3389, 0, int(host_ip.scope_id) if host_ip.scope_id else 0)
+       s.connect(address)
        s.sendall(tpkt.getData())
        pkt = s.recv(8192)
        tpkt.fromString(pkt)

--- a/impacket/examples/utils.py
+++ b/impacket/examples/utils.py
@@ -330,7 +330,7 @@ def get_address(ip, port, ipv6=False):
     return address
 
 import socket
-def get_socket(ip, port, ipv6=False):
+def get_connected_socket(ip, port, ipv6=False):
     s = socket.socket(socket.AF_INET6 if ipv6 else socket.AF_INET)
     address = get_address(ip, port, ipv6)
     s.connect(address)

--- a/impacket/examples/utils.py
+++ b/impacket/examples/utils.py
@@ -317,3 +317,21 @@ def parse_identity(credentials, hashes=None, no_pass=False, aesKey=None, k=False
             lmhash = EMPTY_LM_HASH
 
     return domain, username, password, lmhash, nthash, k
+
+# ----------
+
+def get_address(ip, port, ipv6=False):
+    address = (ip, port)
+    if ipv6:
+        # scope_id (after %) can be present or not - if not, default: 0
+        ip_parts = ip.split('%')
+        scope_id = int(ip_parts[1]) if len(ip_parts) == 2 else 0
+        address = address + (0, scope_id)
+    return address
+
+import socket
+def get_socket(ip, port, ipv6=False):
+    s = socket.socket(socket.AF_INET6 if ipv6 else socket.AF_INET)
+    address = get_address(ip, port, ipv6)
+    s.connect(address)
+    return s

--- a/impacket/examples/utils.py
+++ b/impacket/examples/utils.py
@@ -325,7 +325,13 @@ def get_address(ip, port, ipv6=False):
     if ipv6:
         # scope_id (after %) can be present or not - if not, default: 0
         ip_parts = ip.split('%')
-        scope_id = int(ip_parts[1]) if len(ip_parts) == 2 else 0
+        scope_id = ip_parts[1] if len(ip_parts) == 2 else 0
+        # convert scope_id to int (expected by s.connect)
+        # if exception, assume the interface name and convert to index
+        try:
+            scope_id = int(scope_id)
+        except ValueError:
+            scope_id = socket.if_nametoindex(scope_id)
         address = address + (0, scope_id)
     return address
 


### PR DESCRIPTION
This PR fixes https://github.com/fortra/impacket/issues/1026

Added IP family detection through ´ipaddress´ module. And managing connection to target accordingly based on it