### PR TITLE
Enhance attack logging for ntlmrelayx

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -112,7 +112,7 @@ class MiniShell(cmd.Cmd):
    - admin : true or false 
         '''
 
-        headers = ["Protocol", "Target", "Username", "AdminStatus", "Port"]
+        headers = ["Protocol", "Target", "Username", "AdminStatus", "Port", "ID"]
         url = "http://{}/ntlmrelayx/api/v1.0/relays".format(self.api_address)
         try:
             proxy_handler = ProxyHandler({})

--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -83,7 +83,7 @@ class MiniShell(cmd.Cmd):
 
         # Print header
         print(outputFormat.format(*header))
-        print('  '.join(['-' * itemLen for itemLen in colLen]))
+        print('  '.join(['-' * max(itemLen, 3) for itemLen in colLen]))
 
         # And now the rows
         for row in items:

--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -135,7 +135,8 @@ class MiniShell(cmd.Cmd):
                     elif(_filter=='admin'):
                         _filter=3
                     else:
-                        logging.info('Expect : target / username / admin = value')                    
+                        logging.info('Expect : target / username / admin = value')
+                        return
                     _items=[]
                     for i in items:
                         if(_value.lower() in i[_filter].lower()):

--- a/impacket/examples/logger.py
+++ b/impacket/examples/logger.py
@@ -17,6 +17,7 @@
 import logging
 import sys
 from impacket import version
+from impacket.examples.ntlmrelayx.utils.identity_log import IdentityFilter
 
 # This module can be used by scripts using the Impacket library 
 # in order to configure the root logger to output events 
@@ -30,7 +31,7 @@ class ImpacketFormatter(logging.Formatter):
   Prefixing logged messages through the custom attribute 'bullet'.
   '''
   def __init__(self):
-      logging.Formatter.__init__(self,'%(bullet)s %(message)s', None)
+      logging.Formatter.__init__(self,'%(bullet)s %(identity)s%(message)s', None)
 
   def format(self, record):
     if record.levelno == logging.INFO:
