### PR TITLE
Fix output when printing table rows

### DIFF
--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -1180,7 +1180,7 @@ class MSSQL:
         for row in self.rows:
             for col in self.colMeta:
                 self.__rowsPrinter.logMessage(col['Format'] % row[col['Name']] + self.COL_SEPARATOR)
-            self.__rowsPrinter.logMessage('\n')
+            self.__rowsPrinter.logMessage('\r')
 
     def printReplies(self, error_logger=LOG.error, info_logger=LOG.info):
         for keys in list(self.replies.keys()):


### PR DESCRIPTION
Currently, each time a row is printed in the `printRows` function in `tds.py` a new line as added using the `\n` character. However, due to the way the `DummyPrint` class handles the `\n` character, two new lines are added leading to an additional (unnecessary) new line:
https://github.com/fortra/impacket/blob/082dca34a376d13c70b0df6a1d9048ce98fe9498/impacket/tds.py#L57-L64
Example screenshot from the current state:
<img width="1589" height="752" alt="image" src="https://github.com/user-attachments/assets/087c842e-8f32-4dbf-9f30-369b7b6cb9d5" />

This is fixed by using the character `\r`, which is interpreted as a single new line by the `DummyPrint` class, resulting in proper table formatting:
<img width="1589" height="563" alt="image" src="https://github.com/user-attachments/assets/58331122-4b8a-4f7e-ab1d-bf7eba617972" />
