### PR TITLE
Fix socket reuse in ntlmrelayx

### DIFF
--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -44,6 +44,7 @@ class HTTPRelayServer(Thread):
             self.address_family, server_address = get_address(server_address[0], server_address[1], self.config.ipv6)
             # Tracks the number of times authentication was prompted for WPAD per client
             self.wpad_counters = {}
+            socketserver.TCPServer.allow_reuse_address = True
             socketserver.TCPServer.__init__(self, server_address, RequestHandlerClass)
 
     class HTTPHandler(http.server.SimpleHTTPRequestHandler):

--- a/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/rawrelayserver.py
@@ -45,6 +45,7 @@ class RAWRelayServer(Thread):
             self.config = config
             self.daemon_threads = True
             self.address_family, server_address = get_address(server_address[0], server_address[1], self.config.ipv6)
+            socketserver.TCPServer.allow_reuse_address = True
             socketserver.TCPServer.__init__(self, server_address, RequestHandlerClass)
 
     class RAWHandler(socketserver.BaseRequestHandler):

--- a/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/wcfrelayserver.py
@@ -53,6 +53,7 @@ class WCFRelayServer(Thread):
             self.daemon_threads = True
             self.address_family, server_address = get_address(server_address[0], server_address[1], self.config.ipv6)
             self.wpad_counters = {}
+            socketserver.TCPServer.allow_reuse_address = True
             socketserver.TCPServer.__init__(self, server_address, request_handler_class)
 
     class WCFHandler(socketserver.BaseRequestHandler):


### PR DESCRIPTION
Some of the servers in `ntlmrelayx` are not properly setting the `REUSE_SOCKET` option, which can be annoying when trying to relay. Indeed, if a connection has been made, some time is required before the port can be bind again when relaunching `ntlmrelayx`.
This PR fixes this issue.