@@ -49,7 +50,7 @@ class ImpacketFormatterTimeStamp(ImpacketFormatter):
   Prefixing logged messages through the custom attribute 'bullet'.
   '''
   def __init__(self):
-      logging.Formatter.__init__(self,'[%(asctime)-15s] %(bullet)s %(message)s', None)
+      logging.Formatter.__init__(self,'[%(asctime)-15s] %(bullet)s %(identity)s%(message)s', None)
 
   def formatTime(self, record, datefmt=None):
       return ImpacketFormatter.formatTime(self, record, datefmt="%Y-%m-%d %H:%M:%S")
@@ -62,6 +63,8 @@ def init(ts=False, debug=False):
         handler.setFormatter(ImpacketFormatterTimeStamp())
     else:
         handler.setFormatter(ImpacketFormatter())
+
+    handler.addFilter(IdentityFilter())
 
     logging.getLogger().addHandler(handler)
 

--- a/impacket/examples/ntlmrelayx/attacks/__init__.py
+++ b/impacket/examples/ntlmrelayx/attacks/__init__.py
@@ -36,8 +36,11 @@ PROTOCOL_ATTACKS = {}
 
 def _wrap_run_with_identity(run_func):
     def _wrapped(self, *a, **k):
-        connection_identifier = '%s://%s/%s@%s [%s]' % (self.target.scheme, self.domain, self.username, self.target.hostname, self.relay_client.client_id)
-        with identity_context(connection_identifier):
+        if self.target is not None and self.relay_client is not None:
+            connection_identifier = '%s://%s/%s@%s [%s]' % (self.target.scheme, self.domain, self.username, self.target.hostname, self.relay_client.client_id)
+            with identity_context(connection_identifier):
+                return run_func(self, *a, **k)
+        else:
             return run_func(self, *a, **k)
     return _wrapped
 
@@ -50,7 +53,7 @@ class ProtocolAttack(Thread):
         if 'run' in cls.__dict__:
             cls.run = _wrap_run_with_identity(cls.run)
 
-    def __init__(self, config, client, username, target, relay_client):
+    def __init__(self, config, client, username, target=None, relay_client=None):
         Thread.__init__(self)
         # Set threads as daemon
         self.daemon = True

--- a/impacket/examples/ntlmrelayx/attacks/__init__.py
+++ b/impacket/examples/ntlmrelayx/attacks/__init__.py
@@ -36,7 +36,7 @@ PROTOCOL_ATTACKS = {}
 
 def _wrap_run_with_identity(run_func):
     def _wrapped(self, *a, **k):
-        connection_identifier = '%s/%s@%s[%s]' % (self.domain, self.username, self.target.hostname, self.relay_client.client_id)
+        connection_identifier = '%s://%s/%s@%s [%s]' % (self.target.scheme, self.domain, self.username, self.target.hostname, self.relay_client.client_id)
         with identity_context(connection_identifier):
             return run_func(self, *a, **k)
     return _wrapped

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -116,10 +116,10 @@ class LDAPAttack(ProtocolAttack):
     GENERIC_EXECUTE         = 0x00020004
     GENERIC_ALL             = 0x000F01FF
 
-    def __init__(self, config, LDAPClient, username):
+    def __init__(self, config, LDAPClient, username, target, relay_client):
         self.computerName = '' if not config.addcomputer else config.addcomputer[0]
         self.computerPassword = '' if not config.addcomputer or len(config.addcomputer) < 2 else config.addcomputer[1]
-        ProtocolAttack.__init__(self, config, LDAPClient, username)
+        ProtocolAttack.__init__(self, config, LDAPClient, username, target, relay_client)
         if self.config.interactive:
             # Launch locally listening interactive shell.
             self.tcp_shell = TcpShell()

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -116,7 +116,7 @@ class LDAPAttack(ProtocolAttack):
     GENERIC_EXECUTE         = 0x00020004
     GENERIC_ALL             = 0x000F01FF
 
-    def __init__(self, config, LDAPClient, username, target, relay_client):
+    def __init__(self, config, LDAPClient, username, target=None, relay_client=None):
         self.computerName = '' if not config.addcomputer else config.addcomputer[0]
         self.computerPassword = '' if not config.addcomputer or len(config.addcomputer) < 2 else config.addcomputer[1]
         ProtocolAttack.__init__(self, config, LDAPClient, username, target, relay_client)

--- a/impacket/examples/ntlmrelayx/attacks/mssqlattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/mssqlattack.py
@@ -26,8 +26,8 @@ PROTOCOL_ATTACK_CLASS = "MSSQLAttack"
 
 class MSSQLAttack(ProtocolAttack):
     PLUGIN_NAMES = ["MSSQL"]
-    def __init__(self, config, MSSQLclient, username):
-        ProtocolAttack.__init__(self, config, MSSQLclient, username)
+    def __init__(self, config, MSSQLclient, username, target, relay_client):
+        ProtocolAttack.__init__(self, config, MSSQLclient, username, target, relay_client)
         if self.config.interactive:
             # Launch locally listening interactive shell.
             self.tcp_shell = TcpShell()

--- a/impacket/examples/ntlmrelayx/attacks/mssqlattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/mssqlattack.py
@@ -26,7 +26,7 @@ PROTOCOL_ATTACK_CLASS = "MSSQLAttack"
 
 class MSSQLAttack(ProtocolAttack):
     PLUGIN_NAMES = ["MSSQL"]
-    def __init__(self, config, MSSQLclient, username, target, relay_client):
+    def __init__(self, config, MSSQLclient, username, target=None, relay_client=None):
         ProtocolAttack.__init__(self, config, MSSQLclient, username, target, relay_client)
         if self.config.interactive:
             # Launch locally listening interactive shell.

--- a/impacket/examples/ntlmrelayx/attacks/rpcattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/rpcattack.py
@@ -172,8 +172,8 @@ class ICPRRPCAttack:
 class RPCAttack(ProtocolAttack, TSCHRPCAttack):
     PLUGIN_NAMES = ["RPC"]
 
-    def __init__(self, config, dce, username):
-        ProtocolAttack.__init__(self, config, dce, username)
+    def __init__(self, config, dce, username, target, relay_client):
+        ProtocolAttack.__init__(self, config, dce, username, target, relay_client)
         self.dce = dce
         self.rpctransport = dce.get_rpc_transport()
         self.stringbinding = self.rpctransport.get_stringbinding()

--- a/impacket/examples/ntlmrelayx/attacks/rpcattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/rpcattack.py
@@ -172,7 +172,7 @@ class ICPRRPCAttack:
 class RPCAttack(ProtocolAttack, TSCHRPCAttack):
     PLUGIN_NAMES = ["RPC"]
 
-    def __init__(self, config, dce, username, target, relay_client):
+    def __init__(self, config, dce, username, target=None, relay_client=None):
         ProtocolAttack.__init__(self, config, dce, username, target, relay_client)
         self.dce = dce
         self.rpctransport = dce.get_rpc_transport()

--- a/impacket/examples/ntlmrelayx/attacks/smbattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/smbattack.py
@@ -40,8 +40,8 @@ class SMBAttack(ProtocolAttack):
     shell if the -i option is specified.
     """
     PLUGIN_NAMES = ["SMB"]
-    def __init__(self, config, SMBClient, username):
-        ProtocolAttack.__init__(self, config, SMBClient, username)
+    def __init__(self, config, SMBClient, username, target, relay_client):
+        ProtocolAttack.__init__(self, config, SMBClient, username, target, relay_client)
         if isinstance(SMBClient, smb.SMB) or isinstance(SMBClient, smb3.SMB3):
             self.__SMBConnection = SMBConnection(existingConnection=SMBClient)
         else:

--- a/impacket/examples/ntlmrelayx/attacks/smbattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/smbattack.py
@@ -40,7 +40,7 @@ class SMBAttack(ProtocolAttack):
     shell if the -i option is specified.
     """
     PLUGIN_NAMES = ["SMB"]
-    def __init__(self, config, SMBClient, username, target, relay_client):
+    def __init__(self, config, SMBClient, username, target=None, relay_client=None):
         ProtocolAttack.__init__(self, config, SMBClient, username, target, relay_client)
         if isinstance(SMBClient, smb.SMB) or isinstance(SMBClient, smb3.SMB3):
             self.__SMBConnection = SMBConnection(existingConnection=SMBClient)

--- a/impacket/examples/ntlmrelayx/clients/__init__.py
+++ b/impacket/examples/ntlmrelayx/clients/__init__.py
@@ -16,6 +16,7 @@
 #   Alberto Solino (@agsolino)
 #
 import os, sys, pkg_resources
+from threading import Lock
 from impacket import LOG
 
 PROTOCOL_CLIENTS = {}
@@ -25,6 +26,8 @@ PROTOCOL_CLIENTS = {}
 # writing a plugin for protocol clients:
 # PROTOCOL_CLIENT_CLASS = "<name of the class for the plugin>"
 # PLUGIN_NAME must be the protocol name that will be matched later with the relay targets (e.g. SMB, LDAP, etc)
+client_idx = 0
+lock = Lock()
 class ProtocolClient:
     PLUGIN_NAME = 'PROTOCOL'
     def __init__(self, serverConfig, target, targetPort, extendedSecurity=True):
@@ -93,6 +96,13 @@ class ProtocolClient:
         # Depending on the protocol, different techniques should be used.
         # By default, raise exception
         raise RuntimeError('Virtual Function')
+
+    def setClientId(self):
+        with lock:
+            global client_idx
+            client_idx += 1
+            self.client_id = client_idx
+
 
 for file in pkg_resources.resource_listdir('impacket.examples.ntlmrelayx', 'clients'):
     if file.find('__') >= 0 or file.endswith('.py') is False:

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -475,8 +475,9 @@ class HTTPRelayServer(Thread):
                         self.do_AUTHHEAD(b'NTLM', proxy=proxy)
                 else:
                     # Relay worked, do whatever we want here...
-                    LOG.info("HTTPD(%s): Authenticating against %s://%s as %s SUCCEED" % (self.server.server_address[1],
-                        self.target.scheme, self.target.netloc, self.authUser))
+                    self.client.setClientId()
+                    LOG.info("HTTPD(%s): Authenticating against %s://%s as %s SUCCEED [%s]" % (self.server.server_address[1],
+                        self.target.scheme, self.target.netloc, self.authUser, self.client.client_id))
 
                     ntlm_hash_data = outputToJohnFormat(self.challengeMessage['challenge'],
                                                         authenticateMessage['user_name'],

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -545,7 +545,7 @@ class HTTPRelayServer(Thread):
             if self.target.scheme.upper() in self.server.config.attacks:
                 # We have an attack.. go for it
                 clientThread = self.server.config.attacks[self.target.scheme.upper()](self.server.config, self.client.session,
-                                                                               self.authUser)
+                                                                               self.authUser, self.target, self.client)
                 clientThread.start()
             else:
                 LOG.error('HTTPD(%s): No attack configured for %s' % (self.server.server_address[1], self.target.scheme.upper()))

--- a/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
@@ -114,15 +114,15 @@ class RAWRelayServer(Thread):
                     # Relay worked, do whatever we want here...
                     self.request.sendall(struct.pack('h', 1))
                     self.request.sendall(struct.pack('?', True))
-
+                    self.client.setClientId()
                     if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
-                        LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED" % (
+                        LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED [%s]" % (
                             self.target.scheme, self.target.netloc, authenticateMessage['domain_name'].decode('utf-16le'),
-                            authenticateMessage['user_name'].decode('utf-16le')))
+                            authenticateMessage['user_name'].decode('utf-16le'), self.client.client_id))
                     else:
-                        LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED" % (
+                        LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED [%s]" % (
                             self.target.scheme, self.target.netloc, authenticateMessage['domain_name'].decode('ascii'),
-                            authenticateMessage['user_name'].decode('ascii')))
+                            authenticateMessage['user_name'].decode('ascii'), self.client.client_id))
 
                     ntlm_hash_data = outputToJohnFormat(self.challengeMessage['challenge'],
                                                         authenticateMessage['user_name'],

--- a/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
@@ -195,7 +195,7 @@ class RAWRelayServer(Thread):
             if self.target.scheme.upper() in self.server.config.attacks:
                 # We have an attack.. go for it
                 clientThread = self.server.config.attacks[self.target.scheme.upper()](self.server.config, self.client.session,
-                                                                               self.authUser)
+                                                                               self.authUser, self.target, self.client)
                 clientThread.start()
             else:
                 LOG.error('No attack configured for %s' % self.target.scheme.upper())

--- a/impacket/examples/ntlmrelayx/servers/rpcrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/rpcrelayserver.py
@@ -407,7 +407,9 @@ class RPCRelayServer(Thread):
                 # We have an attack.. go for it
                 clientThread = self.server.config.attacks[self.target.scheme.upper()](self.server.config,
                                                                                       self.client.session,
-                                                                                      self.auth_user)
+                                                                                      self.auth_user,
+                                                                                      self.target,
+                                                                                      self.client)
                 clientThread.start()
             else:
                 LOG.error('No attack configured for %s' % self.target.scheme.upper())

--- a/impacket/examples/ntlmrelayx/servers/rpcrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/rpcrelayserver.py
@@ -237,17 +237,17 @@ class RPCRelayServer(Thread):
 
                 try:
                     self.do_ntlm_auth(token, authenticateMessage)
-
+                    self.client.setClientId()
                     # Relay worked, do whatever we want here...
                     if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
-                        LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED" % (
+                        LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED [%s]" % (
                             self.target.scheme, self.target.netloc,
                             authenticateMessage['domain_name'].decode('utf-16le'),
-                            authenticateMessage['user_name'].decode('utf-16le')))
+                            authenticateMessage['user_name'].decode('utf-16le'), self.client.client_id))
                     else:
-                        LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED" % (
+                        LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED [%s]" % (
                             self.target.scheme, self.target.netloc, authenticateMessage['domain_name'].decode('ascii'),
-                            authenticateMessage['user_name'].decode('ascii')))
+                            authenticateMessage['user_name'].decode('ascii'), self.client.client_id))
 
 
                     ntlm_hash_data = outputToJohnFormat(self.challengeMessage['challenge'],

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -366,7 +366,8 @@ class SMBRelayServer(Thread):
                 client.killConnection()
             else:
                 # We have a session, create a thread and do whatever we want
-                LOG.info("Authenticating against %s://%s as %s SUCCEED" % (self.target.scheme, self.target.netloc, self.authUser))
+                self.client.setClientId()
+                LOG.info("Authenticating against %s://%s as %s SUCCEED [%s]" % (self.target.scheme, self.target.netloc, self.authUser, self.client.client_id))
                 # Log this target as processed for this client
 
                 if not self.config.isADCSAttack:
@@ -662,7 +663,8 @@ class SMBRelayServer(Thread):
                     return None, [packet], errorCode
                 else:
                     # We have a session, create a thread and do whatever we want
-                    LOG.info("Authenticating against %s://%s as %s SUCCEED" % (self.target.scheme, self.target.netloc, self.authUser))
+                    self.client.setClientId()
+                    LOG.info("Authenticating against %s://%s as %s SUCCEED [%s]" % (self.target.scheme, self.target.netloc, self.authUser, self.client.client_id))
 
                     # Log this target as processed for this client
                     self.targetprocessor.registerTarget(self.target, True, self.authUser)
@@ -741,8 +743,9 @@ class SMBRelayServer(Thread):
                 return None, [packet], errorCode
             else:
                 # We have a session, create a thread and do whatever we want
+                self.client.setClientId()
                 self.authUser = ('%s/%s' % (sessionSetupData['PrimaryDomain'], sessionSetupData['Account'])).upper()
-                LOG.info("Authenticating against %s://%s as %s SUCCEED" % (self.target.scheme, self.target.netloc, self.authUser))
+                LOG.info("Authenticating against %s://%s as %s SUCCEED [%s]" % (self.target.scheme, self.target.netloc, self.authUser, self.client.client_id))
 
                 # Log this target as processed for this client
                 self.targetprocessor.registerTarget(self.target, True, self.authUser)

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -921,7 +921,7 @@ class SMBRelayServer(Thread):
         # If SOCKS is not enabled, or not supported for this scheme, fall back to "classic" attacks
         if self.target.scheme.upper() in self.config.attacks:
             # We have an attack.. go for it
-            clientThread = self.config.attacks[self.target.scheme.upper()](self.config, client.session, self.authUser)
+            clientThread = self.config.attacks[self.target.scheme.upper()](self.config, client.session, self.authUser, self.target, self.client)
             clientThread.start()
         else:
             LOG.error('No attack configured for %s' % self.target.scheme.upper())

--- a/impacket/examples/ntlmrelayx/servers/socksserver.py
+++ b/impacket/examples/ntlmrelayx/servers/socksserver.py
@@ -217,7 +217,7 @@ def activeConnectionsWatcher(server):
             server.activeRelays[target][port] = {}
 
         if (userName in server.activeRelays[target][port]) is not True:
-            LOG.info('SOCKS: Adding %s@%s(%s) to active SOCKS connection. Enjoy' % (userName, target, port))
+            LOG.info('SOCKS: Adding %s@%s(%s)[%s] to active SOCKS connection. Enjoy' % (userName, target, port, client.client_id))
             server.activeRelays[target][port][userName] = {}
             # This is the protocolClient. Needed because we need to access the killConnection from time to time.
             # Inside this instance, you have the session attribute pointing to the relayed session.
@@ -267,9 +267,10 @@ def webService(addr, port):
                 for port in server.activeRelays[target]:
                     for user in server.activeRelays[target][port]:
                         if user != 'data' and user != 'scheme':
+                            client_id = server.activeRelays[target][port][user]['protocolClient'].client_id
                             protocol = server.activeRelays[target][port]['scheme']
                             isAdmin = server.activeRelays[target][port][user]['isAdmin']
-                            relays.append([protocol, target, user, isAdmin, str(port)])
+                            relays.append([protocol, target, user, isAdmin, str(port), str(client_id)])
             return jsonify(relays)
 
         @app.route('/ntlmrelayx/api/v1.0/relays', methods=['GET'])

--- a/impacket/examples/ntlmrelayx/servers/socksserver.py
+++ b/impacket/examples/ntlmrelayx/servers/socksserver.py
@@ -217,7 +217,7 @@ def activeConnectionsWatcher(server):
             server.activeRelays[target][port] = {}
 
         if (userName in server.activeRelays[target][port]) is not True:
-            LOG.info('SOCKS: Adding %s://%s@%s(%s)[%s] to active SOCKS connection. Enjoy' % (scheme, userName, target, port, client.client_id))
+            LOG.info('SOCKS: Adding %s://%s@%s(%s) [%s] to active SOCKS connection. Enjoy' % (scheme, userName, target, port, client.client_id))
             server.activeRelays[target][port][userName] = {}
             # This is the protocolClient. Needed because we need to access the killConnection from time to time.
             # Inside this instance, you have the session attribute pointing to the relayed session.

--- a/impacket/examples/ntlmrelayx/servers/socksserver.py
+++ b/impacket/examples/ntlmrelayx/servers/socksserver.py
@@ -217,7 +217,7 @@ def activeConnectionsWatcher(server):
             server.activeRelays[target][port] = {}
 
         if (userName in server.activeRelays[target][port]) is not True:
-            LOG.info('SOCKS: Adding %s@%s(%s)[%s] to active SOCKS connection. Enjoy' % (userName, target, port, client.client_id))
+            LOG.info('SOCKS: Adding %s://%s@%s(%s)[%s] to active SOCKS connection. Enjoy' % (scheme, userName, target, port, client.client_id))
             server.activeRelays[target][port][userName] = {}
             # This is the protocolClient. Needed because we need to access the killConnection from time to time.
             # Inside this instance, you have the session attribute pointing to the relayed session.

--- a/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
@@ -337,7 +337,9 @@ class WCFRelayServer(Thread):
                 # We have an attack.. go for it
                 clientThread = self.server.config.attacks[self.target.scheme.upper()](self.server.config,
                                                                                       self.client.session,
-                                                                                      self.authUser)
+                                                                                      self.authUser,
+                                                                                      self.target,
+                                                                                      self.client)
                 clientThread.start()
             else:
                 LOG.error('No attack configured for %s' % self.target.scheme.upper())

--- a/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
@@ -254,15 +254,16 @@ class WCFRelayServer(Thread):
                 return
 
             # Relay worked, do whatever we want here...
+            self.client.setClientId()
             if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
-                LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED" % (
+                LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED [%s]" % (
                     self.target.scheme, self.target.netloc,
                     authenticateMessage['domain_name'].decode('utf-16le'),
-                    authenticateMessage['user_name'].decode('utf-16le')))
+                    authenticateMessage['user_name'].decode('utf-16le'), self.client.client_id))
             else:
-                LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED" % (
+                LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED [%s]" % (
                     self.target.scheme, self.target.netloc, authenticateMessage['domain_name'].decode('ascii'),
-                    authenticateMessage['user_name'].decode('ascii')))
+                    authenticateMessage['user_name'].decode('ascii'), self.client.client_id))
 
             ntlm_hash_data = outputToJohnFormat(self.challengeMessage['challenge'],
                                                 authenticateMessage['user_name'],

--- a/impacket/examples/ntlmrelayx/utils/identity_log.py
+++ b/impacket/examples/ntlmrelayx/utils/identity_log.py
@@ -27,5 +27,5 @@ class IdentityFilter(logging.Filter):
     def filter(self, record):
         # Will be "" if not set
         identity = _get_identity()
-        record.identity = f"{identity} -> " if identity else ''
+        record.identity = "%s -> " % identity if identity else ''
         return True

--- a/impacket/examples/ntlmrelayx/utils/identity_log.py
+++ b/impacket/examples/ntlmrelayx/utils/identity_log.py
@@ -1,0 +1,36 @@
+# impacket/examples/ntlmrelayx/utils/identity_log.py
+import logging
+import threading
+from contextlib import contextmanager
+
+__all__ = ["set_identity", "clear_identity", "identity_context", "IdentityFilter"]
+
+# Thread-local storage for current identity
+_tlocal = threading.local()
+
+def _get_identity():
+    return getattr(_tlocal, "identity", None)
+
+def set_identity(identity: str | None):
+    setattr(_tlocal, "identity", identity)
+
+def clear_identity():
+    setattr(_tlocal, "identity", None)
+
+@contextmanager
+def identity_context(identity: str | None):
+    prev = _get_identity()
+    try:
+        set_identity(identity)
+        yield
+    finally:
+        # Restore whatever was there before (safer for nested calls)
+        set_identity(prev)
+
+class IdentityFilter(logging.Filter):
+    """Injects .identity into every LogRecord so %(identity)s works in formatters."""
+    def filter(self, record: logging.LogRecord) -> bool:
+        # Will be "-" if not set
+        identity = _get_identity()
+        record.identity = f"{identity} -> " if identity else ''
+        return True

--- a/impacket/examples/ntlmrelayx/utils/identity_log.py
+++ b/impacket/examples/ntlmrelayx/utils/identity_log.py
@@ -3,22 +3,17 @@ import logging
 import threading
 from contextlib import contextmanager
 
-__all__ = ["set_identity", "clear_identity", "identity_context", "IdentityFilter"]
-
 # Thread-local storage for current identity
 _tlocal = threading.local()
 
 def _get_identity():
     return getattr(_tlocal, "identity", None)
 
-def set_identity(identity: str | None):
+def set_identity(identity):
     setattr(_tlocal, "identity", identity)
 
-def clear_identity():
-    setattr(_tlocal, "identity", None)
-
 @contextmanager
-def identity_context(identity: str | None):
+def identity_context(identity):
     prev = _get_identity()
     try:
         set_identity(identity)
@@ -29,8 +24,8 @@ def identity_context(identity: str | None):
 
 class IdentityFilter(logging.Filter):
     """Injects .identity into every LogRecord so %(identity)s works in formatters."""
-    def filter(self, record: logging.LogRecord) -> bool:
-        # Will be "-" if not set
+    def filter(self, record):
+        # Will be "" if not set
         identity = _get_identity()
         record.identity = f"{identity} -> " if identity else ''
         return True


### PR DESCRIPTION
This PR is a continuation of https://github.com/fortra/impacket/pull/2012 (also related with https://github.com/fortra/impacket/issues/1217)

It adds a prefix for every "attack log line" executed on a relayed connection. It follows this format:
* `<SCHEME>://<DOMAIN>/<USERNAME>@<TARGET> [<CLIENT_ID>] -> "message...."`

CLIENT_ID is an auto incremental index for every successfully relayed connection

For example
```
[*] Servers started, waiting for connections
[*] (HTTP): Client requested path: /
[*] (HTTP): Client requested path: /
[*] (HTTP): Connection from 10.10.10.1 controlled, attacking target smb://10.10.10.2
[*] (HTTP): Client requested path: /
[*] (HTTP): Authenticating connection from DOMAIN/USER@10.10.10.1 against smb://10.10.10.2 SUCCEED [1]
[*] smb://DOMAIN/USER@10.10.10.2 [1] -> Service RemoteRegistry is in stopped state
[*] smb://DOMAIN/USER@10.10.10.2 [1] -> Starting service RemoteRegistry
[*] smb://DOMAIN/USER@10.10.10.2 [1] -> Target system bootKey: 0x....
[*] smb://DOMAIN/USER@10.10.10.2 [1] -> Dumping local SAM hashes (uid:rid:lmhash:nthash)
...
```