### PR TITLE
Fixing issue in ntlmrelayx winrmattack & winrm/s relay servers

### DIFF
--- a/impacket/examples/ntlmrelayx/attacks/winrmattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/winrmattack.py
@@ -249,8 +249,8 @@ class WinRMShell(cmd.Cmd):
 class WINRMAttack(ProtocolAttack):
     PLUGIN_NAMES = ["WINRMS"]
 
-    def __init__(self, config, WINRMClient, username):
-        ProtocolAttack.__init__(self, config, WINRMClient, username)
+    def __init__(self, config, WINRMClient, username, target=None, relay_client=None):
+        ProtocolAttack.__init__(self, config, WINRMClient, username, target, relay_client)
         self.tcp_shell = TcpShell()
 
     def run(self):

--- a/impacket/examples/ntlmrelayx/servers/winrmrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/winrmrelayserver.py
@@ -70,8 +70,8 @@ class WinRMRelayServer(Thread):
             try:
                 http.server.SimpleHTTPRequestHandler.__init__(self,request, client_address, server)
             except Exception as e:
-                LOG.debug("Exception:", exc_info=True)
-                LOG.error(str(e))
+                LOG.debug("(WinRM): Exception:", exc_info=True)
+                LOG.error("(WinRM): %s" % str(e))
 
         def handle_one_request(self):
             try:
@@ -167,7 +167,7 @@ class WinRMRelayServer(Thread):
                         _, blob = typeX.split('Negotiate')
                     token = base64.b64decode(blob.strip())
                 except Exception:
-                    LOG.debug("Exception:", exc_info=True)
+                    LOG.debug("(WinRM): Exception:", exc_info=True)
                     self.do_AUTHHEAD(message = b'NTLM', proxy=proxy)
                 else:
                     messageType = struct.unpack('<L',token[len('NTLMSSP\x00'):len('NTLMSSP\x00')+4])[0]
@@ -306,7 +306,7 @@ class WinRMRelayServer(Thread):
                 if self.challengeMessage is False:
                     return False
             else:
-                LOG.error('Protocol Client for %s not found!' % self.target.scheme.upper())
+                LOG.error('(WinRM): Protocol Client for %s not found!' % self.target.scheme.upper())
                 return False
 
             # Calculate auth
@@ -365,7 +365,7 @@ class WinRMRelayServer(Thread):
             elif messageType == 3:
                 authenticateMessage = ntlm.NTLMAuthChallengeResponse()
                 authenticateMessage.fromString(token)
-                LOG.info(authenticateMessage)
+                LOG.info("(WinRM): %s" % authenticateMessage)
                 if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
                     self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('utf-16le'),
                                                 authenticateMessage['user_name'].decode('utf-16le'))).upper()
@@ -430,7 +430,7 @@ class WinRMRelayServer(Thread):
                     target = '%s://%s@%s' % (self.target.scheme, self.authUser.replace("/", '\\'), self.target.netloc)
 
                 if not self.do_ntlm_auth(token, authenticateMessage):
