### PR TITLE
Remove pyopen ssl version restriction

### DIFF
--- a/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
@@ -20,6 +20,9 @@ import base64
 import os
 from OpenSSL import crypto
 
+from cryptography.hazmat.primitives.serialization import pkcs12
+from cryptography.hazmat.primitives.serialization import NoEncryption
+
 from impacket import LOG
 
 # cache already attacked clients
@@ -110,13 +113,18 @@ class ADCSAttack:
         return crypto.dump_certificate_request(csr_type, req)
 
     @staticmethod
-    def generate_pfx(key, certificate, cert_type = crypto.FILETYPE_PEM):
-        certificate = crypto.load_certificate(cert_type, certificate)
-        p12 = crypto.PKCS12()
-        p12.set_certificate(certificate)
-        p12.set_privatekey(key)
-        return p12.export()
+    def generate_pfx(key, certificate):
 
+        pfx_data = pkcs12.serialize_key_and_certificates(
+            name=b"",
+            key=key,
+            cert=certificate,
+            cas=None,
+            encryption_algorithm=NoEncryption()
+        )
+        
+        return pfx_data
+    
     @staticmethod
     def generate_certattributes(template, altName):
         if altName:

--- a/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
@@ -121,7 +121,7 @@ class ADCSAttack:
 
         if cert_type == crypto.FILETYPE_PEM:
             cert=load_pem_x509_certificate(certificate.encode(), backend=default_backend())
-        else: #ASN!/DER
+        else: #ASN1/DER
             cert=load_der_x509_certificate(certificate.encode(), backend=default_backend())
 
         pfx_data = pkcs12.serialize_key_and_certificates(

--- a/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
@@ -22,6 +22,10 @@ from OpenSSL import crypto
 
 from cryptography.hazmat.primitives.serialization import pkcs12
 from cryptography.hazmat.primitives.serialization import NoEncryption
+from cryptography.x509 import load_pem_x509_certificate
+from cryptography.hazmat.backends import default_backend
+
+
 
 from impacket import LOG
 
@@ -81,7 +85,7 @@ class ADCSAttack:
         LOG.info("GOT CERTIFICATE! ID %s" % certificate_id)
         certificate = response.read().decode()
 
-        certificate_store = self.generate_pfx(key, certificate)
+        certificate_store = self.generate_pfx(key.to_cryptography_key(), certificate)
         LOG.info("Writing PKCS#12 certificate to %s/%s.pfx" % (self.config.lootdir, self.username))
         try:
             if not os.path.isdir(self.config.lootdir):
@@ -118,7 +122,7 @@ class ADCSAttack:
         pfx_data = pkcs12.serialize_key_and_certificates(
             name=b"",
             key=key,
-            cert=certificate,
+            cert=load_pem_x509_certificate(certificate.encode(), backend=default_backend()),
             cas=None,
             encryption_algorithm=NoEncryption()
         )

--- a/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
@@ -22,7 +22,7 @@ from OpenSSL import crypto
 
 from cryptography.hazmat.primitives.serialization import pkcs12
 from cryptography.hazmat.primitives.serialization import NoEncryption
-from cryptography.x509 import load_pem_x509_certificate
+from cryptography.x509 import load_pem_x509_certificate, load_der_x509_certificate
 from cryptography.hazmat.backends import default_backend
 
 
@@ -117,12 +117,17 @@ class ADCSAttack:
         return crypto.dump_certificate_request(csr_type, req)
 
     @staticmethod
-    def generate_pfx(key, certificate):
+    def generate_pfx(key, certificate, cert_type=crypto.FILETYPE_PEM):
+
+        if cert_type == crypto.FILETYPE_PEM:
+            cert=load_pem_x509_certificate(certificate.encode(), backend=default_backend())
+        else: #ASN!/DER
+            cert=load_der_x509_certificate(certificate.encode(), backend=default_backend())
 
         pfx_data = pkcs12.serialize_key_and_certificates(
             name=b"",
             key=key,
-            cert=load_pem_x509_certificate(certificate.encode(), backend=default_backend()),
+            cert=cert,
             cas=None,
             encryption_algorithm=NoEncryption()
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ charset_normalizer
 pyasn1>=0.2.3
 pyasn1_modules
 pycryptodomex
-pyOpenSSL==24.0.0
+pyOpenSSL
 ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6
 ldapdomaindump>=0.9.0
 flask>=1.0

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     scripts=glob.glob(os.path.join('examples', '*.py')),
     data_files=data_files,
 
-    install_requires=['pyasn1>=0.2.3', 'pyasn1_modules', 'pycryptodomex', 'pyOpenSSL==24.0.0', 'six', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6',
+    install_requires=['pyasn1>=0.2.3', 'pyasn1_modules', 'pycryptodomex', 'pyOpenSSL', 'six', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6',
                       'ldapdomaindump>=0.9.0', 'flask>=1.0', 'setuptools', 'charset_normalizer'],
     extras_require={':sys_platform=="win32"': ['pyreadline3'],
                     },


### PR DESCRIPTION
This PR removes PyOpenSSL version restriction to 24.0.0. PKCS12 certificate generation it's being done through cryptography module for ADCS attack.