### PR TITLE
Fix encoding for non-ascii char in kerberos authentication

### DIFF
--- a/impacket/krb5/asn1.py
+++ b/impacket/krb5/asn1.py
@@ -125,7 +125,7 @@ class KerberosString(char.GeneralString):
     # TODO marc: I'm not sure how to express this constraint in the API.
     # For now, we will be liberal in what we accept.
     # subtypeSpec = constraint.PermittedAlphabetConstraint(char.IA5String())
-    pass
+    encoding = 'utf-8'
 
 class Realm(KerberosString):
     pass

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -233,7 +233,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
                 except PyAsn1Error:
                     salt = ''
 
-                encryptionTypesData[etype2['etype']] = b(salt)
+                encryptionTypesData[etype2['etype']] = salt.encode('utf-8')
         elif method['padata-type'] == constants.PreAuthenticationDataTypes.PA_ETYPE_INFO.value:
             etypes = decoder.decode(method['padata-value'], asn1Spec = ETYPE_INFO())[0]
             for etype in etypes:
@@ -245,7 +245,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
                 except PyAsn1Error:
                     salt = ''
 
-                encryptionTypesData[etype['etype']] = b(salt)
+                encryptionTypesData[etype['etype']] = salt.encode('utf-8')
 
     enctype = supportedCiphers[0]
 


### PR DESCRIPTION
With the hack.lu CTF this year and therefore a swedish AD environment it was reported that Kerberos authentication does not work with special chars (e.g. `öäü`) that are present in some localized environments: https://github.com/Pennyw0rth/NetExec/issues/963

The problem is that kerberos uses `utf-8` encoding for Kerberos Strings. However, as of now both minikerberos as well as impacket use `latin1` as its encoding, resulting in failed authentication with users that contain special chars.
See:
- [[MS-KILE]](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/) section 3.1.5.7
- openJDK: https://bugs.openjdk.org/browse/JDK-8200152

Before and after:
<img width="843" height="301" alt="image" src="https://github.com/user-attachments/assets/dfe77b6a-4590-4833-82d6-3d9c1e25f730" />

Fixed and used in NetExec:
<img width="1572" height="83" alt="image" src="https://github.com/user-attachments/assets/74fab44e-01bf-492d-b41b-4fbc86f1c5f2" />
