### PR TITLE
SMBServer & NTLMRelayx with IPv6 support

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -290,7 +290,7 @@ if __name__ == '__main__':
 
     # Interface address specification
     parser.add_argument('-ip','--interface-ip', action='store', metavar='INTERFACE_IP', help='IP address of interface to '
-                  'bind SMB and HTTP servers',default='')
+                  'bind relay servers ("0.0.0.0" or "::" if omitted)',default=argparse.SUPPRESS)
 
     serversoptions = parser.add_argument_group()
     serversoptions.add_argument('--no-smb-server', action='store_true', help='Disables the SMB server')
@@ -331,7 +331,7 @@ if __name__ == '__main__':
                                                                    'setting the proxy host to the one supplied.')
     parser.add_argument('-wa','--wpad-auth-num', action='store', type=int, default=1, help='Prompt for authentication N times for clients without MS16-077 installed '
                                                                    'before serving a WPAD file. (default=1)')
-    parser.add_argument('-6','--ipv6', action='store_true',help='Listen on both IPv6 and IPv4')
+    parser.add_argument('-6','--ipv6', action='store_true',help='Listen on IPv6')
     parser.add_argument('--remove-mic', action='store_true',help='Remove MIC (exploit CVE-2019-1040)')
     parser.add_argument('--serve-image', action='store',help='local path of the image that will we returned to clients')
     parser.add_argument('-c', action='store', type=str, required=False, metavar = 'COMMAND', help='Command to execute on '
@@ -528,6 +528,9 @@ if __name__ == '__main__':
         socks_thread.daemon = True
         socks_thread.start()
         threads.add(socks_thread)
+
+    if 'interface_ip' not in options:
+        options.interface_ip = '::' if options.ipv6 else '0.0.0.0'
 
     c = start_servers(options, threads)
 

--- a/examples/smbserver.py
+++ b/examples/smbserver.py
@@ -42,8 +42,9 @@ if __name__ == '__main__':
     parser.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes for the Username, format is LMHASH:NTHASH')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
-    parser.add_argument('-ip', '--interface-address', action='store', default='0.0.0.0', help='ip address of listening interface')
+    parser.add_argument('-ip', '--interface-address', action='store', default=argparse.SUPPRESS, help='ip address of listening interface ("0.0.0.0" or "::" if omitted)')
     parser.add_argument('-port', action='store', default='445', help='TCP port for listening incoming connections (default 445)')
+    parser.add_argument('-6','--ipv6', action='store_true',help='Listen on IPv6')
     parser.add_argument('-smb2support', action='store_true', default=False, help='SMB2 Support (experimental!)')
     parser.add_argument('-outputfile', action='store', default=None, help='Output file to log smbserver output messages')
 
@@ -64,7 +65,10 @@ if __name__ == '__main__':
     else:
         comment = options.comment
 
-    server = smbserver.SimpleSMBServer(listenAddress=options.interface_address, listenPort=int(options.port))
+    if 'interface_address' not in options:
+        options.interface_address = '::' if options.ipv6 else '0.0.0.0'
+
+    server = smbserver.SimpleSMBServer(listenAddress=options.interface_address, listenPort=int(options.port), ipv6=options.ipv6)
 
     if options.outputfile:
         logging.info('Switching output to file %s' % options.outputfile)

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -42,9 +42,13 @@ class HTTPRelayServer(Thread):
             self.daemon_threads = True
             if self.config.ipv6:
                 self.address_family = socket.AF_INET6
+                # scope_id (after %) can be present or not - if not, default: 0
+                ip_parts = server_address[0].split('%')
+                scope_id = int(ip_parts[1]) if len(ip_parts) == 2 else 0
+                server_address = server_address + (0, scope_id)
             # Tracks the number of times authentication was prompted for WPAD per client
             self.wpad_counters = {}
-            socketserver.TCPServer.__init__(self,server_address, RequestHandlerClass)
+            socketserver.TCPServer.__init__(self, server_address, RequestHandlerClass)
 
     class HTTPHandler(http.server.SimpleHTTPRequestHandler):
         def __init__(self,request, client_address, server):

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -33,6 +33,7 @@ from impacket.smbserver import outputToJohnFormat, writeJohnOutputToFile
 from impacket.nt_errors import STATUS_ACCESS_DENIED, STATUS_SUCCESS
 from impacket.examples.ntlmrelayx.utils.targetsutils import TargetsProcessor
 from impacket.examples.ntlmrelayx.servers.socksserver import activeConnections
+from impacket.examples.utils import get_address
 
 class HTTPRelayServer(Thread):
 
@@ -40,12 +41,7 @@ class HTTPRelayServer(Thread):
         def __init__(self, server_address, RequestHandlerClass, config):
             self.config = config
             self.daemon_threads = True
-            if self.config.ipv6:
-                self.address_family = socket.AF_INET6
-                # scope_id (after %) can be present or not - if not, default: 0
-                ip_parts = server_address[0].split('%')
-                scope_id = int(ip_parts[1]) if len(ip_parts) == 2 else 0
-                server_address = server_address + (0, scope_id)
+            server_address = get_address(server_address[0], server_address[1], self.config.ipv6)
             # Tracks the number of times authentication was prompted for WPAD per client
             self.wpad_counters = {}
             socketserver.TCPServer.__init__(self, server_address, RequestHandlerClass)

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -41,7 +41,7 @@ class HTTPRelayServer(Thread):
         def __init__(self, server_address, RequestHandlerClass, config):
             self.config = config
             self.daemon_threads = True
-            server_address = get_address(server_address[0], server_address[1], self.config.ipv6)
+            self.address_family, server_address = get_address(server_address[0], server_address[1], self.config.ipv6)
             # Tracks the number of times authentication was prompted for WPAD per client
             self.wpad_counters = {}
             socketserver.TCPServer.__init__(self, server_address, RequestHandlerClass)

--- a/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
@@ -43,9 +43,12 @@ class RAWRelayServer(Thread):
         def __init__(self, server_address, RequestHandlerClass, config):
             self.config = config
             self.daemon_threads = True
-            #if self.config.ipv6:
-            #    self.address_family = socket.AF_INET6
-
+            if self.config.ipv6:
+                self.address_family = socket.AF_INET6
+                # scope_id (after %) can be present or not - if not, default: 0
+                ip_parts = server_address[0].split('%')
+                scope_id = int(ip_parts[1]) if len(ip_parts) == 2 else 0
+                server_address = server_address + (0, scope_id)
             socketserver.TCPServer.__init__(self, server_address, RequestHandlerClass)
 
     class RAWHandler(socketserver.BaseRequestHandler):

--- a/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
@@ -44,7 +44,7 @@ class RAWRelayServer(Thread):
         def __init__(self, server_address, RequestHandlerClass, config):
             self.config = config
             self.daemon_threads = True
-            server_address = get_address(server_address[0], server_address[1], self.config.ipv6)
+            self.address_family, server_address = get_address(server_address[0], server_address[1], self.config.ipv6)
             socketserver.TCPServer.__init__(self, server_address, RequestHandlerClass)
 
     class RAWHandler(socketserver.BaseRequestHandler):

--- a/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
@@ -34,6 +34,7 @@ from impacket.smbserver import outputToJohnFormat, writeJohnOutputToFile
 from impacket.nt_errors import STATUS_ACCESS_DENIED, STATUS_SUCCESS
 from impacket.examples.ntlmrelayx.utils.targetsutils import TargetsProcessor
 from impacket.examples.ntlmrelayx.servers.socksserver import activeConnections
+from impacket.examples.utils import get_address
 
 
 class RAWRelayServer(Thread):
@@ -43,12 +44,7 @@ class RAWRelayServer(Thread):
         def __init__(self, server_address, RequestHandlerClass, config):
             self.config = config
             self.daemon_threads = True
-            if self.config.ipv6:
-                self.address_family = socket.AF_INET6
-                # scope_id (after %) can be present or not - if not, default: 0
-                ip_parts = server_address[0].split('%')
-                scope_id = int(ip_parts[1]) if len(ip_parts) == 2 else 0
-                server_address = server_address + (0, scope_id)
+            server_address = get_address(server_address[0], server_address[1], self.config.ipv6)
             socketserver.TCPServer.__init__(self, server_address, RequestHandlerClass)
 
     class RAWHandler(socketserver.BaseRequestHandler):

--- a/impacket/examples/ntlmrelayx/servers/rpcrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/rpcrelayserver.py
@@ -28,6 +28,7 @@ from impacket.smbserver import outputToJohnFormat, writeJohnOutputToFile
 from impacket.nt_errors import ERROR_MESSAGES, STATUS_SUCCESS
 from impacket.examples.ntlmrelayx.utils.targetsutils import TargetsProcessor
 from impacket.examples.ntlmrelayx.servers.socksserver import activeConnections
+from impacket.examples.utils import get_address
 
 
 class RPCRelayServer(Thread):
@@ -35,12 +36,7 @@ class RPCRelayServer(Thread):
         def __init__(self, server_address, RequestHandlerClass, config):
             self.config = config
             self.daemon_threads = True
-            if self.config.ipv6:
-                self.address_family = socket.AF_INET6
-                # scope_id (after %) can be present or not - if not, default: 0
-                ip_parts = server_address[0].split('%')
-                scope_id = int(ip_parts[1]) if len(ip_parts) == 2 else 0
-                server_address = server_address + (0, scope_id)
+            server_address = get_address(server_address[0], server_address[1], self.config.ipv6)
             socketserver.TCPServer.allow_reuse_address = True
             socketserver.TCPServer.__init__(self, server_address, RequestHandlerClass)
 

--- a/impacket/examples/ntlmrelayx/servers/rpcrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/rpcrelayserver.py
@@ -37,6 +37,10 @@ class RPCRelayServer(Thread):
             self.daemon_threads = True
             if self.config.ipv6:
                 self.address_family = socket.AF_INET6
+                # scope_id (after %) can be present or not - if not, default: 0
+                ip_parts = server_address[0].split('%')
+                scope_id = int(ip_parts[1]) if len(ip_parts) == 2 else 0
+                server_address = server_address + (0, scope_id)
             socketserver.TCPServer.allow_reuse_address = True
             socketserver.TCPServer.__init__(self, server_address, RequestHandlerClass)
 

--- a/impacket/examples/ntlmrelayx/servers/rpcrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/rpcrelayserver.py
@@ -36,7 +36,7 @@ class RPCRelayServer(Thread):
         def __init__(self, server_address, RequestHandlerClass, config):
             self.config = config
             self.daemon_threads = True
-            server_address = get_address(server_address[0], server_address[1], self.config.ipv6)
+            self.address_family, server_address = get_address(server_address[0], server_address[1], self.config.ipv6)
             socketserver.TCPServer.allow_reuse_address = True
             socketserver.TCPServer.__init__(self, server_address, RequestHandlerClass)
 

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -106,17 +106,13 @@ class SMBRelayServer(Thread):
         smbConfig.set('IPC$','share type','3')
         smbConfig.set('IPC$','path','')
 
-        # Change address_family to IPv6 if this is configured
-        if self.config.ipv6:
-            SMBSERVER.address_family = socket.AF_INET6
-
         # changed to dereference configuration interfaceIp
         if self.config.listeningPort:
             smbport = self.config.listeningPort
         else:
             smbport = 445
 
-        self.server = SMBSERVER((config.interfaceIp,smbport), config_parser = smbConfig)
+        self.server = SMBSERVER((config.interfaceIp,smbport), config_parser=smbConfig, ipv6=self.config.ipv6)
         if not self.config.disableMulti:
             self.server.setAuthCallback(auth_callback)
         logging.getLogger('impacket.smbserver').setLevel(logging.CRITICAL)

--- a/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
@@ -43,6 +43,7 @@ from impacket.nt_errors import STATUS_ACCESS_DENIED, STATUS_SUCCESS
 from impacket.smbserver import outputToJohnFormat, writeJohnOutputToFile
 from impacket.spnego import SPNEGO_NegTokenInit, ASN1_AID, SPNEGO_NegTokenResp, TypesMech, MechTypes, \
     ASN1_SUPPORTED_MECH
+from impacket.examples.utils import get_address
 
 
 class WCFRelayServer(Thread):
@@ -50,12 +51,7 @@ class WCFRelayServer(Thread):
         def __init__(self, server_address, request_handler_class, config):
             self.config = config
             self.daemon_threads = True
-            if self.config.ipv6:
-                self.address_family = socket.AF_INET6
-                # scope_id (after %) can be present or not - if not, default: 0
-                ip_parts = server_address[0].split('%')
-                scope_id = int(ip_parts[1]) if len(ip_parts) == 2 else 0
-                server_address = server_address + (0, scope_id)
+            server_address = get_address(server_address[0], server_address[1], self.config.ipv6)
             self.wpad_counters = {}
             socketserver.TCPServer.__init__(self, server_address, request_handler_class)
 

--- a/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
@@ -51,7 +51,7 @@ class WCFRelayServer(Thread):
         def __init__(self, server_address, request_handler_class, config):
             self.config = config
             self.daemon_threads = True
-            server_address = get_address(server_address[0], server_address[1], self.config.ipv6)
+            self.address_family, server_address = get_address(server_address[0], server_address[1], self.config.ipv6)
             self.wpad_counters = {}
             socketserver.TCPServer.__init__(self, server_address, request_handler_class)
 

--- a/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
@@ -52,6 +52,10 @@ class WCFRelayServer(Thread):
             self.daemon_threads = True
             if self.config.ipv6:
                 self.address_family = socket.AF_INET6
+                # scope_id (after %) can be present or not - if not, default: 0
+                ip_parts = server_address[0].split('%')
+                scope_id = int(ip_parts[1]) if len(ip_parts) == 2 else 0
+                server_address = server_address + (0, scope_id)
             self.wpad_counters = {}
             socketserver.TCPServer.__init__(self, server_address, request_handler_class)
 

--- a/impacket/examples/utils.py
+++ b/impacket/examples/utils.py
@@ -322,7 +322,9 @@ def parse_identity(credentials, hashes=None, no_pass=False, aesKey=None, k=False
 
 def get_address(ip, port, ipv6=False):
     address = (ip, port)
+    address_family = socket.AF_INET
     if ipv6:
+        address_family = socket.AF_INET6
         # scope_id (after %) can be present or not - if not, default: 0
         ip_parts = ip.split('%')
         scope_id = ip_parts[1] if len(ip_parts) == 2 else 0
@@ -333,11 +335,11 @@ def get_address(ip, port, ipv6=False):
         except ValueError:
             scope_id = socket.if_nametoindex(scope_id)
         address = address + (0, scope_id)
-    return address
+    return address_family, address
 
 import socket
 def get_connected_socket(ip, port, ipv6=False):
     s = socket.socket(socket.AF_INET6 if ipv6 else socket.AF_INET)
-    address = get_address(ip, port, ipv6)
+    _, address = get_address(ip, port, ipv6)
     s.connect(address)
     return s

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -3990,6 +3990,8 @@ class SMBSERVERHandler(socketserver.BaseRequestHandler):
 class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
     # class SMBSERVER(socketserver.ForkingMixIn, socketserver.TCPServer):
     def __init__(self, server_address, handler_class=SMBSERVERHandler, config_parser=None, ipv6=False):
+        # duplicate of https://github.com/fortra/impacket/blob/082dca34a376d13c70b0df6a1d9048ce98fe9498/impacket/examples/utils.py#L323
+        # didn't reuse that same function in order not to make a lcass from the library depend on one from impacket/examples
         if ipv6:
             self.address_family = socket.AF_INET6
             # scope_id (after %) can be present or not - if not, default: 0

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -3991,12 +3991,18 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
     # class SMBSERVER(socketserver.ForkingMixIn, socketserver.TCPServer):
     def __init__(self, server_address, handler_class=SMBSERVERHandler, config_parser=None, ipv6=False):
         # duplicate of https://github.com/fortra/impacket/blob/082dca34a376d13c70b0df6a1d9048ce98fe9498/impacket/examples/utils.py#L323
-        # didn't reuse that same function in order not to make a lcass from the library depend on one from impacket/examples
+        # didn't reuse that same function in order not to make a class from the library depend on one from impacket/examples
         if ipv6:
             self.address_family = socket.AF_INET6
             # scope_id (after %) can be present or not - if not, default: 0
             ip_parts = server_address[0].split('%')
             scope_id = ip_parts[1] if len(ip_parts) == 2 else 0
+            # convert scope_id to int (expected by s.connect)
+            # if exception, assume the interface name and convert to index
+            try:
+                scope_id = int(scope_id)
+            except ValueError:
+                scope_id = socket.if_nametoindex(scope_id)
             server_address = server_address + (0, scope_id)
 
         socketserver.TCPServer.allow_reuse_address = True


### PR DESCRIPTION
This PR fixes https://github.com/fortra/impacket/issues/1787
* **smbserver** -> added `-6` (or `--ipv6`) flag parameter

It also fixes IPv6 support in `ntlmrelayx`
* **ntlmrelayx** -> fixed case when `-6` was set and a specific `-ip` was configured

Note: It has to be updated after merging https://github.com/fortra/impacket/pull/2023 to reuse the `utils.get_address` function.