### PR TITLE
Fix negative timestamps when using secretsdump local on windows

### DIFF
--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -1458,8 +1458,13 @@ class SAMHashes(OfflineRegistry):
         # NT Time is in 100-nanosecond intervals since 1601-01-01 (UTC)
         # The difference between 1601 and 1970 is 11644473600 seconds
         nt_time = int.from_bytes(nt_time, byteorder='little')  # Convert byte string to integer
-        unix_time = (nt_time - 116444736000000000) // 10000000  # Convert to Unix time (seconds)
-        return datetime.utcfromtimestamp(unix_time)
+
+        # datetime on windows can't handle negative timestamps (i.e. before 1970), therefore we must return the 0 time directly
+        if nt_time == 0:
+            return datetime(1601, 1, 1, 0, 0, 0)
+        else:
+            unix_time = (nt_time - 116444736000000000) // 10000000  # Convert to Unix time (seconds)
+            return datetime.utcfromtimestamp(unix_time)
 
     def MD5(self, data):
         md5 = hashlib.new('md5')


### PR DESCRIPTION
When using secrestdump SAM dump on Windows (e.g. `--sam secdump` or the `backup_operator` module) secretsdump crashes. This is due to the negative timestamp that is passed into datetime which can't be handled on windows:

> \# On Windows localtime_s throws an OSError for negative values,
> \# thus we can't perform fold detection for values of time less
> \# than the max time fold. See comments in _datetimemodule's
> \# version of this method for more details.
> if t < max_fold_seconds and sys.platform.startswith("win"):
>     return result

This happens when the `userAccountF['LastIncorrectPasswordTimestamp']` is zero in nt time and is then converted to a negative unixTimestamp integer. This can easily be fixed by manually returning the 0 nt timestamp on when the input is 0.

Before:
<img width="2187" height="1069" alt="image" src="https://github.com/user-attachments/assets/29794f86-cd84-4d6f-a054-45229fb919cf" />
After:
<img width="1757" height="177" alt="image" src="https://github.com/user-attachments/assets/40355139-48f1-482a-a823-ab75b86a5637" />