-                    LOG.error("Authenticating against %s://%s as %s FAILED" % (self.target.scheme, self.target.netloc,
+                    LOG.error("(WinRM): Authenticating against %s://%s as %s FAILED" % (self.target.scheme, self.target.netloc,
                                                                                self.authUser))
                     if self.server.config.disableMulti:
                         self.send_not_found()
@@ -467,7 +467,7 @@ class WinRMRelayServer(Thread):
                                               self.server.config.outputFile)
 
                     if self.server.config.dumpHashes is True:
-                        LOG.info(ntlm_hash_data['hash_string'])
+                        LOG.info("(WinRM): %s" % ntlm_hash_data['hash_string'])
 
                     self.do_attack()
 

--- a/impacket/examples/ntlmrelayx/servers/winrmrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/winrmrelayserver.py
@@ -79,14 +79,14 @@ class WinRMRelayServer(Thread):
             except KeyboardInterrupt:
                 raise
             except Exception as e:
-                LOG.debug("WinRM(%s): Exception:" % self.server.server_address[1], exc_info=True)
+                LOG.debug("(WinRM): Exception:", exc_info=True)
 
         def log_message(self, format, *args):
             return
 
         def send_error(self, code, message=None):
             if message.find('RPC_OUT') >=0 or message.find('RPC_IN'):
-                LOG.info('WinRM(%s): send_error path: %s' % (self.server.server_address[1], self.path.lower()))
+                LOG.info('(WinRM): send_error path: %s' % self.path.lower())
                 return self.do_GET()
             return http.server.SimpleHTTPRequestHandler.send_error(self,code,message)
 
@@ -259,7 +259,7 @@ class WinRMRelayServer(Thread):
                 content_length = int(self.headers.get('Content-Length', 0))
                 self.rfile.read(content_length)
             else:
-                LOG.info('WinRM(%s): Client requested path: %s' % (self.server.server_address[1], self.path.lower()))
+                LOG.info('(WinRM): Client requested path: %s' % self.path.lower())
                 self.send_not_found()
                 return
 
@@ -375,13 +375,11 @@ class WinRMRelayServer(Thread):
 
                 self.target = self.server.config.target.getTarget(identity = self.authUser)
                 if self.target is None:
-                    LOG.info("WinRM(%s): Connection from %s@%s controlled, but there are no more targets left!" %
-                        (self.server.server_address[1], self.authUser, self.client_address[0]))
+                    LOG.info("(WinRM): Connection from %s@%s controlled, but there are no more targets left!" % (self.authUser, self.client_address[0]))
                     self.send_not_found()
                     return
 
-                LOG.info("WinRM(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
-                    self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+                LOG.info("(WinRM): Connection from %s@%s controlled, attacking target %s://%s" % (self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
 
                 self.relayToHost = True
                 self.do_REDIRECT()
@@ -391,35 +389,29 @@ class WinRMRelayServer(Thread):
                 if self.server.config.disableMulti:
                     self.target = self.server.config.target.getTarget(multiRelay=False)
                     if self.target is None:
-                        LOG.info("WinRM(%s): Connection from %s controlled, but there are no more targets left!" % (
-                            self.server.server_address[1], self.client_address[0]))
+                        LOG.info("(WinRM): Connection from %s controlled, but there are no more targets left!" % self.client_address[0])
                         self.send_not_found()
                         return
 
-                    LOG.info("WinRM(%s): Connection from %s controlled, attacking target %s://%s" % (
-                        self.server.server_address[1], self.client_address[0], self.target.scheme, self.target.netloc))
+                    LOG.info("(WinRM): Connection from %s controlled, attacking target %s://%s" % (self.client_address[0], self.target.scheme, self.target.netloc))
 
                 if not self.do_ntlm_negotiate(token, proxy=proxy):
                     # Connection failed
                     if self.server.config.disableMulti:
-                        LOG.error('WinRM(%s): Negotiating NTLM with %s://%s failed' % (self.server.server_address[1],
-                                  self.target.scheme, self.target.netloc))
+                        LOG.error('(WinRM): Negotiating NTLM with %s://%s failed' % (self.target.scheme, self.target.netloc))
                         self.send_not_found()
                         return
                     else:
-                        LOG.error('WinRM(%s): Negotiating NTLM with %s://%s failed. Skipping to next target' % (
-                            self.server.server_address[1], self.target.scheme, self.target.netloc))
+                        LOG.error('(WinRM): Negotiating NTLM with %s://%s failed. Skipping to next target' % (self.target.scheme, self.target.netloc))
 
                         self.target = self.server.config.target.getTarget(identity=self.authUser)
 
                         if self.target is None:
-                            LOG.info( "WinRM(%s): Connection from %s@%s controlled, but there are no more targets left!" %
-                                (self.server.server_address[1], self.authUser, self.client_address[0]))
+                            LOG.info("(WinRM): Connection from %s@%s controlled, but there are no more targets left!" % (self.authUser, self.client_address[0]))
                             self.send_not_found()
                             return
 
-                        LOG.info("WinRM(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
-                            self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+                        LOG.info("(WinRM): Connection from %s@%s controlled, attacking target %s://%s" % (self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
 
                         self.do_REDIRECT()
 
@@ -449,13 +441,11 @@ class WinRMRelayServer(Thread):
                         # No anonymous login, go to next host and avoid triggering a popup
                         self.target = self.server.config.target.getTarget(identity=self.authUser)
                         if self.target is None:
-                            LOG.info("WinRM(%s): Connection from %s@%s controlled, but there are no more targets left!" %
-                                (self.server.server_address[1], self.authUser, self.client_address[0]))
+                            LOG.info("(WinRM): Connection from %s@%s controlled, but there are no more targets left!" % (self.authUser, self.client_address[0]))
                             self.send_not_found()
                             return
 
-                        LOG.info("WinRM(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
-                            self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+                        LOG.info("(WinRM): Connection from %s@%s controlled, attacking target %s://%s" % (self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
 
                         self.do_REDIRECT()
                     else:
@@ -463,8 +453,7 @@ class WinRMRelayServer(Thread):
                         self.do_AUTHHEAD(b'Negotiate', proxy=proxy)
                 else:
                     # Relay worked, do whatever we want here...
-                    LOG.info("WinRM(%s): Authenticating against %s://%s as %s SUCCEED" % (self.server.server_address[1],
-                        self.target.scheme, self.target.netloc, self.authUser))
+                    LOG.info("(WinRM): Authenticating against %s://%s as %s SUCCEED" % (self.target.scheme, self.target.netloc, self.authUser))
 
                     ntlm_hash_data = outputToJohnFormat(self.challengeMessage['challenge'],
                                                         authenticateMessage['user_name'],
@@ -493,8 +482,7 @@ class WinRMRelayServer(Thread):
                         self.target = self.server.config.target.getTarget(identity=self.authUser)
 
                         if self.target is None:
-                            LOG.info("WinRM(%s): Connection from %s@%s controlled, but there are no more targets left!" % (
-                                self.server.server_address[1], self.authUser, self.client_address[0]))
+                            LOG.info("(WinRM): Connection from %s@%s controlled, but there are no more targets left!" % (self.authUser, self.client_address[0]))
 
                             # Return Multi-Status status code to WebDAV servers
                             if self.command == "PROPFIND":
@@ -511,8 +499,7 @@ class WinRMRelayServer(Thread):
                             return
 
                         # We have the next target, let's keep relaying...
-                        LOG.info("WinRM(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
-                            self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+                        LOG.info("(WinRM): Connection from %s@%s controlled, attacking target %s://%s" % (self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
                         self.do_REDIRECT()
 
         def do_attack(self):
@@ -530,7 +517,7 @@ class WinRMRelayServer(Thread):
                                                                                self.authUser, self.target, self.client)
                 clientThread.start()
             else:
-                LOG.error('WinRM(%s): No attack configured for %s' % (self.server.server_address[1], self.target.scheme.upper()))
+                LOG.error('(WinRM): No attack configured for %s' % self.target.scheme.upper())
 
     def __init__(self, config):
         Thread.__init__(self)

--- a/impacket/examples/ntlmrelayx/servers/winrmrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/winrmrelayserver.py
@@ -527,7 +527,7 @@ class WinRMRelayServer(Thread):
             if self.target.scheme.upper() in self.server.config.attacks:
                 # We have an attack.. go for it
                 clientThread = self.server.config.attacks[self.target.scheme.upper()](self.server.config, self.client.session,
-                                                                               self.authUser)
+                                                                               self.authUser, self.target, self.client)
                 clientThread.start()
             else:
                 LOG.error('WinRM(%s): No attack configured for %s' % (self.server.server_address[1], self.target.scheme.upper()))

--- a/impacket/examples/ntlmrelayx/servers/winrmrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/winrmrelayserver.py
@@ -30,6 +30,7 @@ from impacket.smbserver import outputToJohnFormat, writeJohnOutputToFile
 from impacket.nt_errors import STATUS_ACCESS_DENIED, STATUS_SUCCESS
 from impacket.examples.ntlmrelayx.utils.targetsutils import TargetsProcessor
 from impacket.examples.ntlmrelayx.servers.socksserver import activeConnections
+from impacket.examples.utils import get_address
 
 class WinRMRelayServer(Thread):
 
@@ -37,8 +38,7 @@ class WinRMRelayServer(Thread):
         def __init__(self, server_address, RequestHandlerClass, config):
             self.config = config
             self.daemon_threads = True
-            if self.config.ipv6:
-                self.address_family = socket.AF_INET6
+            self.address_family, server_address = get_address(server_address[0], server_address[1], self.config.ipv6)
             # Tracks the number of times authentication was prompted for WPAD per client
             self.wpad_counters = {}
             socketserver.TCPServer.allow_reuse_address = True

--- a/impacket/examples/ntlmrelayx/servers/winrmrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/winrmrelayserver.py
@@ -453,7 +453,8 @@ class WinRMRelayServer(Thread):
                         self.do_AUTHHEAD(b'Negotiate', proxy=proxy)
                 else:
                     # Relay worked, do whatever we want here...
-                    LOG.info("(WinRM): Authenticating against %s://%s as %s SUCCEED" % (self.target.scheme, self.target.netloc, self.authUser))
+                    self.client.setClientId()
+                    LOG.info("(WinRM): Authenticating connection from %s@%s against %s://%s SUCCEED [%s]" % (self.authUser, self.client_address[0], self.target.scheme, self.target.netloc, self.client.client_id))
 
                     ntlm_hash_data = outputToJohnFormat(self.challengeMessage['challenge'],
                                                         authenticateMessage['user_name'],

--- a/impacket/examples/ntlmrelayx/servers/winrmsrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/winrmsrelayserver.py
@@ -99,8 +99,8 @@ class WinRMSRelayServer(Thread):
             try:
                 http.server.SimpleHTTPRequestHandler.__init__(self,request, client_address, server)
             except Exception as e:
-                LOG.debug("Exception:", exc_info=True)
-                LOG.error(str(e))
+                LOG.debug("(WinRMS): Exception:", exc_info=True)
+                LOG.error("(WinRMS): %s" % str(e))
 
         def handle_one_request(self):
             try:
@@ -195,7 +195,7 @@ class WinRMSRelayServer(Thread):
                         _, blob = typeX.split('Negotiate')
                     token = base64.b64decode(blob.strip())
                 except Exception:
-                    LOG.debug("Exception:", exc_info=True)
+                    LOG.debug("(WinRMS): Exception:", exc_info=True)
                     self.do_AUTHHEAD(message = b'NTLM', proxy=proxy)
                 else:
                     messageType = struct.unpack('<L',token[len('NTLMSSP\x00'):len('NTLMSSP\x00')+4])[0]
@@ -333,7 +333,7 @@ class WinRMSRelayServer(Thread):
                 if self.challengeMessage is False:
                     return False
             else:
-                LOG.error('Protocol Client for %s not found!' % self.target.scheme.upper())
+                LOG.error('(WinRMS): Protocol Client for %s not found!' % self.target.scheme.upper())
                 return False
 
             self.do_AUTHHEAD(message = b'NTLM '+base64.b64encode(self.challengeMessage.getData()), proxy=proxy)
@@ -453,7 +453,7 @@ class WinRMSRelayServer(Thread):
                     target = '%s://%s@%s' % (self.target.scheme, self.authUser.replace("/", '\\'), self.target.netloc)
 
                 if not self.do_ntlm_auth(token, authenticateMessage):
-                    LOG.error("Authenticating against %s://%s as %s FAILED" % (self.target.scheme, self.target.netloc,
+                    LOG.error("(WinRMS): Authenticating against %s://%s as %s FAILED" % (self.target.scheme, self.target.netloc,
                                                                                self.authUser))
                     if self.server.config.disableMulti:
                         self.send_not_found()
@@ -491,7 +491,7 @@ class WinRMSRelayServer(Thread):
                                               self.server.config.outputFile)
 
                     if self.server.config.dumpHashes is True:
-                        LOG.info(ntlm_hash_data['hash_string'])
+                        LOG.info("(WinRMS): %s" % ntlm_hash_data['hash_string'])
 
                     self.do_attack()
 

--- a/impacket/examples/ntlmrelayx/servers/winrmsrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/winrmsrelayserver.py
@@ -477,7 +477,8 @@ class WinRMSRelayServer(Thread):
                         self.do_AUTHHEAD(b'Negotiate', proxy=proxy)
                 else:
                     # Relay worked, do whatever we want here...
-                    LOG.info("(WinRMS): Authenticating against %s://%s as %s SUCCEED" % (self.target.scheme, self.target.netloc, self.authUser))
+                    self.client.setClientId()
+                    LOG.info("(WinRMS): Authenticating connection from %s@%s against %s://%s SUCCEED [%s]" % (self.authUser, self.client_address[0], self.target.scheme, self.target.netloc, self.client.client_id))
 
                     ntlm_hash_data = outputToJohnFormat(self.challengeMessage['challenge'],
                                                         authenticateMessage['user_name'],

--- a/impacket/examples/ntlmrelayx/servers/winrmsrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/winrmsrelayserver.py
@@ -551,7 +551,7 @@ class WinRMSRelayServer(Thread):
             if self.target.scheme.upper()  in self.server.config.attacks:
                 # We have an attack.. go for it
                 clientThread = self.server.config.attacks[self.target.scheme.upper()](self.server.config, self.client.session,
-                                                                               self.authUser)
+                                                                               self.authUser, self.target, self.client)
                 clientThread.start()
             else:
                 LOG.error('WinRMS(%s): No attack configured for %s' % (self.server.server_address[1], self.target.scheme.upper()))

--- a/impacket/examples/ntlmrelayx/servers/winrmsrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/winrmsrelayserver.py
@@ -33,6 +33,7 @@ from impacket.smbserver import outputToJohnFormat, writeJohnOutputToFile
 from impacket.nt_errors import STATUS_ACCESS_DENIED, STATUS_SUCCESS
 from impacket.examples.ntlmrelayx.utils.targetsutils import TargetsProcessor
 from impacket.examples.ntlmrelayx.servers.socksserver import activeConnections
+from impacket.examples.utils import get_address
 
 class WinRMSRelayServer(Thread):
 
@@ -40,8 +41,7 @@ class WinRMSRelayServer(Thread):
         def __init__(self, server_address, RequestHandlerClass, config):
             self.config = config
             self.daemon_threads = True
-            if self.config.ipv6:
-                self.address_family = socket.AF_INET6
+            self.address_family, server_address = get_address(server_address[0], server_address[1], self.config.ipv6)
             self.wpad_counters = {}
             
             socketserver.TCPServer.allow_reuse_address = True

--- a/impacket/examples/ntlmrelayx/servers/winrmsrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/winrmsrelayserver.py
@@ -108,14 +108,14 @@ class WinRMSRelayServer(Thread):
             except KeyboardInterrupt:
                 raise
             except Exception as e:
-                LOG.debug("WinRMS(%s): Exception:" % self.server.server_address[1], exc_info=True)
+                LOG.debug("(WinRMS): Exception:", exc_info=True)
 
         def log_message(self, format, *args):
             return
 
         def send_error(self, code, message=None):
             if message.find('RPC_OUT') >= 0 or message.find('RPC_IN'):
-                LOG.info('WinRMS(%s): send_error path: %s' % (self.server.server_address[1], self.path.lower()))
+                LOG.info('(WinRMS): send_error path: %s' % self.path.lower())
                 return self.do_GET()
             return http.server.SimpleHTTPRequestHandler.send_error(self, code, message)
 
@@ -286,7 +286,7 @@ class WinRMSRelayServer(Thread):
                 content_length = int(self.headers.get('Content-Length', 0))
                 self.rfile.read(content_length)
             else:
-                LOG.info('WinRMS(%s): Client requested path: %s' % (self.server.server_address[1], self.path.lower()))
+                LOG.info('(WinRMS): Client requested path: %s' % self.path.lower())
                 self.send_not_found()
                 return
 
@@ -399,13 +399,11 @@ class WinRMSRelayServer(Thread):
 
                 self.target = self.server.config.target.getTarget(identity = self.authUser)
                 if self.target is None:
-                    LOG.info("WinRMS(%s): Connection from %s@%s controlled, but there are no more targets left!" %
-                        (self.server.server_address[1], self.authUser, self.client_address[0]))
+                    LOG.info("(WinRMS): Connection from %s@%s controlled, but there are no more targets left!" % (self.authUser, self.client_address[0]))
                     self.send_not_found()
                     return
 
-                LOG.info("WinRMS(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
-                    self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+                LOG.info("(WinRMS): Connection from %s@%s controlled, attacking target %s://%s" % (self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
 
                 self.relayToHost = True
                 self.do_REDIRECT()
@@ -415,35 +413,29 @@ class WinRMSRelayServer(Thread):
                 if self.server.config.disableMulti:
                     self.target = self.server.config.target.getTarget(multiRelay=False)
                     if self.target is None:
-                        LOG.info("WinRMS(%s): Connection from %s controlled, but there are no more targets left!" % (
-                            self.server.server_address[1], self.client_address[0]))
+                        LOG.info("(WinRMS): Connection from %s controlled, but there are no more targets left!" % self.client_address[0])
                         self.send_not_found()
                         return
 
-                    LOG.info("WinRMS(%s): Connection from %s controlled, attacking target %s://%s" % (
-                        self.server.server_address[1], self.client_address[0], self.target.scheme, self.target.netloc))
+                    LOG.info("(WinRMS): Connection from %s controlled, attacking target %s://%s" % (self.client_address[0], self.target.scheme, self.target.netloc))
 
                 if not self.do_ntlm_negotiate(token, proxy=proxy):
                     # Connection failed
                     if self.server.config.disableMulti:
-                        LOG.error('WinRMS(%s): Negotiating NTLM with %s://%s failed' % (self.server.server_address[1],
-                                  self.target.scheme, self.target.netloc))
+                        LOG.error('(WinRMS): Negotiating NTLM with %s://%s failed' % (self.target.scheme, self.target.netloc))
                         self.send_not_found()
                         return
                     else:
-                        LOG.error('WinRMS(%s): Negotiating NTLM with %s://%s failed. Skipping to next target' % (
-                            self.server.server_address[1], self.target.scheme, self.target.netloc))
+                        LOG.error('(WinRMS): Negotiating NTLM with %s://%s failed. Skipping to next target' % (self.target.scheme, self.target.netloc))
 
                         self.target = self.server.config.target.getTarget(identity=self.authUser)
 
                         if self.target is None:
-                            LOG.info( "WinRMS(%s): Connection from %s@%s controlled, but there are no more targets left!" %
-                                (self.server.server_address[1], self.authUser, self.client_address[0]))
+                            LOG.info("(WinRMS): Connection from %s@%s controlled, but there are no more targets left!" % (self.authUser, self.client_address[0]))
                             self.send_not_found()
                             return
 
-                        LOG.info("WinRMS(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
-                            self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+                        LOG.info("(WinRMS): Connection from %s@%s controlled, attacking target %s://%s" % (self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
 
                         self.do_REDIRECT()
 
@@ -473,13 +465,11 @@ class WinRMSRelayServer(Thread):
                         # No anonymous login, go to next host and avoid triggering a popup
                         self.target = self.server.config.target.getTarget(identity=self.authUser)
                         if self.target is None:
-                            LOG.info("WinRMS(%s): Connection from %s@%s controlled, but there are no more targets left!" %
-                                (self.server.server_address[1], self.authUser, self.client_address[0]))
+                            LOG.info("(WinRMS): Connection from %s@%s controlled, but there are no more targets left!" % (self.authUser, self.client_address[0]))
                             self.send_not_found()
                             return
 
-                        LOG.info("WinRMS(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
-                            self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+                        LOG.info("(WinRMS): Connection from %s@%s controlled, attacking target %s://%s" % (self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
 
                         self.do_REDIRECT()
                     else:
@@ -487,8 +477,7 @@ class WinRMSRelayServer(Thread):
                         self.do_AUTHHEAD(b'Negotiate', proxy=proxy)
                 else:
                     # Relay worked, do whatever we want here...
-                    LOG.info("WinRMS(%s): Authenticating against %s://%s as %s SUCCEED" % (self.server.server_address[1],
-                        self.target.scheme, self.target.netloc, self.authUser))
+                    LOG.info("(WinRMS): Authenticating against %s://%s as %s SUCCEED" % (self.target.scheme, self.target.netloc, self.authUser))
 
                     ntlm_hash_data = outputToJohnFormat(self.challengeMessage['challenge'],
                                                         authenticateMessage['user_name'],
@@ -517,8 +506,7 @@ class WinRMSRelayServer(Thread):
                         self.target = self.server.config.target.getTarget(identity=self.authUser)
 
                         if self.target is None:
-                            LOG.info("WinRMS(%s): Connection from %s@%s controlled, but there are no more targets left!" % (
-                                self.server.server_address[1], self.authUser, self.client_address[0]))
+                            LOG.info("(WinRMS): Connection from %s@%s controlled, but there are no more targets left!" % (self.authUser, self.client_address[0]))
 
                             # Return Multi-Status status code to WebDAV servers
                             if self.command == "PROPFIND":
@@ -535,8 +523,7 @@ class WinRMSRelayServer(Thread):
                             return
 
                         # We have the next target, let's keep relaying...
-                        LOG.info("WinRMS(%s): Connection from %s@%s controlled, attacking target %s://%s" % (self.server.server_address[1],
-                            self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
+                        LOG.info("(WinRMS): Connection from %s@%s controlled, attacking target %s://%s" % (self.authUser, self.client_address[0], self.target.scheme, self.target.netloc))
                         self.do_REDIRECT()
 
         def do_attack(self):
@@ -554,7 +541,7 @@ class WinRMSRelayServer(Thread):
                                                                                self.authUser, self.target, self.client)
                 clientThread.start()
             else:
-                LOG.error('WinRMS(%s): No attack configured for %s' % (self.server.server_address[1], self.target.scheme.upper()))
+                LOG.error('(WinRMS): No attack configured for %s' % self.target.scheme.upper())
 
     def __init__(self, config):
         Thread.__init__(self)


### PR DESCRIPTION
This PR fixes https://github.com/fortra/impacket/issues/2049

`winrmattack` was implemented in the context of https://github.com/fortra/impacket/pull/1987 - while https://github.com/fortra/impacket/pull/2032 was being worked on -
#2032 was wrongly synced when merging into master leaving the attack constructor signature with missing parameters