### PR TITLE
Fix breaking issues introduced in #1894

### DIFF
--- a/examples/atexec.py
+++ b/examples/atexec.py
@@ -32,6 +32,7 @@ import logging
 
 from impacket.examples import logger
 from impacket import version
+from impacket.smb import FILE_SHARE_READ
 from impacket.dcerpc.v5 import tsch, transport
 from impacket.dcerpc.v5.dtypes import NULL
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE, \
@@ -219,7 +220,7 @@ class TSCH_EXEC:
         while True:
             try:
                 logging.info('Attempting to read ADMIN$\\Temp\\%s' % tmpFileName)
-                smbConnection.getFile('ADMIN$', 'Temp\\%s' % tmpFileName, output_callback)
+                smbConnection.getFile('ADMIN$', 'Temp\\%s' % tmpFileName, output_callback, FILE_SHARE_READ)
                 break
             except Exception as e:
                 if str(e).find('SHARING') > 0:

--- a/examples/dcomexec.py
+++ b/examples/dcomexec.py
@@ -58,7 +58,7 @@ from impacket.dcerpc.v5.dcomrt import OBJREF, FLAGS_OBJREF_CUSTOM, OBJREF_CUSTOM
 from impacket.dcerpc.v5.dtypes import NULL
 from impacket.examples import logger
 from impacket.examples.utils import parse_target
-from impacket.smbconnection import SMBConnection, SMB_DIALECT, SMB2_DIALECT_002, SMB2_DIALECT_21
+from impacket.smbconnection import SMBConnection, SMB_DIALECT, SMB2_DIALECT_002, SMB2_DIALECT_21, FILE_SHARE_READ
 from impacket.krb5.keytab import Keytab
 
 OUTPUT_FILENAME = '__' + str(time.time())[:5]
@@ -361,7 +361,7 @@ class RemoteShell(cmd.Cmd):
 
         while True:
             try:
-                self.__transferClient.getFile(self._share, self._output, output_callback)
+                self.__transferClient.getFile(self._share, self._output, output_callback, FILE_SHARE_READ)
                 break
             except Exception as e:
                 if str(e).find('STATUS_SHARING_VIOLATION') >=0:

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -53,6 +53,7 @@ from base64 import b64encode
 from impacket.examples import logger
 from impacket.examples.utils import parse_target
 from impacket import version, smbserver
+from impacket.smb import FILE_SHARE_READ
 from impacket.dcerpc.v5 import transport, scmr
 from impacket.krb5.keytab import Keytab
 
@@ -268,7 +269,7 @@ class RemoteShell(cmd.Cmd):
             self.__outputBuffer += data
 
         if self.__mode == 'SHARE':
-            self.transferClient.getFile(self.__share, OUTPUT_FILENAME, output_callback)
+            self.transferClient.getFile(self.__share, OUTPUT_FILENAME, output_callback, FILE_SHARE_READ)
             self.transferClient.deleteFile(self.__share, OUTPUT_FILENAME)
         else:
             fd = open(SMBSERVER_DIR + '/' + OUTPUT_FILENAME,'rb')

--- a/examples/wmiexec.py
+++ b/examples/wmiexec.py
@@ -38,7 +38,7 @@ from base64 import b64encode
 from impacket.examples import logger
 from impacket.examples.utils import parse_target
 from impacket import version
-from impacket.smbconnection import SMBConnection, SMB_DIALECT, SMB2_DIALECT_002, SMB2_DIALECT_21
+from impacket.smbconnection import SMBConnection, SMB_DIALECT, SMB2_DIALECT_002, SMB2_DIALECT_21, FILE_SHARE_READ
 from impacket.dcerpc.v5.dcomrt import DCOMConnection, COMVERSION
 from impacket.dcerpc.v5.dcom import wmi
 from impacket.dcerpc.v5.dtypes import NULL
@@ -269,7 +269,7 @@ class RemoteShell(cmd.Cmd):
 
         while True:
             try:
-                self.__transferClient.getFile(self.__share, self.__output, output_callback)
+                self.__transferClient.getFile(self.__share, self.__output, output_callback, FILE_SHARE_READ)
                 break
             except Exception as e:
                 if str(e).find('STATUS_SHARING_VIOLATION') >= 0:
@@ -281,6 +281,7 @@ class RemoteShell(cmd.Cmd):
                     logging.debug('Connection broken, trying to recreate it')
                     self.__transferClient.reconnect()
                     return self.get_output()
+        
         self.__transferClient.deleteFile(self.__share, self.__output)
 
     def execute_remote(self, data, shell_type='cmd'):

--- a/impacket/examples/ntlmrelayx/attacks/smbattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/smbattack.py
@@ -191,7 +191,7 @@ class SMBAttack(ProtocolAttack):
                     if self.config.command is not None:
                         remoteOps._RemoteOperations__executeRemote(self.config.command)
                         LOG.info("Executed specified command on host: %s", self.__SMBConnection.getRemoteHost())
-                        self.__SMBConnection.getFile('ADMIN$', 'Temp\\__output', self.__answer)
+                        self.__SMBConnection.getFile('ADMIN$', 'Temp\\__output', self.__answer, smb.FILE_SHARE_READ)
                         self.__SMBConnection.deleteFile('ADMIN$', 'Temp\\__output')
                         print(self.__answerTMP.decode(self.config.encoding, 'replace'))
                     else:

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -1169,7 +1169,7 @@ class RemoteOperations:
         tries = 0
         while True:
             try:
-                self.__smbConnection.getFile('ADMIN$', 'Temp\\__output', self.__answer)
+                self.__smbConnection.getFile('ADMIN$', 'Temp\\__output', self.__answer, FILE_SHARE_READ)
                 break
             except Exception as e:
                 if tries > 30:


### PR DESCRIPTION
Hello,
Following my previous contribution in #1894 I changed the default behavior of the `getFile` method of the `SMBConnection` class.  
Now it always uses overly permissive share access modes instead of overly restrictive ones.  
This is very useful if we wish to read "locked" files (files that have active open process handles to them).
But in doing so I forgot a crucial element of impacket's exec suite.  
All of them rely on receiving a `STATUS_SHARING_VIOLATION` error in order to know when the command stops being executed remotely.  
This commit fixes all exec examples and modules.  