### PR TITLE
dcerpc: TCPTransport.recv: break on empty recv to avoid infinite loop

### DIFF
--- a/impacket/dcerpc/v5/transport.py
+++ b/impacket/dcerpc/v5/transport.py
@@ -386,7 +386,7 @@ class TCPTransport(DCERPCTransport):
                 if chunk != b'':
                     buffer += chunk
                 else:
-                    break
+                    raise DCERPCException("Connection closed by remote host")
         else:
             buffer = self.__socket.recv(8192)
         return buffer


### PR DESCRIPTION
When the peer closes the connection, socket.recv() returns b''.
The previous loop made no progress and could spin forever.
Break on empty chunk to avoid the infinite loop.