### PR TITLE
Fix - Add support for DCOM connections to loopback addresses

### DIFF
--- a/impacket/dcerpc/v5/dcomrt.py
+++ b/impacket/dcerpc/v5/dcomrt.py
@@ -32,6 +32,7 @@
 
 from __future__ import division
 from __future__ import print_function
+import ipaddress
 import socket
 from struct import pack
 from threading import Timer, current_thread
@@ -1251,15 +1252,10 @@ class INTERFACE:
         self.__cinstance = cinstance
     
     def is_target_loopback(self):
-        """
-        Detect all loopback IP addresses.
-        This is assuming 127.0.0.0/8 is IPv4 loopback.
-        Also accounting for IPv6 loopback addresses.
-        This should only be used to filter user input and automatically redirect any DCOM connections
-         from local machines to correct string-bindings on the local endpoint mapper.
-        """
-        return self.get_target().startswith('127.') \
-            or self.get_target() == '::1' or self.get_target() == '0:0:0:0:0:0:0:1' # IPv6 loopback addresses.
+        try:
+            return ipaddress.ip_address(self.get_target()).is_loopback
+        except ValueError:
+            return False
 
     def is_fqdn(self):
         # I will assume the following
@@ -1317,13 +1313,10 @@ class INTERFACE:
                             bindingPort = ''
 
                         if self.is_target_loopback():
-                            # Accept the first matched string-binding.
-                            # This is because we know we want to connect no matter what.
+                            # The endpoint mapper does not advertise loopback addresses, but
+                            # this connection was explicitly requested for one. Reuse its port.
                             LOG.debug('Detected loopback DCOM connection attempt, using first available StringBinding.')
-                            stringBinding = 'ncacn_ip_tcp:' + strBinding['aNetworkAddr'][:-1]
-                            # TODO: Decide if we also want to change our self.__target accordingly...?
-                            # Notice - it breaks stuff.
-                            # self.__target = binding
+                            stringBinding = 'ncacn_ip_tcp:%s%s' % (self.get_target(), bindingPort)
                             break
                         
                         if binding.upper().find(self.get_target().upper()) >= 0:

--- a/tests/dcerpc/test_dcomrt.py
+++ b/tests/dcerpc/test_dcomrt.py
@@ -35,6 +35,20 @@ from impacket.dcerpc.v5 import dcomrt
 from impacket.dcerpc.v5.dcom import scmp, vds, oaut, comev
 
 
+class InterfaceTests(unittest.TestCase):
+
+    def test_is_target_loopback(self):
+        interface = dcomrt.INTERFACE.__new__(dcomrt.INTERFACE)
+
+        for target in ('127.0.0.1', '127.255.255.255', '::1', '0:0:0:0:0:0:0:1'):
+            interface._INTERFACE__target = target
+            self.assertTrue(interface.is_target_loopback())
+
+        for target in ('192.0.2.1', '2001:db8::1', 'server.example.test'):
+            interface._INTERFACE__target = target
+            self.assertFalse(interface.is_target_loopback())
+
+
 class DCOMTests(DCERPCTests):
 
     string_binding = r"ncacn_ip_tcp:{0.machine}"


### PR DESCRIPTION
If we try to connect to a machine via a proxy to it's loopback address we fail.  
This is because the DCOM Connection client does not find any "valid string-bindings" that match the specified IP address (`127.0.0.1`).

<img width="896" height="200" alt="Screenshot 2025-09-12 000458" src="https://github.com/user-attachments/assets/50e389dc-672f-427f-ad0a-7836d74aae6c" />

This behavior may be logically fine but it harms end-user use.  
This commit fixes the issue by checking for use of loopback addresses and handling them correctly.  

<img width="928" height="445" alt="Screenshot 2025-09-12 001216" src="https://github.com/user-attachments/assets/3c16cb58-4797-4579-a153-0919df3dceee" />
