### PR TITLE
Add support for `TDS_SSVARIANT` structure in tds.py

### DIFF
--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -35,6 +35,7 @@ from __future__ import print_function
 
 # Native SSL support for in memory handshake
 import ssl
+
 # Used to compute the CBT TOKEN
 from hashlib import md5
 import struct
@@ -44,430 +45,463 @@ import random
 import binascii
 import math
 import datetime
-import string
+from decimal import Decimal, getcontext
 from uuid import uuid4
 
 from impacket import ntlm, uuid, LOG
 from impacket.structure import Structure
 from impacket.mssql.version import MSSQL_VERSION
 
+
 # We need to have a fake Logger to be compatible with the way Impact
 # prints information. Outside Impact it's just a print. Inside
 # we will receive the Impact logger instance to print row information
 # The rest it processed through the standard impacket logging mech.
 class DummyPrint:
-    def logMessage(self,message):
-        if message == '\n':
+    def logMessage(self, message):
+        if message == "\n":
             print(message)
-        elif message == '\r':
+        elif message == "\r":
             print()
         else:
-            print(message, end=' ')
+            print(message, end=" ")
+
 
 # MC-SQLR Constants and Structures
-SQLR_PORT           = 1434
-SQLR_CLNT_BCAST_EX  = 0x02
-SQLR_CLNT_UCAST_EX  = 0x03
-SQLR_CLNT_UCAST_INST= 0x04
-SQLR_CLNT_UCAST_DAC = 0x0f
+SQLR_PORT = 1434
+SQLR_CLNT_BCAST_EX = 0x02
+SQLR_CLNT_UCAST_EX = 0x03
+SQLR_CLNT_UCAST_INST = 0x04
+SQLR_CLNT_UCAST_DAC = 0x0F
 
 
 class SQLR(Structure):
-    commonHdr = (
-        ('OpCode','B'),
-    )
+    commonHdr = (("OpCode", "B"),)
+
 
 class SQLR_UCAST_INST(SQLR):
-    structure = (
-        ('Instance',':')
-    )
-    def __init__(self, data = None):
-        SQLR.__init__(self,data)
+    structure = ("Instance", ":")
+
+    def __init__(self, data=None):
+        SQLR.__init__(self, data)
         if data is not None:
-            self['OpCode'] = SQLR_CLNT_UCAST_INST
+            self["OpCode"] = SQLR_CLNT_UCAST_INST
+
 
 class SQLR_UCAST_DAC(SQLR):
     structure = (
-        ('Protocol', 'B=1'),
-        ('Instance', ':'),
+        ("Protocol", "B=1"),
+        ("Instance", ":"),
     )
-    def __init__(self, data = None):
-        SQLR.__init__(self,data)
+
+    def __init__(self, data=None):
+        SQLR.__init__(self, data)
         if data is not None:
-            self['OpCode'] = SQLR_CLNT_UCAST_DAC
+            self["OpCode"] = SQLR_CLNT_UCAST_DAC
+
 
 class SQLR_Response(SQLR):
     structure = (
-        ('Size','<H'),
-        ('_Data','_-Data','self["Size"]'),
-        ('Data',':'),
+        ("Size", "<H"),
+        ("_Data", "_-Data", 'self["Size"]'),
+        ("Data", ":"),
     )
+
 
 class SQLErrorException(Exception):
     pass
 
+
 # TDS Constants and Structures
 
 # TYPE constants
-TDS_SQL_BATCH       = 1
-TDS_PRE_TDS_LOGIN   = 2
-TDS_RPC             = 3
-TDS_TABULAR         = 4
-TDS_ATTENTION       = 6
-TDS_BULK_LOAD_DATA  = 7
-TDS_TRANSACTION     = 14
-TDS_LOGIN7          = 16
-TDS_SSPI            = 17
-TDS_PRE_LOGIN       = 18
+TDS_SQL_BATCH = 1
+TDS_PRE_TDS_LOGIN = 2
+TDS_RPC = 3
+TDS_TABULAR = 4
+TDS_ATTENTION = 6
+TDS_BULK_LOAD_DATA = 7
+TDS_TRANSACTION = 14
+TDS_LOGIN7 = 16
+TDS_SSPI = 17
+TDS_PRE_LOGIN = 18
 
 # Status constants
-TDS_STATUS_NORMAL            = 0
-TDS_STATUS_EOM               = 1
-TDS_STATUS_RESET_CONNECTION  = 8
-TDS_STATUS_RESET_SKIPTRANS   = 16
+TDS_STATUS_NORMAL = 0
+TDS_STATUS_EOM = 1
+TDS_STATUS_RESET_CONNECTION = 8
+TDS_STATUS_RESET_SKIPTRANS = 16
 
 # Encryption
-TDS_ENCRYPT_OFF              = 0
-TDS_ENCRYPT_ON               = 1
-TDS_ENCRYPT_NOT_SUP          = 2
-TDS_ENCRYPT_REQ              = 3
+TDS_ENCRYPT_OFF = 0
+TDS_ENCRYPT_ON = 1
+TDS_ENCRYPT_NOT_SUP = 2
+TDS_ENCRYPT_REQ = 3
 
 # Option 2 Flags
-TDS_INTEGRATED_SECURITY_ON   = 0x80
-TDS_INIT_LANG_FATAL          = 0x01
-TDS_ODBC_ON                  = 0x02
+TDS_INTEGRATED_SECURITY_ON = 0x80
+TDS_INIT_LANG_FATAL = 0x01
+TDS_ODBC_ON = 0x02
 
 # Token Types
-TDS_ALTMETADATA_TOKEN        = 0x88
-TDS_ALTROW_TOKEN             = 0xD3
-TDS_COLMETADATA_TOKEN        = 0x81
-TDS_COLINFO_TOKEN            = 0xA5
-TDS_DONE_TOKEN               = 0xFD
-TDS_DONEPROC_TOKEN           = 0xFE
-TDS_DONEINPROC_TOKEN         = 0xFF
-TDS_ENVCHANGE_TOKEN          = 0xE3
-TDS_ERROR_TOKEN              = 0xAA
-TDS_INFO_TOKEN               = 0xAB
-TDS_LOGINACK_TOKEN           = 0xAD
-TDS_NBCROW_TOKEN             = 0xD2
-TDS_OFFSET_TOKEN             = 0x78
-TDS_ORDER_TOKEN              = 0xA9
-TDS_RETURNSTATUS_TOKEN       = 0x79
-TDS_RETURNVALUE_TOKEN        = 0xAC
-TDS_ROW_TOKEN                = 0xD1
-TDS_SSPI_TOKEN               = 0xED
-TDS_TABNAME_TOKEN            = 0xA4
+TDS_ALTMETADATA_TOKEN = 0x88
+TDS_ALTROW_TOKEN = 0xD3
+TDS_COLMETADATA_TOKEN = 0x81
+TDS_COLINFO_TOKEN = 0xA5
+TDS_DONE_TOKEN = 0xFD
+TDS_DONEPROC_TOKEN = 0xFE
+TDS_DONEINPROC_TOKEN = 0xFF
+TDS_ENVCHANGE_TOKEN = 0xE3
+TDS_ERROR_TOKEN = 0xAA
+TDS_INFO_TOKEN = 0xAB
+TDS_LOGINACK_TOKEN = 0xAD
+TDS_NBCROW_TOKEN = 0xD2
+TDS_OFFSET_TOKEN = 0x78
+TDS_ORDER_TOKEN = 0xA9
+TDS_RETURNSTATUS_TOKEN = 0x79
+TDS_RETURNVALUE_TOKEN = 0xAC
+TDS_ROW_TOKEN = 0xD1
+TDS_SSPI_TOKEN = 0xED
+TDS_TABNAME_TOKEN = 0xA4
 
 # ENVCHANGE Types
-TDS_ENVCHANGE_DATABASE       = 1
-TDS_ENVCHANGE_LANGUAGE       = 2
-TDS_ENVCHANGE_CHARSET        = 3
-TDS_ENVCHANGE_PACKETSIZE     = 4
-TDS_ENVCHANGE_UNICODE        = 5
-TDS_ENVCHANGE_UNICODE_DS     = 6
-TDS_ENVCHANGE_COLLATION      = 7
-TDS_ENVCHANGE_TRANS_START    = 8
-TDS_ENVCHANGE_TRANS_COMMIT   = 9
-TDS_ENVCHANGE_ROLLBACK       = 10
-TDS_ENVCHANGE_DTC            = 11
+TDS_ENVCHANGE_DATABASE = 1
+TDS_ENVCHANGE_LANGUAGE = 2
+TDS_ENVCHANGE_CHARSET = 3
+TDS_ENVCHANGE_PACKETSIZE = 4
+TDS_ENVCHANGE_UNICODE = 5
+TDS_ENVCHANGE_UNICODE_DS = 6
+TDS_ENVCHANGE_COLLATION = 7
+TDS_ENVCHANGE_TRANS_START = 8
+TDS_ENVCHANGE_TRANS_COMMIT = 9
+TDS_ENVCHANGE_ROLLBACK = 10
+TDS_ENVCHANGE_DTC = 11
 
 # Column types
 # FIXED-LEN Data Types
-TDS_NULL_TYPE                = 0x1F
-TDS_INT1TYPE                 = 0x30
-TDS_BITTYPE                  = 0x32
-TDS_INT2TYPE                 = 0x34
-TDS_INT4TYPE                 = 0x38
-TDS_DATETIM4TYPE             = 0x3A
-TDS_FLT4TYPE                 = 0x3B
-TDS_MONEYTYPE                = 0x3C
-TDS_DATETIMETYPE             = 0x3D
-TDS_FLT8TYPE                 = 0x3E
-TDS_MONEY4TYPE               = 0x7A
-TDS_INT8TYPE                 = 0x7F
+TDS_NULL_TYPE = 0x1F
+TDS_INT1TYPE = 0x30
+TDS_BITTYPE = 0x32
+TDS_INT2TYPE = 0x34
+TDS_INT4TYPE = 0x38
+TDS_DATETIM4TYPE = 0x3A
+TDS_FLT4TYPE = 0x3B
+TDS_MONEYTYPE = 0x3C
+TDS_DATETIMETYPE = 0x3D
+TDS_FLT8TYPE = 0x3E
+TDS_MONEY4TYPE = 0x7A
+TDS_INT8TYPE = 0x7F
 
 # VARIABLE-Len Data Types
-TDS_GUIDTYPE                 = 0x24
-TDS_INTNTYPE                 = 0x26
-TDS_DECIMALTYPE              = 0x37
-TDS_NUMERICTYPE              = 0x3F
-TDS_BITNTYPE                 = 0x68
-TDS_DECIMALNTYPE             = 0x6A
-TDS_NUMERICNTYPE             = 0x6C
-TDS_FLTNTYPE                 = 0x6D
-TDS_MONEYNTYPE               = 0x6E
-TDS_DATETIMNTYPE             = 0x6F
-TDS_DATENTYPE                = 0x28
-TDS_TIMENTYPE                = 0x29
-TDS_DATETIME2NTYPE           = 0x2A
-TDS_DATETIMEOFFSETNTYPE      = 0x2B
-TDS_CHARTYPE                 = 0x2F
-TDS_VARCHARTYPE              = 0x27
-TDS_BINARYTYPE               = 0x2D
-TDS_VARBINARYTYPE            = 0x25
-TDS_BIGVARBINTYPE            = 0xA5
-TDS_BIGVARCHRTYPE            = 0xA7
-TDS_BIGBINARYTYPE            = 0xAD
-TDS_BIGCHARTYPE              = 0xAF
-TDS_NVARCHARTYPE             = 0xE7
-TDS_NCHARTYPE                = 0xEF
-TDS_XMLTYPE                  = 0xF1
-TDS_UDTTYPE                  = 0xF0
-TDS_TEXTTYPE                 = 0x23
-TDS_IMAGETYPE                = 0x22
-TDS_NTEXTTYPE                = 0x63
-TDS_SSVARIANTTYPE            = 0x62
+TDS_GUIDTYPE = 0x24
+TDS_INTNTYPE = 0x26
+TDS_DECIMALTYPE = 0x37
+TDS_NUMERICTYPE = 0x3F
+TDS_BITNTYPE = 0x68
+TDS_DECIMALNTYPE = 0x6A
+TDS_NUMERICNTYPE = 0x6C
+TDS_FLTNTYPE = 0x6D
+TDS_MONEYNTYPE = 0x6E
+TDS_DATETIMNTYPE = 0x6F
+TDS_DATENTYPE = 0x28
+TDS_TIMENTYPE = 0x29
+TDS_DATETIME2NTYPE = 0x2A
+TDS_DATETIMEOFFSETNTYPE = 0x2B
+TDS_CHARTYPE = 0x2F
+TDS_VARCHARTYPE = 0x27
+TDS_BINARYTYPE = 0x2D
+TDS_VARBINARYTYPE = 0x25
+TDS_BIGVARBINTYPE = 0xA5
+TDS_BIGVARCHRTYPE = 0xA7
+TDS_BIGBINARYTYPE = 0xAD
+TDS_BIGCHARTYPE = 0xAF
+TDS_NVARCHARTYPE = 0xE7
+TDS_NCHARTYPE = 0xEF
+TDS_XMLTYPE = 0xF1
+TDS_UDTTYPE = 0xF0
+TDS_TEXTTYPE = 0x23
+TDS_IMAGETYPE = 0x22
+TDS_NTEXTTYPE = 0x63
+TDS_SSVARIANTTYPE = 0x62
+
 
 class TDSPacket(Structure):
     structure = (
-        ('Type','<B'),
-        ('Status','<B=1'),
-        ('Length','>H=8+len(Data)'),
-        ('SPID','>H=0'),
-        ('PacketID','<B=0'),
-        ('Window','<B=0'),
-        ('Data',':'),
+        ("Type", "<B"),
+        ("Status", "<B=1"),
+        ("Length", ">H=8+len(Data)"),
+        ("SPID", ">H=0"),
+        ("PacketID", "<B=0"),
+        ("Window", "<B=0"),
+        ("Data", ":"),
     )
+
 
 class TDS_PRELOGIN(Structure):
     structure = (
-        ('VersionToken','>B=0'),
-        ('VersionOffset','>H'),
-        ('VersionLength','>H=len(self["Version"])'),
-        ('EncryptionToken','>B=0x1'),
-        ('EncryptionOffset','>H'),
-        ('EncryptionLength','>H=1'),
-        ('InstanceToken','>B=2'),
-        ('InstanceOffset','>H'),
-        ('InstanceLength','>H=len(self["Instance"])'),
-        ('ThreadIDToken','>B=3'),
-        ('ThreadIDOffset','>H'),
-        ('ThreadIDLength','>H=4'),
-        ('EndToken','>B=0xff'),
-        ('_Version','_-Version','self["VersionLength"]'),
-        ('Version',':'),
-        ('Encryption','B'),
-        ('_Instance','_-Instance','self["InstanceLength"]-1'),
-        ('Instance',':'),
-        ('ThreadID',':'),
+        ("VersionToken", ">B=0"),
+        ("VersionOffset", ">H"),
+        ("VersionLength", '>H=len(self["Version"])'),
+        ("EncryptionToken", ">B=0x1"),
+        ("EncryptionOffset", ">H"),
+        ("EncryptionLength", ">H=1"),
+        ("InstanceToken", ">B=2"),
+        ("InstanceOffset", ">H"),
+        ("InstanceLength", '>H=len(self["Instance"])'),
+        ("ThreadIDToken", ">B=3"),
+        ("ThreadIDOffset", ">H"),
+        ("ThreadIDLength", ">H=4"),
+        ("EndToken", ">B=0xff"),
+        ("_Version", "_-Version", 'self["VersionLength"]'),
+        ("Version", ":"),
+        ("Encryption", "B"),
+        ("_Instance", "_-Instance", 'self["InstanceLength"]-1'),
+        ("Instance", ":"),
+        ("ThreadID", ":"),
     )
 
     def getData(self):
-        self['VersionOffset']=21
-        self['EncryptionOffset']=self['VersionOffset'] + len(self['Version'])
-        self['InstanceOffset']=self['EncryptionOffset'] + 1
-        self['ThreadIDOffset']=self['InstanceOffset'] + len(self['Instance'])
+        self["VersionOffset"] = 21
+        self["EncryptionOffset"] = self["VersionOffset"] + len(self["Version"])
+        self["InstanceOffset"] = self["EncryptionOffset"] + 1
+        self["ThreadIDOffset"] = self["InstanceOffset"] + len(self["Instance"])
         return Structure.getData(self)
+
 
 class TDS_LOGIN(Structure):
     structure = (
-        ('Length','<L=0'),
-        ('TDSVersion','>L=0x71'),
-        ('PacketSize','<L=32764'),
-        ('ClientProgVer','>L=7'),
-        ('ClientPID','<L=0'),
-        ('ConnectionID','<L=0'),
-        ('OptionFlags1','<B=0xe0'),
-        ('OptionFlags2','<B'),
-        ('TypeFlags','<B=0'),
-        ('OptionFlags3','<B=0'),
-        ('ClientTimeZone','<L=0'),
-        ('ClientLCID','<L=0'),
-        ('HostNameOffset','<H'),
-        ('HostNameLength','<H=len(self["HostName"])//2'),
-        ('UserNameOffset','<H=0'),
-        ('UserNameLength','<H=len(self["UserName"])//2'),
-        ('PasswordOffset','<H=0'),
-        ('PasswordLength','<H=len(self["Password"])//2'),
-        ('AppNameOffset','<H'),
-        ('AppNameLength','<H=len(self["AppName"])//2'),
-        ('ServerNameOffset','<H'),
-        ('ServerNameLength','<H=len(self["ServerName"])//2'),
-        ('UnusedOffset','<H=0'),
-        ('UnusedLength','<H=0'),
-        ('CltIntNameOffset','<H'),
-        ('CltIntNameLength','<H=len(self["CltIntName"])//2'),
-        ('LanguageOffset','<H=0'),
-        ('LanguageLength','<H=0'),
-        ('DatabaseOffset','<H=0'),
-        ('DatabaseLength','<H=len(self["Database"])//2'),
-        ('ClientID','6s=b"\x01\x02\x03\x04\x05\x06"'),
-        ('SSPIOffset','<H'),
-        ('SSPILength','<H=len(self["SSPI"])'),
-        ('AtchDBFileOffset','<H'),
-        ('AtchDBFileLength','<H=len(self["AtchDBFile"])//2'),
-        ('HostName',':'),
-        ('UserName',':'),
-        ('Password',':'),
-        ('AppName',':'),
-        ('ServerName',':'),
-        ('CltIntName',':'),
-        ('Database',':'),
-        ('SSPI',':'),
-        ('AtchDBFile',':'),
+        ("Length", "<L=0"),
+        ("TDSVersion", ">L=0x71"),
+        ("PacketSize", "<L=32764"),
+        ("ClientProgVer", ">L=7"),
+        ("ClientPID", "<L=0"),
+        ("ConnectionID", "<L=0"),
+        ("OptionFlags1", "<B=0xe0"),
+        ("OptionFlags2", "<B"),
+        ("TypeFlags", "<B=0"),
+        ("OptionFlags3", "<B=0"),
+        ("ClientTimeZone", "<L=0"),
+        ("ClientLCID", "<L=0"),
+        ("HostNameOffset", "<H"),
+        ("HostNameLength", '<H=len(self["HostName"])//2'),
+        ("UserNameOffset", "<H=0"),
+        ("UserNameLength", '<H=len(self["UserName"])//2'),
+        ("PasswordOffset", "<H=0"),
+        ("PasswordLength", '<H=len(self["Password"])//2'),
+        ("AppNameOffset", "<H"),
+        ("AppNameLength", '<H=len(self["AppName"])//2'),
+        ("ServerNameOffset", "<H"),
+        ("ServerNameLength", '<H=len(self["ServerName"])//2'),
+        ("UnusedOffset", "<H=0"),
+        ("UnusedLength", "<H=0"),
+        ("CltIntNameOffset", "<H"),
+        ("CltIntNameLength", '<H=len(self["CltIntName"])//2'),
+        ("LanguageOffset", "<H=0"),
+        ("LanguageLength", "<H=0"),
+        ("DatabaseOffset", "<H=0"),
+        ("DatabaseLength", '<H=len(self["Database"])//2'),
+        ("ClientID", '6s=b"\x01\x02\x03\x04\x05\x06"'),
+        ("SSPIOffset", "<H"),
+        ("SSPILength", '<H=len(self["SSPI"])'),
+        ("AtchDBFileOffset", "<H"),
+        ("AtchDBFileLength", '<H=len(self["AtchDBFile"])//2'),
+        ("HostName", ":"),
+        ("UserName", ":"),
+        ("Password", ":"),
+        ("AppName", ":"),
+        ("ServerName", ":"),
+        ("CltIntName", ":"),
+        ("Database", ":"),
+        ("SSPI", ":"),
+        ("AtchDBFile", ":"),
     )
-    def __init__(self,data=None):
-        Structure.__init__(self,data)
+
+    def __init__(self, data=None):
+        Structure.__init__(self, data)
         if data is None:
-            self['UserName'] = ''
-            self['Password'] = ''
-            self['Database'] = ''
-            self['AtchDBFile'] = ''
+            self["UserName"] = ""
+            self["Password"] = ""
+            self["Database"] = ""
+            self["AtchDBFile"] = ""
 
     def fromString(self, data):
         Structure.fromString(self, data)
-        if self['HostNameLength'] > 0:
-            self['HostName'] = data[self['HostNameOffset']:][:self['HostNameLength']*2]
+        if self["HostNameLength"] > 0:
+            self["HostName"] = data[self["HostNameOffset"] :][
+                : self["HostNameLength"] * 2
+            ]
 
-        if self['UserNameLength'] > 0:
-            self['UserName'] = data[self['UserNameOffset']:][:self['UserNameLength']*2]
+        if self["UserNameLength"] > 0:
+            self["UserName"] = data[self["UserNameOffset"] :][
+                : self["UserNameLength"] * 2
+            ]
 
-        if self['PasswordLength'] > 0:
-            self['Password'] = data[self['PasswordOffset']:][:self['PasswordLength']*2]
+        if self["PasswordLength"] > 0:
+            self["Password"] = data[self["PasswordOffset"] :][
+                : self["PasswordLength"] * 2
+            ]
 
-        if self['AppNameLength'] > 0:
-            self['AppName'] = data[self['AppNameOffset']:][:self['AppNameLength']*2]
+        if self["AppNameLength"] > 0:
+            self["AppName"] = data[self["AppNameOffset"] :][: self["AppNameLength"] * 2]
 
-        if self['ServerNameLength'] > 0:
-            self['ServerName'] = data[self['ServerNameOffset']:][:self['ServerNameLength']*2]
+        if self["ServerNameLength"] > 0:
+            self["ServerName"] = data[self["ServerNameOffset"] :][
+                : self["ServerNameLength"] * 2
+            ]
 
-        if self['CltIntNameLength'] > 0:
-            self['CltIntName'] = data[self['CltIntNameOffset']:][:self['CltIntNameLength']*2]
+        if self["CltIntNameLength"] > 0:
+            self["CltIntName"] = data[self["CltIntNameOffset"] :][
+                : self["CltIntNameLength"] * 2
+            ]
 
-        if self['DatabaseLength'] > 0:
-            self['Database'] = data[self['DatabaseOffset']:][:self['DatabaseLength']*2]
+        if self["DatabaseLength"] > 0:
+            self["Database"] = data[self["DatabaseOffset"] :][
+                : self["DatabaseLength"] * 2
+            ]
 
-        if self['SSPILength'] > 0:
-            self['SSPI'] = data[self['SSPIOffset']:][:self['SSPILength']*2]
+        if self["SSPILength"] > 0:
+            self["SSPI"] = data[self["SSPIOffset"] :][: self["SSPILength"] * 2]
 
-        if self['AtchDBFileLength'] > 0:
-            self['AtchDBFile'] = data[self['AtchDBFileOffset']:][:self['AtchDBFileLength']*2]
+        if self["AtchDBFileLength"] > 0:
+            self["AtchDBFile"] = data[self["AtchDBFileOffset"] :][
+                : self["AtchDBFileLength"] * 2
+            ]
 
     def getData(self):
-        index = 36+50
-        self['HostNameOffset']= index
+        index = 36 + 50
+        self["HostNameOffset"] = index
 
-        index += len(self['HostName'])
+        index += len(self["HostName"])
 
-        if self['UserName'] != '':
-            self['UserNameOffset'] = index
+        if self["UserName"] != "":
+            self["UserNameOffset"] = index
         else:
-            self['UserNameOffset'] = 0
+            self["UserNameOffset"] = 0
 
-        index += len(self['UserName'])
+        index += len(self["UserName"])
 
-        if self['Password'] != '':
-            self['PasswordOffset'] = index
+        if self["Password"] != "":
+            self["PasswordOffset"] = index
         else:
-            self['PasswordOffset'] = 0
+            self["PasswordOffset"] = 0
 
-        index += len(self['Password'])
+        index += len(self["Password"])
 
-        self['AppNameOffset']= index
-        self['ServerNameOffset']=self['AppNameOffset'] + len(self['AppName'])
-        self['CltIntNameOffset']=self['ServerNameOffset'] + len(self['ServerName'])
-        self['LanguageOffset']=self['CltIntNameOffset'] + len(self['CltIntName'])
-        self['DatabaseOffset']=self['LanguageOffset']
-        self['SSPIOffset']=self['DatabaseOffset'] + len(self['Database'])
-        self['AtchDBFileOffset']=self['SSPIOffset'] + len(self['SSPI'])
+        self["AppNameOffset"] = index
+        self["ServerNameOffset"] = self["AppNameOffset"] + len(self["AppName"])
+        self["CltIntNameOffset"] = self["ServerNameOffset"] + len(self["ServerName"])
+        self["LanguageOffset"] = self["CltIntNameOffset"] + len(self["CltIntName"])
+        self["DatabaseOffset"] = self["LanguageOffset"]
+        self["SSPIOffset"] = self["DatabaseOffset"] + len(self["Database"])
+        self["AtchDBFileOffset"] = self["SSPIOffset"] + len(self["SSPI"])
         return Structure.getData(self)
+
 
 class TDS_LOGIN_ACK(Structure):
     structure = (
-        ('TokenType','<B'),
-        ('Length','<H'),
-        ('Interface','<B'),
-        ('TDSVersion','<L'),
-        ('ProgNameLen','<B'),
-        ('_ProgNameLen','_-ProgName','self["ProgNameLen"]*2'),
-        ('ProgName',':'),
-        ('MajorVer','<B'),
-        ('MinorVer','<B'),
-        ('BuildNumHi','<B'),
-        ('BuildNumLow','<B'),
+        ("TokenType", "<B"),
+        ("Length", "<H"),
+        ("Interface", "<B"),
+        ("TDSVersion", "<L"),
+        ("ProgNameLen", "<B"),
+        ("_ProgNameLen", "_-ProgName", 'self["ProgNameLen"]*2'),
+        ("ProgName", ":"),
+        ("MajorVer", "<B"),
+        ("MinorVer", "<B"),
+        ("BuildNumHi", "<B"),
+        ("BuildNumLow", "<B"),
     )
+
 
 class TDS_RETURNSTATUS(Structure):
     structure = (
-        ('TokenType','<B'),
-        ('Value','<L'),
+        ("TokenType", "<B"),
+        ("Value", "<L"),
     )
+
 
 class TDS_INFO_ERROR(Structure):
     structure = (
-        ('TokenType','<B'),
-        ('Length','<H'),
-        ('Number','<L'),
-        ('State','<B'),
-        ('Class','<B'),
-        ('MsgTextLen','<H'),
-        ('_MsgTextLen','_-MsgText','self["MsgTextLen"]*2'),
-        ('MsgText',':'),
-        ('ServerNameLen','<B'),
-        ('_ServerNameLen','_-ServerName','self["ServerNameLen"]*2'),
-        ('ServerName',':'),
-        ('ProcNameLen','<B'),
-        ('_ProcNameLen','_-ProcName','self["ProcNameLen"]*2'),
-        ('ProcName',':'),
-        ('LineNumber','<H'),
+        ("TokenType", "<B"),
+        ("Length", "<H"),
+        ("Number", "<L"),
+        ("State", "<B"),
+        ("Class", "<B"),
+        ("MsgTextLen", "<H"),
+        ("_MsgTextLen", "_-MsgText", 'self["MsgTextLen"]*2'),
+        ("MsgText", ":"),
+        ("ServerNameLen", "<B"),
+        ("_ServerNameLen", "_-ServerName", 'self["ServerNameLen"]*2'),
+        ("ServerName", ":"),
+        ("ProcNameLen", "<B"),
+        ("_ProcNameLen", "_-ProcName", 'self["ProcNameLen"]*2'),
+        ("ProcName", ":"),
+        ("LineNumber", "<H"),
     )
+
 
 class TDS_ENVCHANGE(Structure):
     structure = (
-        ('TokenType','<B'),
-        ('Length','<H=4+len(Data)'),
-        ('Type','<B'),
-        ('_Data','_-Data','self["Length"]-1'),
-        ('Data',':'),
+        ("TokenType", "<B"),
+        ("Length", "<H=4+len(Data)"),
+        ("Type", "<B"),
+        ("_Data", "_-Data", 'self["Length"]-1'),
+        ("Data", ":"),
     )
+
 
 class TDS_DONEINPROC(Structure):
     structure = (
-        ('TokenType','<B'),
-        ('Status','<H'),
-        ('CurCmd','<H'),
-        ('DoneRowCount','<L'),
+        ("TokenType", "<B"),
+        ("Status", "<H"),
+        ("CurCmd", "<H"),
+        ("DoneRowCount", "<L"),
     )
+
 
 class TDS_ORDER(Structure):
     structure = (
-        ('TokenType','<B'),
-        ('Length','<H'),
-        ('_Data','_-Data','self["Length"]'),
-        ('Data',':'),
+        ("TokenType", "<B"),
+        ("Length", "<H"),
+        ("_Data", "_-Data", 'self["Length"]'),
+        ("Data", ":"),
     )
 
 
 class TDS_ENVCHANGE_VARCHAR(Structure):
     structure = (
-        ('NewValueLen','<B=len(NewValue)'),
-        ('_NewValue','_-NewValue','self["NewValueLen"]*2'),
-        ('NewValue',':'),
-        ('OldValueLen','<B=len(OldValue)'),
-        ('_OldValue','_-OldValue','self["OldValueLen"]*2'),
-        ('OldValue',':'),
+        ("NewValueLen", "<B=len(NewValue)"),
+        ("_NewValue", "_-NewValue", 'self["NewValueLen"]*2'),
+        ("NewValue", ":"),
+        ("OldValueLen", "<B=len(OldValue)"),
+        ("_OldValue", "_-OldValue", 'self["OldValueLen"]*2'),
+        ("OldValue", ":"),
     )
+
 
 class TDS_ROW(Structure):
     structure = (
-        ('TokenType','<B'),
-        ('Data',':'),
+        ("TokenType", "<B"),
+        ("Data", ":"),
     )
+
 
 class TDS_DONE(Structure):
     structure = (
-        ('TokenType','<B'),
-        ('Status','<H'),
-        ('CurCmd','<H'),
-        ('DoneRowCount','<L'),
+        ("TokenType", "<B"),
+        ("Status", "<H"),
+        ("CurCmd", "<H"),
+        ("DoneRowCount", "<L"),
     )
+
 
 class TDS_COLMETADATA(Structure):
     structure = (
-        ('TokenType','<B'),
-        ('Count','<H'),
-        ('Data',':'),
+        ("TokenType", "<B"),
+        ("Count", "<H"),
+        ("Data", ":"),
     )
+
 
 class TDS_SSVARIANT(Structure):
     """
@@ -519,9 +553,10 @@ class TDS_SSVARIANT(Structure):
     Note: Data types cannot be NULL when inside a sql_variant. If the value is NULL,
     the sql_variant itself has to be NULL (TotalLength = 0).
     """
+
     structure = (
-        ('TotalLength','<L=0'),
-        ('Data',':'),
+        ("TotalLength", "<L=0"),
+        ("Data", ":"),
     )
 
     def __init__(self, data=None):
@@ -538,25 +573,25 @@ class TDS_SSVARIANT(Structure):
         Returns:
             Parsed value in its appropriate Python type, or 'NULL' if empty
         """
-        if self['TotalLength'] == 0:
-            return 'NULL'
+        if self["TotalLength"] == 0:
+            return "NULL"
 
-        data = self['Data']
+        data = self["Data"]
 
         # Read BaseType (1 byte)
-        self.baseType = struct.unpack('<B', data[:1])[0]
+        self.baseType = struct.unpack("<B", data[:1])[0]
         data = data[1:]
 
         # Read PropBytes (1 byte)
-        self.propBytes = struct.unpack('<B', data[:1])[0]
+        self.propBytes = struct.unpack("<B", data[:1])[0]
         data = data[1:]
 
         # Extract type-specific properties
-        self.properties = data[:self.propBytes]
-        data = data[self.propBytes:]
+        self.properties = data[: self.propBytes]
+        data = data[self.propBytes :]
 
         # Calculate the actual data length
-        dataLength = self['TotalLength'] - 2 - self.propBytes
+        dataLength = self["TotalLength"] - 2 - self.propBytes
         valueData = data[:dataLength]
 
         # Parse value based on BaseType
@@ -578,52 +613,62 @@ class TDS_SSVARIANT(Structure):
         try:
             # Types with VARIANT_PROPBYTES = 0 (no properties)
             if baseType == TDS_INT1TYPE:
-                return struct.unpack('<B', data[:1])[0]
+                return struct.unpack("<B", data[:1])[0]
             elif baseType == TDS_INT2TYPE:
-                return struct.unpack('<h', data[:2])[0]
+                return struct.unpack("<h", data[:2])[0]
             elif baseType == TDS_INT4TYPE:
-                return struct.unpack('<l', data[:4])[0]
+                return struct.unpack("<l", data[:4])[0]
             elif baseType == TDS_INT8TYPE:
-                return struct.unpack('<q', data[:8])[0]
+                return struct.unpack("<q", data[:8])[0]
 
             # Bit type
             elif baseType == TDS_BITTYPE:
-                return struct.unpack('<B', data[:1])[0]
+                return struct.unpack("<B", data[:1])[0]
 
             # Floating point types
             elif baseType == TDS_FLT4TYPE:
-                return struct.unpack('<f', data[:4])[0]
+                return struct.unpack("<f", data[:4])[0]
             elif baseType == TDS_FLT8TYPE:
-                return struct.unpack('<d', data[:8])[0]
+                return struct.unpack("<d", data[:8])[0]
 
             # Unicode character types
             elif baseType in (TDS_NVARCHARTYPE, TDS_NCHARTYPE):
                 # Properties: Collation (5 bytes) + MaxLength (2 bytes)
-                return data.decode('utf-16le')
+                return data.decode("utf-16le")
 
             # ANSI character types
-            elif baseType in (TDS_VARCHARTYPE, TDS_CHARTYPE, TDS_BIGVARCHRTYPE, TDS_BIGCHARTYPE):
+            elif baseType in (
+                TDS_VARCHARTYPE,
+                TDS_CHARTYPE,
+                TDS_BIGVARCHRTYPE,
+                TDS_BIGCHARTYPE,
+            ):
                 # Properties: Collation (5 bytes) + MaxLength (varies)
                 # Try UTF-8 first, fallback to latin-1
                 try:
-                    return data.decode('utf-8')
+                    return data.decode("utf-8")
                 except UnicodeDecodeError:
-                    return data.decode('latin-1')
+                    return data.decode("latin-1")
 
             # Binary types
-            elif baseType in (TDS_VARBINARYTYPE, TDS_BINARYTYPE, TDS_BIGVARBINTYPE, TDS_BIGBINARYTYPE):
-                return binascii.b2a_hex(data).decode('ascii')
+            elif baseType in (
+                TDS_VARBINARYTYPE,
+                TDS_BINARYTYPE,
+                TDS_BIGVARBINTYPE,
+                TDS_BIGBINARYTYPE,
+            ):
+                return binascii.b2a_hex(data).decode("ascii")
 
             # Money types
             elif baseType == TDS_MONEY4TYPE:
-                value = struct.unpack('<l', data[:4])[0]
-                return value / 10000.0
+                value = struct.unpack("<l", data[:4])[0]
+                return Decimal(value) / Decimal(10000)
             elif baseType == TDS_MONEYTYPE:
                 # Money: first 4 bytes are the high-order signed dword (little-endian),
                 # next 4 bytes are the low-order unsigned dword (little-endian).
-                high, low = struct.unpack('<lL', data[:8])
+                high, low = struct.unpack("<lL", data[:8])
                 value = (high << 32) + low
-                return value / 10000.0
+                return Decimal(value) / Decimal(10000)
 
             # GUID type
             elif baseType == TDS_GUIDTYPE:
@@ -632,29 +677,38 @@ class TDS_SSVARIANT(Structure):
             # Datetime types
             elif baseType == TDS_DATETIMETYPE:
                 # 4 bytes days + 4 bytes time
-                dateValue = struct.unpack('<l', data[:4])[0]
-                timeValue = struct.unpack('<L', data[4:8])[0]
+                dateValue = struct.unpack("<l", data[:4])[0]
+                timeValue = struct.unpack("<L", data[4:8])[0]
                 baseDate = datetime.date(1900, 1, 1)
                 dateValue = datetime.date.fromordinal(baseDate.toordinal() + dateValue)
                 hours, mod = divmod(timeValue // 300, 60 * 60)
                 minutes, second = divmod(mod, 60)
-                return datetime.datetime(dateValue.year, dateValue.month, dateValue.day, hours, minutes, second)
+                return datetime.datetime(
+                    dateValue.year,
+                    dateValue.month,
+                    dateValue.day,
+                    hours,
+                    minutes,
+                    second,
+                )
 
             elif baseType == TDS_DATETIM4TYPE:
                 # 2 bytes days + 2 bytes minutes
-                dateValue = struct.unpack('<H', data[:2])[0]
-                timeValue = struct.unpack('<H', data[2:4])[0]
+                dateValue = struct.unpack("<H", data[:2])[0]
+                timeValue = struct.unpack("<H", data[2:4])[0]
                 baseDate = datetime.date(1900, 1, 1)
                 dateValue = datetime.date.fromordinal(baseDate.toordinal() + dateValue)
                 hours, minutes = divmod(timeValue, 60)
-                return datetime.datetime(dateValue.year, dateValue.month, dateValue.day, hours, minutes, 0)
+                return datetime.datetime(
+                    dateValue.year, dateValue.month, dateValue.day, hours, minutes, 0
+                )
 
             elif baseType == TDS_DATENTYPE:
                 # date: 3-byte unsigned integer (days since year 1)
                 # VARIANT_PROPBYTES = 0
                 if len(data) < 3:
-                    return 'NULL'
-                dateValue = struct.unpack('<L', data[:3] + b'\x00')[0]
+                    return "NULL"
+                dateValue = struct.unpack("<L", data[:3] + b"\x00")[0]
                 return datetime.date.fromordinal(dateValue)
 
             # Types with VARIANT_PROPBYTES = 1 (1 byte for scale)
@@ -666,16 +720,16 @@ class TDS_SSVARIANT(Structure):
                 # Time is stored as 3-5 bytes depending on scale
                 timeBytes = len(data)
                 if timeBytes == 3:
-                    timeValue = struct.unpack('<L', data[:3] + b'\x00')[0]
+                    timeValue = struct.unpack("<L", data[:3] + b"\x00")[0]
                 elif timeBytes == 4:
-                    timeValue = struct.unpack('<L', data[:4])[0]
+                    timeValue = struct.unpack("<L", data[:4])[0]
                 elif timeBytes == 5:
-                    timeValue = struct.unpack('<Q', data[:5] + b'\x00\x00\x00')[0]
+                    timeValue = struct.unpack("<Q", data[:5] + b"\x00\x00\x00")[0]
                 else:
                     return f"<unsupported time bytes: {timeBytes}>"
 
                 # Convert to time (stored in 10^-scale second units)
-                divisor = 10 ** scale
+                divisor = 10**scale
                 seconds = timeValue / divisor
                 hours = int(seconds // 3600)
                 minutes = int((seconds % 3600) // 60)
@@ -690,23 +744,23 @@ class TDS_SSVARIANT(Structure):
                 timeBytes = 3 if scale <= 2 else (4 if scale <= 4 else 5)
 
                 if len(data) < timeBytes + 3:
-                    return 'NULL'
+                    return "NULL"
 
                 # Parse time part
                 if timeBytes == 3:
-                    timeValue = struct.unpack('<L', data[:3] + b'\x00')[0]
+                    timeValue = struct.unpack("<L", data[:3] + b"\x00")[0]
                 elif timeBytes == 4:
-                    timeValue = struct.unpack('<L', data[:4])[0]
+                    timeValue = struct.unpack("<L", data[:4])[0]
                 else:  # 5 bytes
-                    timeValue = struct.unpack('<Q', data[:5] + b'\x00\x00\x00')[0]
+                    timeValue = struct.unpack("<Q", data[:5] + b"\x00\x00\x00")[0]
 
                 data = data[timeBytes:]
 
                 # Parse date part (3 bytes)
-                dateValue = struct.unpack('<L', data[:3] + b'\x00')[0]
+                dateValue = struct.unpack("<L", data[:3] + b"\x00")[0]
 
                 # Convert to datetime
-                divisor = 10 ** scale
+                divisor = 10**scale
                 seconds = timeValue / divisor
                 hours = int(seconds // 3600)
                 minutes = int((seconds % 3600) // 60)
@@ -714,8 +768,15 @@ class TDS_SSVARIANT(Structure):
                 microsecs = int((seconds % 1) * 1000000)
 
                 date_obj = datetime.date.fromordinal(dateValue)
-                return datetime.datetime(date_obj.year, date_obj.month, date_obj.day,
-                                        hours, minutes, secs, microsecs)
+                return datetime.datetime(
+                    date_obj.year,
+                    date_obj.month,
+                    date_obj.day,
+                    hours,
+                    minutes,
+                    secs,
+                    microsecs,
+                )
 
             elif baseType == TDS_DATETIMEOFFSETNTYPE:
                 # datetimeoffset(n): scale in properties[0]
@@ -724,27 +785,27 @@ class TDS_SSVARIANT(Structure):
                 timeBytes = 3 if scale <= 2 else (4 if scale <= 4 else 5)
 
                 if len(data) < timeBytes + 5:
-                    return 'NULL'
+                    return "NULL"
 
                 # Parse time part
                 if timeBytes == 3:
-                    timeValue = struct.unpack('<L', data[:3] + b'\x00')[0]
+                    timeValue = struct.unpack("<L", data[:3] + b"\x00")[0]
                 elif timeBytes == 4:
-                    timeValue = struct.unpack('<L', data[:4])[0]
+                    timeValue = struct.unpack("<L", data[:4])[0]
                 else:  # 5 bytes
-                    timeValue = struct.unpack('<Q', data[:5] + b'\x00\x00\x00')[0]
+                    timeValue = struct.unpack("<Q", data[:5] + b"\x00\x00\x00")[0]
 
                 data = data[timeBytes:]
 
                 # Parse date part (3 bytes)
-                dateValue = struct.unpack('<L', data[:3] + b'\x00')[0]
+                dateValue = struct.unpack("<L", data[:3] + b"\x00")[0]
                 data = data[3:]
 
                 # Parse offset (2 bytes signed, minutes)
-                offsetMinutes = struct.unpack('<h', data[:2])[0]
+                offsetMinutes = struct.unpack("<h", data[:2])[0]
 
                 # Convert to datetime with timezone
-                divisor = 10 ** scale
+                divisor = 10**scale
                 seconds = timeValue / divisor
                 hours = int(seconds // 3600)
                 minutes = int((seconds % 3600) // 60)
@@ -752,8 +813,15 @@ class TDS_SSVARIANT(Structure):
                 microsecs = int((seconds % 1) * 1000000)
 
                 date_obj = datetime.date.fromordinal(dateValue)
-                dt = datetime.datetime(date_obj.year, date_obj.month, date_obj.day,
-                                      hours, minutes, secs, microsecs)
+                dt = datetime.datetime(
+                    date_obj.year,
+                    date_obj.month,
+                    date_obj.day,
+                    hours,
+                    minutes,
+                    secs,
+                    microsecs,
+                )
 
                 # Create timezone-aware datetime
                 tz = datetime.timezone(datetime.timedelta(minutes=offsetMinutes))
@@ -767,18 +835,25 @@ class TDS_SSVARIANT(Structure):
                 scale = properties[1] if len(properties) > 1 else 0
 
                 if len(data) == 0:
-                    return 'NULL'
+                    return "NULL"
 
                 # First byte is sign (1 = positive, 0 = negative)
                 sign = 1 if data[0] == 1 else -1
 
                 # Remaining bytes are the number in little-endian format
                 numBytes = data[1:]
-                value = int.from_bytes(numBytes, byteorder='little', signed=False)
+                value = int.from_bytes(numBytes, byteorder="little", signed=False)
 
-                # Apply scale
-                result = sign * value / (10 ** scale)
-                return result
+                getcontext().prec = precision
+
+                number = Decimal(value)
+                if scale:
+                    number /= Decimal(10) ** scale
+
+                if sign < 0:
+                    number = -number
+
+                return number
 
             # For unsupported types, return hex representation
             else:
@@ -790,8 +865,16 @@ class TDS_SSVARIANT(Structure):
 
 
 class MSSQL:
-    def __init__(self, address, port=1433, remoteName = '', workstation_id: str = "", application_name: str = "", rowsPrinter=DummyPrint()):
-        #self.packetSize = 32764
+    def __init__(
+        self,
+        address,
+        port=1433,
+        remoteName="",
+        workstation_id: str = "",
+        application_name: str = "",
+        rowsPrinter=DummyPrint(),
+    ):
+        # self.packetSize = 32764
         self.packetSize = 32763
         self.server = address
         self.remoteName = remoteName
@@ -800,8 +883,8 @@ class MSSQL:
         self.replies = {}
         self.colMeta = []
         self.rows = []
-        self.currentDB = ''
-        self.COL_SEPARATOR = '  '
+        self.currentDB = ""
+        self.COL_SEPARATOR = "  "
         self.MAX_COL_LEN = 255
         self.lastError = False
         self.tlsSocket = None
@@ -809,20 +892,24 @@ class MSSQL:
         self.mssql_version = ""
 
         self._workstation_id = workstation_id or f"DESKTOP-{uuid4().hex[:8].upper()}"
-        self._application_name = application_name or "Microsoft SQL Server Management Studio - Query"
+        self._application_name = (
+            application_name or "Microsoft SQL Server Management Studio - Query"
+        )
 
     # With Kerberos we need to know to which MSSQL instance we are going to connect (to compute the SPN)
     # As such we need to be able to list these instances which is what this code does
-    def getInstances(self, timeout = 5):
+    def getInstances(self, timeout=5):
         packet = SQLR()
-        packet['OpCode'] = SQLR_CLNT_UCAST_EX
+        packet["OpCode"] = SQLR_CLNT_UCAST_EX
 
         # Open the connection
-        af, socktype, proto, canonname, sa = socket.getaddrinfo(self.server, SQLR_PORT, 0, socket.SOCK_DGRAM)[0]
+        af, socktype, proto, canonname, sa = socket.getaddrinfo(
+            self.server, SQLR_PORT, 0, socket.SOCK_DGRAM
+        )[0]
         s = socket.socket(af, socktype, proto)
 
-        s.sendto(packet.getData(), 0, ( self.server, SQLR_PORT ))
-        ready, _, _ = select.select([ s.fileno() ], [ ] , [ ], timeout)
+        s.sendto(packet.getData(), 0, (self.server, SQLR_PORT))
+        ready, _, _ = select.select([s.fileno()], [], [], timeout)
         if not ready:
             return []
         else:
@@ -832,7 +919,7 @@ class MSSQL:
         resp = SQLR_Response(data)
 
         # Now parse the results
-        entries = resp['Data'].split(b';;')
+        entries = resp["Data"].split(b";;")
 
         # We don't want the last one, it's empty
         entries.pop()
@@ -841,49 +928,57 @@ class MSSQL:
         resp = []
 
         for i, entry in enumerate(entries):
-            fields = entry.split(b';')
+            fields = entry.split(b";")
             ret = {}
             for j, field in enumerate(fields):
                 if (j & 0x1) == 0:
-                    ret[field.decode('utf-8')] = fields[j+1].decode('utf-8')
+                    ret[field.decode("utf-8")] = fields[j + 1].decode("utf-8")
             resp.append(ret)
 
         return resp
-
 
     # This is where we compute the pre login TDS packet
     def preLogin(self):
         # First we initiate the structure
         prelogin = TDS_PRELOGIN()
         # Then we fill the version of the MSSQL client we use
-        prelogin['Version'] = b"\x08\x00\x01\x55\x00\x00"
+        prelogin["Version"] = b"\x08\x00\x01\x55\x00\x00"
         # We specify we support encryption but don't want it
-        prelogin['Encryption'] = TDS_ENCRYPT_OFF
+        prelogin["Encryption"] = TDS_ENCRYPT_OFF
         # Random threadID because we don't care about this
-        prelogin['ThreadID'] = struct.pack('<L',random.randint(0,65535))
+        prelogin["ThreadID"] = struct.pack("<L", random.randint(0, 65535))
         # The instance name
-        prelogin['Instance'] = b'MSSQLServer\x00'
+        prelogin["Instance"] = b"MSSQLServer\x00"
         # We send the prelogin packet, receive the response from the server
         self.sendTDS(TDS_PRE_LOGIN, prelogin.getData(), 0)
         tds = self.recvTDS()
-        response = TDS_PRELOGIN(tds['Data'])
-        self.mssql_version = MSSQL_VERSION(response['Version'])
+        response = TDS_PRELOGIN(tds["Data"])
+        self.mssql_version = MSSQL_VERSION(response["Version"])
         # And return the result to the Login or KerberosLogin functions for futher parsing
         return response
 
-    def encryptPassword(self, password ):
-        return bytes(bytearray([((x & 0x0f) << 4) + ((x & 0xf0) >> 4) ^ 0xa5 for x in bytearray(password)]))
+    def encryptPassword(self, password):
+        return bytes(
+            bytearray(
+                [
+                    ((x & 0x0F) << 4) + ((x & 0xF0) >> 4) ^ 0xA5
+                    for x in bytearray(password)
+                ]
+            )
+        )
 
     def connect(self, timeout=30):
-        af, socktype, proto, canonname, sa = socket.getaddrinfo(self.server, self.port, 0, socket.SOCK_STREAM)[0]
+        af, socktype, proto, canonname, sa = socket.getaddrinfo(
+            self.server, self.port, 0, socket.SOCK_STREAM
+        )[0]
         sock = socket.socket(af, socktype, proto)
         sock.settimeout(timeout)
 
         try:
             sock.connect(sa)
         except Exception:
-            #import traceback
-            #traceback.print_exc()
+            # import traceback
+            # traceback.print_exc()
             raise
 
         self.socket = sock
@@ -904,30 +999,30 @@ class MSSQL:
     # This function is the generic sendTDS packet which is used to embed data into a regular TDS packet
     # Once the TDS packet is computed, it is send to the socketSendall function that will check
     # whether or not we have to encrypt the packets
-    def sendTDS(self, packetType, data, packetID = 1):
-        if (len(data)-8) > self.packetSize:
-            remaining = data[self.packetSize-8:]
+    def sendTDS(self, packetType, data, packetID=1):
+        if (len(data) - 8) > self.packetSize:
+            remaining = data[self.packetSize - 8 :]
             tds = TDSPacket()
-            tds['Type'] = packetType
-            tds['Status'] = TDS_STATUS_NORMAL
-            tds['PacketID'] = packetID
-            tds['Data'] = data[:self.packetSize-8]
+            tds["Type"] = packetType
+            tds["Status"] = TDS_STATUS_NORMAL
+            tds["PacketID"] = packetID
+            tds["Data"] = data[: self.packetSize - 8]
             self.socketSendall(tds.getData())
 
-            while len(remaining) > (self.packetSize-8):
+            while len(remaining) > (self.packetSize - 8):
                 packetID += 1
-                tds['PacketID'] = packetID
-                tds['Data'] = remaining[:self.packetSize-8]
+                tds["PacketID"] = packetID
+                tds["Data"] = remaining[: self.packetSize - 8]
                 self.socketSendall(tds.getData())
-                remaining = remaining[self.packetSize-8:]
+                remaining = remaining[self.packetSize - 8 :]
             data = remaining
-            packetID+=1
+            packetID += 1
 
         tds = TDSPacket()
-        tds['Type'] = packetType
-        tds['Status'] = TDS_STATUS_EOM
-        tds['PacketID'] = packetID
-        tds['Data'] = data
+        tds["Type"] = packetType
+        tds["Status"] = TDS_STATUS_EOM
+        tds["PacketID"] = packetID
+        tds["Data"] = data
         self.socketSendall(tds.getData())
 
     # This function is a wrapper that is used to dispatch packets to send depending of the TLS context
@@ -964,32 +1059,31 @@ class MSSQL:
 
     #################### SEND DATA #####################################################################
 
-
     #################### READ DATA #####################################################################
 
     # This function is the generic recvTDS packet which is used to extract data from a regular TDS packet
     # Once the TDS packet is extracted, it is send to the socketRecv function that will check
     # whether or not we have to decrypt the packets
-    def recvTDS(self, packetSize = None):
+    def recvTDS(self, packetSize=None):
         if packetSize is None:
             packetSize = self.packetSize
 
-        data = b''
-        while data == b'':
+        data = b""
+        while data == b"":
             data = self.socketRecv(packetSize)
 
         packet = TDSPacket(data)
 
-        status = packet['Status']
-        packetLen = packet['Length']-8
-        while packetLen > len(packet['Data']):
+        status = packet["Status"]
+        packetLen = packet["Length"] - 8
+        while packetLen > len(packet["Data"]):
             data = self.socketRecv(packetSize)
-            packet['Data'] += data
+            packet["Data"] += data
 
         remaining = None
-        if packetLen <  len(packet['Data']):
-            remaining = packet['Data'][packetLen:]
-            packet['Data'] = packet['Data'][:packetLen]
+        if packetLen < len(packet["Data"]):
+            remaining = packet["Data"][packetLen:]
+            packet["Data"] = packet["Data"][:packetLen]
 
         while status != TDS_STATUS_EOM:
             if remaining is not None:
@@ -997,19 +1091,19 @@ class MSSQL:
             else:
                 tmpPacket = TDSPacket(self.socketRecv(packetSize))
 
-            packetLen = tmpPacket['Length'] - 8
-            while packetLen > len(tmpPacket['Data']):
+            packetLen = tmpPacket["Length"] - 8
+            while packetLen > len(tmpPacket["Data"]):
                 data = self.socketRecv(packetSize)
-                tmpPacket['Data'] += data
+                tmpPacket["Data"] += data
 
             remaining = None
-            if packetLen <  len(tmpPacket['Data']):
-                remaining = tmpPacket['Data'][packetLen:]
-                tmpPacket['Data'] = tmpPacket['Data'][:packetLen]
+            if packetLen < len(tmpPacket["Data"]):
+                remaining = tmpPacket["Data"][packetLen:]
+                tmpPacket["Data"] = tmpPacket["Data"][:packetLen]
 
-            status = tmpPacket['Status']
-            packet['Data'] += tmpPacket['Data']
-            packet['Length'] += tmpPacket['Length'] - 8
+            status = tmpPacket["Status"]
+            packet["Data"] += tmpPacket["Data"]
+            packet["Length"] += tmpPacket["Length"] - 8
 
         return packet
 
@@ -1042,14 +1136,15 @@ class MSSQL:
 
     #################### READ DATA #####################################################################
 
-
     # This function returns the computed Channel Binding Token based on the tls-unique value
     def generate_cbt_from_tls_unique(self):
         channel_binding_struct = b""
         initiator_address = b"\x00" * 8
         acceptor_address = b"\x00" * 8
         application_data_raw = b"tls-unique:" + self.tls_unique
-        len_application_data = len(application_data_raw).to_bytes(4, byteorder="little", signed=False)
+        len_application_data = len(application_data_raw).to_bytes(
+            4, byteorder="little", signed=False
+        )
         application_data = len_application_data
         application_data += application_data_raw
         channel_binding_struct += initiator_address
@@ -1065,7 +1160,7 @@ class MSSQL:
         LOG.info("Encryption required, switching to TLS")
         # Creates a TLS context
         context = ssl.SSLContext()
-        context.set_ciphers('ALL:@SECLEVEL=0')
+        context.set_ciphers("ALL:@SECLEVEL=0")
         context.minimum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
         context.verify_mode = ssl.CERT_NONE
 
@@ -1113,81 +1208,133 @@ class MSSQL:
         # Finally we retrieve the tls-unique value which is computed from the final TLS handshake message (this is the CBT token)
         self.tls_unique = tls.get_channel_binding("tls-unique")
 
-    def kerberosLogin(self, database, username, password='', domain='', hashes=None, aesKey='', kdcHost=None, TGT=None, TGS=None, useCache=True):
+    def kerberosLogin(
+        self,
+        database,
+        username,
+        password="",
+        domain="",
+        hashes=None,
+        aesKey="",
+        kdcHost=None,
+        TGT=None,
+        TGS=None,
+        useCache=True,
+    ):
         if hashes is not None:
-            lmhash, nthash = hashes.split(':')
+            lmhash, nthash = hashes.split(":")
             lmhash = binascii.a2b_hex(lmhash)
             nthash = binascii.a2b_hex(nthash)
         else:
-            lmhash = ''
-            nthash = ''
+            lmhash = ""
+            nthash = ""
 
         resp = self.preLogin()
         # If the MSSQL Server responds with a TDS_ENCRYPT_REQ or TDS_ENCRYPT_OFF
         # Then it means we need to setup a TLS context
-        if resp['Encryption'] == TDS_ENCRYPT_REQ or resp['Encryption'] == TDS_ENCRYPT_OFF:
+        if (
+            resp["Encryption"] == TDS_ENCRYPT_REQ
+            or resp["Encryption"] == TDS_ENCRYPT_OFF
+        ):
             self.set_tls_context()
 
         # That part is used to compute the Version field for the NTLM_NEGOTIATE and NTLM_AUTHENTICATE messages
         self.version = ntlm.VERSION()
-        self.version["ProductMajorVersion"], self.version["ProductMinorVersion"], self.version["ProductBuild"] = 10, 0, 20348
+        (
+            self.version["ProductMajorVersion"],
+            self.version["ProductMinorVersion"],
+            self.version["ProductBuild"],
+        ) = (10, 0, 20348)
 
         login = TDS_LOGIN()
-        login['HostName'] = self.workstation_id.encode('utf-16le')
-        login['AppName']  = self.application_name.encode('utf-16le')
-        login['ServerName'] = self.remoteName.encode('utf-16le')
-        login['CltIntName']  = login['AppName']
-        login['ClientPID'] = random.randint(0,1024)
-        login['PacketSize'] = self.packetSize
+        login["HostName"] = self.workstation_id.encode("utf-16le")
+        login["AppName"] = self.application_name.encode("utf-16le")
+        login["ServerName"] = self.remoteName.encode("utf-16le")
+        login["CltIntName"] = login["AppName"]
+        login["ClientPID"] = random.randint(0, 1024)
+        login["PacketSize"] = self.packetSize
         if database is not None:
-            login['Database'] = database.encode('utf-16le')
-        login['OptionFlags2'] = TDS_INIT_LANG_FATAL | TDS_ODBC_ON
+            login["Database"] = database.encode("utf-16le")
+        login["OptionFlags2"] = TDS_INIT_LANG_FATAL | TDS_ODBC_ON
 
         # Importing down here so pyasn1 is not required if kerberos is not used.
         from impacket.spnego import SPNEGO_NegTokenInit, TypesMech
         from impacket.krb5.ccache import CCache
         from impacket.krb5.asn1 import AP_REQ, Authenticator, TGS_REP, seq_set
-        from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGS, KerberosError, CheckSumField
+        from impacket.krb5.kerberosv5 import (
+            getKerberosTGT,
+            getKerberosTGS,
+            KerberosError,
+            CheckSumField,
+        )
         from impacket.krb5 import constants
         from impacket.krb5.types import Principal, KerberosTime, Ticket
         from pyasn1.codec.der import decoder, encoder
         from pyasn1.type.univ import noValue
-        from impacket.krb5.gssapi import CheckSumField, GSS_C_REPLAY_FLAG, GSS_C_SEQUENCE_FLAG
+        from impacket.krb5.gssapi import (
+            CheckSumField,
+            GSS_C_REPLAY_FLAG,
+            GSS_C_SEQUENCE_FLAG,
+        )
 
         if useCache:
-            domain, username, TGT, TGS = CCache.parseFile(domain, username, 'MSSQLSvc/%s:%d' % (self.remoteName, self.port))
+            domain, username, TGT, TGS = CCache.parseFile(
+                domain, username, "MSSQLSvc/%s:%d" % (self.remoteName, self.port)
+            )
 
             if TGS is None:
                 # search for the port's instance name instead (instance name based SPN)
-                LOG.debug('Searching target\'s instances to look for port number %s' % self.port)
+                LOG.debug(
+                    "Searching target's instances to look for port number %s"
+                    % self.port
+                )
                 instances = self.getInstances()
                 instanceName = None
                 for i in instances:
                     try:
-                        if int(i['tcp']) == self.port:
-                            instanceName = i['InstanceName']
+                        if int(i["tcp"]) == self.port:
+                            instanceName = i["InstanceName"]
                     except Exception as e:
                         pass
 
                 if instanceName:
-                    domain, username, TGT, TGS = CCache.parseFile(domain, username, 'MSSQLSvc/%s.%s:%s' % (self.remoteName.split('.')[0], domain, instanceName))
+                    domain, username, TGT, TGS = CCache.parseFile(
+                        domain,
+                        username,
+                        "MSSQLSvc/%s.%s:%s"
+                        % (self.remoteName.split(".")[0], domain, instanceName),
+                    )
 
         # First of all, we need to get a TGT for the user
-        userName = Principal(username, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
+        userName = Principal(
+            username, type=constants.PrincipalNameType.NT_PRINCIPAL.value
+        )
         while True:
             if TGT is None:
                 if TGS is None:
                     try:
-                        tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, password, domain, lmhash, nthash, aesKey, kdcHost)
+                        tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(
+                            userName, password, domain, lmhash, nthash, aesKey, kdcHost
+                        )
                     except KerberosError as e:
-                        if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
+                        if (
+                            e.getErrorCode()
+                            == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value
+                        ):
                             # We might face this if the target does not support AES
                             # So, if that's the case we'll force using RC4 by converting
                             # the password to lm/nt hashes and hope for the best. If that's already
                             # done, byebye.
-                            if lmhash == '' and nthash == '' and (aesKey == '' or aesKey is None) and TGT is None and TGS is None:
+                            if (
+                                lmhash == ""
+                                and nthash == ""
+                                and (aesKey == "" or aesKey is None)
+                                and TGT is None
+                                and TGS is None
+                            ):
                                 from impacket.ntlm import compute_lmhash, compute_nthash
-                                LOG.debug('Got KDC_ERR_ETYPE_NOSUPP, fallback to RC4')
+
+                                LOG.debug("Got KDC_ERR_ETYPE_NOSUPP, fallback to RC4")
                                 lmhash = compute_lmhash(password)
                                 nthash = compute_nthash(password)
                                 continue
@@ -1196,9 +1343,9 @@ class MSSQL:
                         else:
                             raise
             else:
-                tgt = TGT['KDC_REP']
-                cipher = TGT['cipher']
-                sessionKey = TGT['sessionKey']
+                tgt = TGT["KDC_REP"]
+                cipher = TGT["cipher"]
+                sessionKey = TGT["sessionKey"]
 
             if TGS is None:
                 # From https://msdn.microsoft.com/en-us/library/ms191153.aspx?f=255&MSPPError=-2147217396
@@ -1211,18 +1358,34 @@ class MSSQL:
                 #         FQDN is the fully qualified domain name of the server.
                 #         port is the TCP port number.
                 #         instancename is the name of the SQL Server instance.
-                serverName = Principal('MSSQLSvc/%s.%s:%d' % (self.remoteName.split('.')[0], domain, self.port), type=constants.PrincipalNameType.NT_SRV_INST.value)
+                serverName = Principal(
+                    "MSSQLSvc/%s.%s:%d"
+                    % (self.remoteName.split(".")[0], domain, self.port),
+                    type=constants.PrincipalNameType.NT_SRV_INST.value,
+                )
                 try:
-                    tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey)
+                    tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(
+                        serverName, domain, kdcHost, tgt, cipher, sessionKey
+                    )
                 except KerberosError as e:
-                    if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
+                    if (
+                        e.getErrorCode()
+                        == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value
+                    ):
                         # We might face this if the target does not support AES
                         # So, if that's the case we'll force using RC4 by converting
                         # the password to lm/nt hashes and hope for the best. If that's already
                         # done, byebye.
-                        if lmhash == '' and nthash == '' and (aesKey == '' or aesKey is None) and TGT is None and TGS is None:
+                        if (
+                            lmhash == ""
+                            and nthash == ""
+                            and (aesKey == "" or aesKey is None)
+                            and TGT is None
+                            and TGS is None
+                        ):
                             from impacket.ntlm import compute_lmhash, compute_nthash
-                            LOG.debug('Got KDC_ERR_ETYPE_NOSUPP, fallback to RC4')
+
+                            LOG.debug("Got KDC_ERR_ETYPE_NOSUPP, fallback to RC4")
                             lmhash = compute_lmhash(password)
                             nthash = compute_nthash(password)
                         else:
@@ -1232,9 +1395,9 @@ class MSSQL:
                 else:
                     break
             else:
-                tgs = TGS['KDC_REP']
-                cipher = TGS['cipher']
-                sessionKey = TGS['sessionKey']
+                tgs = TGS["KDC_REP"]
+                cipher = TGS["cipher"]
+                sessionKey = TGS["sessionKey"]
                 break
 
         # Let's build a NegTokenInit with a Kerberos REQ_AP
@@ -1242,30 +1405,30 @@ class MSSQL:
         blob = SPNEGO_NegTokenInit()
 
         # Kerberos
-        blob['MechTypes'] = [TypesMech['MS KRB5 - Microsoft Kerberos 5']]
+        blob["MechTypes"] = [TypesMech["MS KRB5 - Microsoft Kerberos 5"]]
 
         # Let's extract the ticket from the TGS
-        tgs = decoder.decode(tgs, asn1Spec = TGS_REP())[0]
+        tgs = decoder.decode(tgs, asn1Spec=TGS_REP())[0]
         ticket = Ticket()
-        ticket.from_asn1(tgs['ticket'])
+        ticket.from_asn1(tgs["ticket"])
 
         # Now let's build the AP_REQ
         apReq = AP_REQ()
-        apReq['pvno'] = 5
-        apReq['msg-type'] = int(constants.ApplicationTagNumbers.AP_REQ.value)
+        apReq["pvno"] = 5
+        apReq["msg-type"] = int(constants.ApplicationTagNumbers.AP_REQ.value)
 
         opts = list()
-        apReq['ap-options'] = constants.encodeFlags(opts)
-        seq_set(apReq, 'ticket', ticket.to_asn1)
+        apReq["ap-options"] = constants.encodeFlags(opts)
+        seq_set(apReq, "ticket", ticket.to_asn1)
 
         authenticator = Authenticator()
-        authenticator['authenticator-vno'] = 5
-        authenticator['crealm'] = domain
-        seq_set(authenticator, 'cname', userName.components_to_asn1)
+        authenticator["authenticator-vno"] = 5
+        authenticator["crealm"] = domain
+        seq_set(authenticator, "cname", userName.components_to_asn1)
         now = datetime.datetime.now(datetime.timezone.utc)
 
-        authenticator['cusec'] = now.microsecond
-        authenticator['ctime'] = KerberosTime.to_asn1(now)
+        authenticator["cusec"] = now.microsecond
+        authenticator["ctime"] = KerberosTime.to_asn1(now)
         authenticator["cksum"] = noValue
         authenticator["cksum"]["cksumtype"] = 0x8003
 
@@ -1283,101 +1446,118 @@ class MSSQL:
         # AP-REQ Authenticator (includes application authenticator
         # subkey), encrypted with the application session key
         # (Section 5.5.1)
-        encryptedEncodedAuthenticator = cipher.encrypt(sessionKey, 11, encodedAuthenticator, None)
+        encryptedEncodedAuthenticator = cipher.encrypt(
+            sessionKey, 11, encodedAuthenticator, None
+        )
 
-        apReq['authenticator'] = noValue
-        apReq['authenticator']['etype'] = cipher.enctype
-        apReq['authenticator']['cipher'] = encryptedEncodedAuthenticator
+        apReq["authenticator"] = noValue
+        apReq["authenticator"]["etype"] = cipher.enctype
+        apReq["authenticator"]["cipher"] = encryptedEncodedAuthenticator
 
-        blob['MechToken'] = encoder.encode(apReq)
+        blob["MechToken"] = encoder.encode(apReq)
 
         # Seeting the last options for our TDS packet
         # TDS_INTEGRATED_SECURITY_ON enables Windows authentication
-        login['OptionFlags2'] |= TDS_INTEGRATED_SECURITY_ON
+        login["OptionFlags2"] |= TDS_INTEGRATED_SECURITY_ON
         # Include the entire blog's data into the login packet in the SSPI field
-        login['SSPI'] = blob.getData()
+        login["SSPI"] = blob.getData()
         # Sets the length of the packet
-        login['Length'] = len(login.getData())
+        login["Length"] = len(login.getData())
 
         # Send login packet which is containing the Kerberos tickets
         self.sendTDS(TDS_LOGIN7, login.getData())
 
         # According to the specs, if encryption is not required, we must encrypt just
         # the first Login packet :-o
-        if resp['Encryption'] == TDS_ENCRYPT_OFF:
+        if resp["Encryption"] == TDS_ENCRYPT_OFF:
             self.tlsSocket = None
 
         # We then receive the TDS response from the server and parse its response to see if we are logged in or not
         tds = self.recvTDS()
-        self.replies = self.parseReply(tds['Data'])
+        self.replies = self.parseReply(tds["Data"])
         if TDS_LOGINACK_TOKEN in self.replies:
             return True
         else:
             return False
 
-    def login(self, database, username, password='', domain='', hashes = None, useWindowsAuth = False):
+    def login(
+        self,
+        database,
+        username,
+        password="",
+        domain="",
+        hashes=None,
+        useWindowsAuth=False,
+    ):
 
         if hashes is not None:
-            lmhash, nthash = hashes.split(':')
+            lmhash, nthash = hashes.split(":")
             lmhash = binascii.a2b_hex(lmhash)
             nthash = binascii.a2b_hex(nthash)
         else:
-            lmhash = ''
-            nthash = ''
+            lmhash = ""
+            nthash = ""
 
         # First things first, we need to anounciate to the MSSQL server sending a TDS_PRELOGIN
         resp = self.preLogin()
 
         # If the MSSQL Server responds with a TDS_ENCRYPT_REQ or TDS_ENCRYPT_OFF
         # Then it means we need to setup a TLS context
-        if resp['Encryption'] == TDS_ENCRYPT_REQ or resp['Encryption'] == TDS_ENCRYPT_OFF:
+        if (
+            resp["Encryption"] == TDS_ENCRYPT_REQ
+            or resp["Encryption"] == TDS_ENCRYPT_OFF
+        ):
             self.set_tls_context()
 
         # That part is used to compute the Version field for the NTLM_NEGOTIATE and NTLM_AUTHENTICATE messages
         self.version = ntlm.VERSION()
-        self.version["ProductMajorVersion"], self.version["ProductMinorVersion"], self.version["ProductBuild"] = 10, 0, 20348
+        (
+            self.version["ProductMajorVersion"],
+            self.version["ProductMinorVersion"],
+            self.version["ProductBuild"],
+        ) = (10, 0, 20348)
 
         login = TDS_LOGIN()
-        login['HostName'] = self.workstation_id.encode('utf-16le')
-        login['AppName']  = self.application_name.encode('utf-16le')
-        login['ServerName'] = self.remoteName.encode('utf-16le')
-        login['CltIntName']  = login['AppName']
-        login['ClientPID'] = random.randint(0,1024)
-        login['PacketSize'] = self.packetSize
+        login["HostName"] = self.workstation_id.encode("utf-16le")
+        login["AppName"] = self.application_name.encode("utf-16le")
+        login["ServerName"] = self.remoteName.encode("utf-16le")
+        login["CltIntName"] = login["AppName"]
+        login["ClientPID"] = random.randint(0, 1024)
+        login["PacketSize"] = self.packetSize
         if database is not None:
-            login['Database'] = database.encode('utf-16le')
+            login["Database"] = database.encode("utf-16le")
 
         # These flags means:
         # TDS_INIT_LANG_FATAL: if we specify a language (let's say fr) and we want the MSSQL server to serve us french
         # But for a reason, it can't, then the connection is closed
         # TDS_ODBC_ON: specifies that we are a ODBC driver (but we are clearly not)
-        login['OptionFlags2'] = TDS_INIT_LANG_FATAL | TDS_ODBC_ON
+        login["OptionFlags2"] = TDS_INIT_LANG_FATAL | TDS_ODBC_ON
 
         # If we rely on Windows Authentication
         if useWindowsAuth is True:
             # Amongs these fields, the following flag need to be set if we rely on a Windows Authentication (and not local mssql accounts)
-            login['OptionFlags2'] |= TDS_INTEGRATED_SECURITY_ON
+            login["OptionFlags2"] |= TDS_INTEGRATED_SECURITY_ON
             # We send compute the first NTLM message (NTLMSSP_NEGOTIATE) asking for NTLMv2
             # Indeed NTLMv2 doesn't support CBT nor signing
-            auth = ntlm.getNTLMSSPType1('', '', use_ntlmv2=True, version=self.version)
+            auth = ntlm.getNTLMSSPType1("", "", use_ntlmv2=True, version=self.version)
             # We then fill the TDS_LOGIN["SSPI"] fields with the NTLMSSP_NEGOTIATE packet
-            login['SSPI'] = auth.getData()
+            login["SSPI"] = auth.getData()
 
         # If we rely on local MSSQL authentication (sa account for example)
         else:
-            login['UserName'] = username.encode('utf-16le')
-            login['Password'] = self.encryptPassword(password.encode('utf-16le'))
-            login['SSPI'] = ''
+            login["UserName"] = username.encode("utf-16le")
+            login["Password"] = self.encryptPassword(password.encode("utf-16le"))
+            login["SSPI"] = ""
 
         # And finally we fill the Length field and send the TDS packet to initiate NTLM authentication
-        login['Length'] = len(login.getData())
+        login["Length"] = len(login.getData())
 
         # Send the NTLMSSP Negotiate or SQL Auth Packet
         self.sendTDS(TDS_LOGIN7, login.getData())
 
         # According to the specs, if encryption is not required, we must encrypt just
         # the first Login packet :-o
-        if resp['Encryption'] == TDS_ENCRYPT_OFF:
+        if resp["Encryption"] == TDS_ENCRYPT_OFF:
             self.tlsSocket = None
 
         # We then receive its response which is either
@@ -1388,7 +1568,7 @@ class MSSQL:
         if useWindowsAuth is True:
 
             # Each TDS packet has a header so we extract the NTLMSSP_CHALLENGE from it
-            serverChallenge = tds['Data'][3:]
+            serverChallenge = tds["Data"][3:]
 
             # We then compute the Channel Binding Token from the tls-unique value retrieved before
             channel_binding_value = b""
@@ -1407,20 +1587,19 @@ class MSSQL:
                 service="MSSQLSvc",
                 use_ntlmv2=True,
                 channel_binding_value=channel_binding_value,
-                version=self.version
+                version=self.version,
             )
 
             # Now we initiate the MIC field with 0's
             type3["MIC"] = b"\x00" * 16
 
-
             # And we calculate the final MIC value based on the 3 NTLMSSP packets and the exportedEncryptedSessionKey
             ntlm_negotiate_data = auth.getData()
-            ntlm_challenge_data =  ntlm.NTLMAuthChallenge(serverChallenge).getData()
+            ntlm_challenge_data = ntlm.NTLMAuthChallenge(serverChallenge).getData()
             ntlm_authenticate_data = type3.getData()
             newmic = ntlm.hmac_md5(
                 exportedSessionKey,
-                ntlm_negotiate_data + ntlm_challenge_data + ntlm_authenticate_data
+                ntlm_negotiate_data + ntlm_challenge_data + ntlm_authenticate_data,
             )
             LOG.debug(f"Computed MIC is {newmic.hex()}")
             type3["MIC"] = newmic
@@ -1432,70 +1611,70 @@ class MSSQL:
 
         # At this point we have received an authentication response from the server whether it is
         # via a WindowsAuth or a local MSSQL auth so we just have to parse the response
-        self.replies = self.parseReply(tds['Data'])
+        self.replies = self.parseReply(tds["Data"])
         if TDS_LOGINACK_TOKEN in self.replies:
             return True
         else:
             return False
 
-
     def processColMeta(self):
         for col in self.colMeta:
-            if col['Type'] in [TDS_NVARCHARTYPE, TDS_NCHARTYPE, TDS_NTEXTTYPE]:
-                col['Length'] = col['TypeData']//2
-                fmt = '%%-%ds'
-            elif col['Type'] in [TDS_GUIDTYPE]:
-                col['Length'] = 36
-                fmt = '%%%ds'
-            elif col['Type'] in [TDS_DECIMALNTYPE,TDS_NUMERICNTYPE]:
-                col['Length'] = ord(col['TypeData'][0:1])
-                fmt = '%%%ds'
-            elif col['Type'] in [TDS_DATETIMNTYPE]:
-                col['Length'] = 19
-                fmt = '%%-%ds'
-            elif col['Type'] in [TDS_INT4TYPE, TDS_INTNTYPE]:
-                col['Length'] = 11
-                fmt = '%%%ds'
-            elif col['Type'] in [TDS_FLTNTYPE, TDS_MONEYNTYPE]:
-                col['Length'] = 25
-                fmt = '%%%ds'
-            elif col['Type'] in [TDS_BITNTYPE, TDS_BIGCHARTYPE]:
-                col['Length'] = col['TypeData']
-                fmt = '%%%ds'
-            elif col['Type'] in [TDS_BIGBINARYTYPE, TDS_BIGVARBINTYPE]:
-                col['Length'] = col['TypeData'] * 2
-                fmt = '%%%ds'
-            elif col['Type'] in [TDS_TEXTTYPE, TDS_BIGVARCHRTYPE]:
-                col['Length'] = col['TypeData']
-                fmt = '%%-%ds'
+            if col["Type"] in [TDS_NVARCHARTYPE, TDS_NCHARTYPE, TDS_NTEXTTYPE]:
+                col["Length"] = col["TypeData"] // 2
+                fmt = "%%-%ds"
+            elif col["Type"] in [TDS_GUIDTYPE]:
+                col["Length"] = 36
+                fmt = "%%%ds"
+            elif col["Type"] in [TDS_DECIMALNTYPE, TDS_NUMERICNTYPE]:
+                col["Length"] = ord(col["TypeData"][0:1])
+                fmt = "%%%ds"
+            elif col["Type"] in [TDS_DATETIMNTYPE]:
+                col["Length"] = 19
+                fmt = "%%-%ds"
+            elif col["Type"] in [TDS_INT4TYPE, TDS_INTNTYPE]:
+                col["Length"] = 11
+                fmt = "%%%ds"
+            elif col["Type"] in [TDS_FLTNTYPE, TDS_MONEYNTYPE]:
+                col["Length"] = 25
+                fmt = "%%%ds"
+            elif col["Type"] in [TDS_BITNTYPE, TDS_BIGCHARTYPE]:
+                col["Length"] = col["TypeData"]
+                fmt = "%%%ds"
+            elif col["Type"] in [TDS_BIGBINARYTYPE, TDS_BIGVARBINTYPE]:
+                col["Length"] = col["TypeData"] * 2
+                fmt = "%%%ds"
+            elif col["Type"] in [TDS_TEXTTYPE, TDS_BIGVARCHRTYPE]:
+                col["Length"] = col["TypeData"]
+                fmt = "%%-%ds"
             else:
-                col['Length'] = 10
-                fmt = '%%%ds'
+                col["Length"] = 10
+                fmt = "%%%ds"
 
-            col['minLenght'] = 0
+            col["minLenght"] = 0
             for row in self.rows:
-                if len(str(row[col['Name']])) > col['minLenght']:
-                   col['minLenght'] = len(str(row[col['Name']]))
-            if col['minLenght'] < col['Length']:
-                col['Length'] = col['minLenght']
+                if len(str(row[col["Name"]])) > col["minLenght"]:
+                    col["minLenght"] = len(str(row[col["Name"]]))
+            if col["minLenght"] < col["Length"]:
+                col["Length"] = col["minLenght"]
 
-            if len(col['Name']) > col['Length']:
-                col['Length'] = len(col['Name'])
-            elif col['Length'] > self.MAX_COL_LEN:
-                col['Length'] = self.MAX_COL_LEN
+            if len(col["Name"]) > col["Length"]:
+                col["Length"] = len(col["Name"])
+            elif col["Length"] > self.MAX_COL_LEN:
+                col["Length"] = self.MAX_COL_LEN
 
-            col['Format'] = fmt % col['Length']
-
+            col["Format"] = fmt % col["Length"]
 
     def printColumnsHeader(self):
         if len(self.colMeta) == 0:
             return
         for col in self.colMeta:
-            self.__rowsPrinter.logMessage(col['Format'] % col['Name'] + self.COL_SEPARATOR)
-        self.__rowsPrinter.logMessage('\r')
+            self.__rowsPrinter.logMessage(
+                col["Format"] % col["Name"] + self.COL_SEPARATOR
+            )
+        self.__rowsPrinter.logMessage("\r")
         for col in self.colMeta:
-            self.__rowsPrinter.logMessage('-'*col['Length'] + self.COL_SEPARATOR)
-        self.__rowsPrinter.logMessage('\r')
+            self.__rowsPrinter.logMessage("-" * col["Length"] + self.COL_SEPARATOR)
+        self.__rowsPrinter.logMessage("\r")
 
     def printRows(self):
         if self.lastError is True:
@@ -1504,42 +1683,72 @@ class MSSQL:
         self.printColumnsHeader()
         for row in self.rows:
             for col in self.colMeta:
-                self.__rowsPrinter.logMessage(col['Format'] % row[col['Name']] + self.COL_SEPARATOR)
-            self.__rowsPrinter.logMessage('\r')
+                self.__rowsPrinter.logMessage(
+                    col["Format"] % row[col["Name"]] + self.COL_SEPARATOR
+                )
+            self.__rowsPrinter.logMessage("\r")
 
     def printReplies(self, error_logger=LOG.error, info_logger=LOG.info):
         for keys in list(self.replies.keys()):
             for i, key in enumerate(self.replies[keys]):
-                if key['TokenType'] == TDS_ERROR_TOKEN:
-                    self.lastError = SQLErrorException("ERROR(%s): Line %d: %s" % (key['ServerName'].decode('utf-16le'), key['LineNumber'], key['MsgText'].decode('utf-16le')))
+                if key["TokenType"] == TDS_ERROR_TOKEN:
+                    self.lastError = SQLErrorException(
+                        "ERROR(%s): Line %d: %s"
+                        % (
+                            key["ServerName"].decode("utf-16le"),
+                            key["LineNumber"],
+                            key["MsgText"].decode("utf-16le"),
+                        )
+                    )
                     error_logger(self.lastError)
 
-                elif key['TokenType'] == TDS_INFO_TOKEN:
-                    info_logger("INFO(%s): Line %d: %s" % (key['ServerName'].decode('utf-16le'), key['LineNumber'], key['MsgText'].decode('utf-16le')))
+                elif key["TokenType"] == TDS_INFO_TOKEN:
+                    info_logger(
+                        "INFO(%s): Line %d: %s"
+                        % (
+                            key["ServerName"].decode("utf-16le"),
+                            key["LineNumber"],
+                            key["MsgText"].decode("utf-16le"),
+                        )
+                    )
 
-                elif key['TokenType'] == TDS_LOGINACK_TOKEN:
-                    info_logger(f"ACK: Result: {key['Interface']} - {self.mssql_version}")
+                elif key["TokenType"] == TDS_LOGINACK_TOKEN:
+                    info_logger(
+                        f"ACK: Result: {key['Interface']} - {self.mssql_version}"
+                    )
 
-                elif key['TokenType'] == TDS_ENVCHANGE_TOKEN:
-                    if key['Type'] in (TDS_ENVCHANGE_DATABASE, TDS_ENVCHANGE_LANGUAGE, TDS_ENVCHANGE_CHARSET, TDS_ENVCHANGE_PACKETSIZE):
-                        record = TDS_ENVCHANGE_VARCHAR(key['Data'])
-                        if record['OldValue'] == '':
-                            record['OldValue'] = 'None'.encode('utf-16le')
-                        elif record['NewValue'] == '':
-                            record['NewValue'] = 'None'.encode('utf-16le')
-                        if key['Type'] == TDS_ENVCHANGE_DATABASE:
-                            _type = 'DATABASE'
-                        elif key['Type'] == TDS_ENVCHANGE_LANGUAGE:
-                            _type = 'LANGUAGE'
-                        elif key['Type'] == TDS_ENVCHANGE_CHARSET:
-                            _type = 'CHARSET'
-                        elif key['Type'] == TDS_ENVCHANGE_PACKETSIZE:
-                            _type = 'PACKETSIZE'
+                elif key["TokenType"] == TDS_ENVCHANGE_TOKEN:
+                    if key["Type"] in (
+                        TDS_ENVCHANGE_DATABASE,
+                        TDS_ENVCHANGE_LANGUAGE,
+                        TDS_ENVCHANGE_CHARSET,
+                        TDS_ENVCHANGE_PACKETSIZE,
+                    ):
+                        record = TDS_ENVCHANGE_VARCHAR(key["Data"])
+                        if record["OldValue"] == "":
+                            record["OldValue"] = "None".encode("utf-16le")
+                        elif record["NewValue"] == "":
+                            record["NewValue"] = "None".encode("utf-16le")
+                        if key["Type"] == TDS_ENVCHANGE_DATABASE:
+                            _type = "DATABASE"
+                        elif key["Type"] == TDS_ENVCHANGE_LANGUAGE:
+                            _type = "LANGUAGE"
+                        elif key["Type"] == TDS_ENVCHANGE_CHARSET:
+                            _type = "CHARSET"
+                        elif key["Type"] == TDS_ENVCHANGE_PACKETSIZE:
+                            _type = "PACKETSIZE"
                         else:
-                            _type = "%d" % key['Type']
-                        info_logger("ENVCHANGE(%s): Old Value: %s, New Value: %s" % (_type,record['OldValue'].decode('utf-16le'), record['NewValue'].decode('utf-16le')))
+                            _type = "%d" % key["Type"]
+                        info_logger(
+                            "ENVCHANGE(%s): Old Value: %s, New Value: %s"
+                            % (
+                                _type,
+                                record["OldValue"].decode("utf-16le"),
+                                record["NewValue"].decode("utf-16le"),
+                            )
+                        )
 
-    def parseRow(self,token,tuplemode=False):
+    def parseRow(self, token, tuplemode=False):
         # TODO: This REALLY needs to be improved. Right now we don't support correctly all the data types
         # help would be appreciated ;)
         if len(token) == 1:
@@ -1547,29 +1756,36 @@ class MSSQL:
 
         row = [] if tuplemode else {}
 
-        origDataLen = len(token['Data'])
-        data = token['Data']
+        origDataLen = len(token["Data"])
+        data = token["Data"]
         for col in self.colMeta:
-            _type = col['Type']
-            if (_type == TDS_NVARCHARTYPE) |\
-               (_type == TDS_NCHARTYPE):
-                #print "NVAR 0x%x" % _type
-                charLen = struct.unpack('<H',data[:struct.calcsize('<H')])[0]
-                data = data[struct.calcsize('<H'):]
+            _type = col["Type"]
+            if (_type == TDS_NVARCHARTYPE) | (_type == TDS_NCHARTYPE):
+                # print "NVAR 0x%x" % _type
+                charLen = struct.unpack("<H", data[: struct.calcsize("<H")])[0]
+                data = data[struct.calcsize("<H") :]
                 if charLen != 0xFFFF:
-                    value = data[:charLen].decode('utf-16le')
+                    value = data[:charLen].decode("utf-16le")
                     data = data[charLen:]
                 else:
-                    value = 'NULL'
+                    value = "NULL"
 
             elif _type == TDS_BIGVARCHRTYPE:
-                charLen = struct.unpack('<H',data[:struct.calcsize('<H')])[0]
-                data = data[struct.calcsize('<H'):]
+                charLen = struct.unpack("<H", data[:2])[0]
+                data = data[2:]
+
                 if charLen != 0xFFFF:
-                    value = data[:charLen]
+                    raw = data[:charLen]
                     data = data[charLen:]
+
+                    # SQL Server stores VARCHAR in server codepage, not UTF-8
+                    # latin-1 is the safest reversible mapping
+                    try:
+                        value = raw.decode("latin-1")
+                    except UnicodeDecodeError:
+                        value = raw.decode("utf-8", errors="replace")
                 else:
-                    value = 'NULL'
+                    value = "NULL"
 
             elif _type == TDS_GUIDTYPE:
                 uuidLen = ord(data[0:1])
@@ -1579,58 +1795,58 @@ class MSSQL:
                     value = uuid.bin_to_string(uu)
                     data = data[uuidLen:]
                 else:
-                    value = 'NULL'
+                    value = "NULL"
 
-            elif (_type == TDS_NTEXTTYPE) |\
-                 (_type == TDS_IMAGETYPE) :
+            elif (_type == TDS_NTEXTTYPE) | (_type == TDS_IMAGETYPE):
                 # Skip the pointer data
                 charLen = ord(data[0:1])
                 if charLen == 0:
-                    value = 'NULL'
+                    value = "NULL"
                     data = data[1:]
                 else:
-                    data = data[1+charLen+8:]
-                    charLen = struct.unpack('<L',data[:struct.calcsize('<L')])[0]
-                    data = data[struct.calcsize('<L'):]
+                    data = data[1 + charLen + 8 :]
+                    charLen = struct.unpack("<L", data[: struct.calcsize("<L")])[0]
+                    data = data[struct.calcsize("<L") :]
                     if charLen != 0xFFFF:
                         if _type == TDS_NTEXTTYPE:
-                            value = data[:charLen].decode('utf-16le')
+                            value = data[:charLen].decode("utf-16le")
                         else:
                             value = binascii.b2a_hex(data[:charLen])
                         data = data[charLen:]
                     else:
-                        value = 'NULL'
+                        value = "NULL"
 
             elif _type == TDS_TEXTTYPE:
                 # Skip the pointer data
                 charLen = ord(data[0:1])
                 if charLen == 0:
-                    value = 'NULL'
+                    value = "NULL"
                     data = data[1:]
                 else:
-                    data = data[1+charLen+8:]
-                    charLen = struct.unpack('<L',data[:struct.calcsize('<L')])[0]
-                    data = data[struct.calcsize('<L'):]
+                    data = data[1 + charLen + 8 :]
+                    charLen = struct.unpack("<L", data[: struct.calcsize("<L")])[0]
+                    data = data[struct.calcsize("<L") :]
                     if charLen != 0xFFFF:
                         value = data[:charLen]
                         data = data[charLen:]
                     else:
-                        value = 'NULL'
+                        value = "NULL"
 
-            elif (_type == TDS_BIGVARBINTYPE) |\
-                 (_type == TDS_BIGBINARYTYPE):
-                charLen = struct.unpack('<H',data[:struct.calcsize('<H')])[0]
-                data = data[struct.calcsize('<H'):]
+            elif (_type == TDS_BIGVARBINTYPE) | (_type == TDS_BIGBINARYTYPE):
+                charLen = struct.unpack("<H", data[: struct.calcsize("<H")])[0]
+                data = data[struct.calcsize("<H") :]
                 if charLen != 0xFFFF:
                     value = binascii.b2a_hex(data[:charLen])
                     data = data[charLen:]
                 else:
-                    value = 'NULL'
+                    value = "NULL"
 
-            elif (_type == TDS_DATETIM4TYPE) |\
-                 (_type == TDS_DATETIMNTYPE) |\
-                 (_type == TDS_DATETIMETYPE):
-                value = ''
+            elif (
+                (_type == TDS_DATETIM4TYPE)
+                | (_type == TDS_DATETIMNTYPE)
+                | (_type == TDS_DATETIMETYPE)
+            ):
+                value = ""
                 if _type == TDS_DATETIMNTYPE:
                     # For DATETIMNTYPE, the only valid lengths are 0x04 and 0x08, which map to smalldatetime and
                     # datetime SQL data _types respectively.
@@ -1639,7 +1855,7 @@ class MSSQL:
                     elif ord(data[0:1]) == 8:
                         _type = TDS_DATETIMETYPE
                     else:
-                        value = 'NULL'
+                        value = "NULL"
                     data = data[1:]
                 if _type == TDS_DATETIMETYPE:
                     # datetime is represented in the following sequence:
@@ -1647,13 +1863,13 @@ class MSSQL:
                     #   numbers are allowed to represents dates since January 1, 1753.
                     # * One 4-byte unsigned integer that represents the number of one three-hundredths of a second
                     #  (300 counts per second) elapsed since 12 AM that day.
-                    dateValue = struct.unpack('<l',data[:4])[0]
+                    dateValue = struct.unpack("<l", data[:4])[0]
                     data = data[4:]
                     if dateValue < 0:
-                        baseDate = datetime.date(1753,1,1)
+                        baseDate = datetime.date(1753, 1, 1)
                     else:
-                        baseDate = datetime.date(1900,1,1)
-                    timeValue = struct.unpack('<L',data[:4])[0]
+                        baseDate = datetime.date(1900, 1, 1)
+                    timeValue = struct.unpack("<L", data[:4])[0]
                     data = data[4:]
                 elif _type == TDS_DATETIM4TYPE:
                     # Small datetime
@@ -1663,77 +1879,96 @@ class MSSQL:
                     # * One 2-byte unsigned integer that represents the number of days since January 1, 1900.
                     # * One 2-byte unsigned integer that represents the number of minutes elapsed since 12 AM that
                     #   day.
-                    dateValue = struct.unpack('<H',data[:struct.calcsize('<H')])[0]
-                    data = data[struct.calcsize('<H'):]
-                    timeValue = struct.unpack('<H',data[:struct.calcsize('<H')])[0]
-                    data = data[struct.calcsize('<H'):]
-                    baseDate = datetime.date(1900,1,1)
-                if value != 'NULL':
-                    dateValue = datetime.date.fromordinal(baseDate.toordinal() + dateValue)
-                    hours, mod = divmod(timeValue//300, 60*60)
+                    dateValue = struct.unpack("<H", data[: struct.calcsize("<H")])[0]
+                    data = data[struct.calcsize("<H") :]
+                    timeValue = struct.unpack("<H", data[: struct.calcsize("<H")])[0]
+                    data = data[struct.calcsize("<H") :]
+                    baseDate = datetime.date(1900, 1, 1)
+                if value != "NULL":
+                    dateValue = datetime.date.fromordinal(
+                        baseDate.toordinal() + dateValue
+                    )
+                    hours, mod = divmod(timeValue // 300, 60 * 60)
                     minutes, second = divmod(mod, 60)
-                    value = datetime.datetime(dateValue.year, dateValue.month, dateValue.day, hours, minutes, second)
+                    value = datetime.datetime(
+                        dateValue.year,
+                        dateValue.month,
+                        dateValue.day,
+                        hours,
+                        minutes,
+                        second,
+                    )
 
-            elif (_type == TDS_INT4TYPE) |\
-                 (_type == TDS_MONEY4TYPE) |\
-                 (_type == TDS_FLT4TYPE):
-                #print "INT4"
-                value = struct.unpack('<l',data[:struct.calcsize('<l')])[0]
-                data = data[struct.calcsize('<l'):]
+            elif _type == TDS_INT4TYPE:
+                value = struct.unpack("<l", data[:4])[0]
+                data = data[4:]
+
+            elif _type == TDS_FLT4TYPE:
+                value = struct.unpack("<f", data[:4])[0]
+                data = data[4:]
+
+            elif _type == TDS_MONEY4TYPE:
+                raw = struct.unpack("<l", data[:4])[0]
+                value = Decimal(raw) / Decimal(10000)
+                data = data[4:]
 
             elif _type == TDS_FLTNTYPE:
                 valueSize = ord(data[:1])
                 if valueSize == 4:
-                    fmt = '<f'
+                    fmt = "<f"
                 elif valueSize == 8:
-                    fmt = '<d'
+                    fmt = "<d"
 
                 data = data[1:]
 
                 if valueSize > 0:
-                    value = struct.unpack(fmt,data[:valueSize])[0]
+                    value = struct.unpack(fmt, data[:valueSize])[0]
                     data = data[valueSize:]
                 else:
-                    value = 'NULL'
+                    value = "NULL"
 
             elif _type == TDS_MONEYNTYPE:
                 valueSize = ord(data[:1])
                 if valueSize == 4:
-                    fmt = '<l'
+                    fmt = "<l"
                 elif valueSize == 8:
-                    fmt = '<q'
+                    fmt = "<q"
 
                 data = data[1:]
 
                 if valueSize > 0:
-                    value = struct.unpack(fmt,data[:valueSize])[0]
-                    if valueSize == 4:
-                        value = float(value) // math.pow(10,4)
-                    else:
-                        value = float(value >> 32) // math.pow(10,4)
+                    raw = struct.unpack(
+                        "<q" if valueSize == 8 else "<l", data[:valueSize]
+                    )[0]
+                    value = Decimal(raw) / Decimal(10000)
                     data = data[valueSize:]
                 else:
-                    value = 'NULL'
-
+                    value = "NULL"
 
             elif _type == TDS_BIGCHARTYPE:
-                #print "BIGC"
-                charLen = struct.unpack('<H',data[:struct.calcsize('<H')])[0]
-                data = data[struct.calcsize('<H'):]
+                # print "BIGC"
+                charLen = struct.unpack("<H", data[: struct.calcsize("<H")])[0]
+                data = data[struct.calcsize("<H") :]
                 value = data[:charLen]
                 data = data[charLen:]
 
-            elif (_type == TDS_INT8TYPE) |\
-                 (_type == TDS_FLT8TYPE) |\
-                 (_type == TDS_MONEYTYPE):
-                #print "DATETIME"
-                value = struct.unpack('<q',data[:struct.calcsize('<q')])[0]
-                data = data[struct.calcsize('<q'):]
+            elif _type == TDS_INT8TYPE:
+                value = struct.unpack("<q", data[:8])[0]
+                data = data[8:]
 
+            elif _type == TDS_FLT8TYPE:
+                value = struct.unpack("<d", data[:8])[0]
+                data = data[8:]
+
+            elif _type == TDS_MONEYTYPE:
+                high, low = struct.unpack("<lL", data[:8])
+                combined = (high << 32) + low
+                value = Decimal(combined) / Decimal(10000)
+                data = data[8:]
 
             elif _type == TDS_INT2TYPE:
-                #print "INT2TYPE"
-                value = struct.unpack('<H',(data[:2]))[0]
+                # print "INT2TYPE"
+                value = struct.unpack("<H", (data[:2]))[0]
                 data = data[2:]
 
             elif _type == TDS_DATENTYPE:
@@ -1743,47 +1978,44 @@ class MSSQL:
                 data = data[1:]
                 if valueSize > 0:
                     dateBytes = data[:valueSize]
-                    dateValue = struct.unpack('<L','\x00'+dateBytes)[0]
-                    value = datetime.date.fromtimestamp(dateValue)
+                    dateValue = struct.unpack("<L", dateBytes + b"\x00")[0]
+                    # SQL DATE is days since 0001-01-01, not Unix epoch.
+                    value = datetime.date.fromordinal(dateValue)
                     data = data[valueSize:]
                 else:
-                    value = 'NULL'
+                    value = "NULL"
 
-            elif (_type == TDS_BITTYPE) |\
-                 (_type == TDS_INT1TYPE):
-                #print "BITTYPE"
-                value = ord(data[:1])
+            elif (_type == TDS_BITTYPE) | (_type == TDS_INT1TYPE):
+                # print "BITTYPE"
+                value = bool(data[0])
                 data = data[1:]
 
-            elif (_type == TDS_NUMERICNTYPE) |\
-                 (_type == TDS_DECIMALNTYPE):
-                valueLen = ord(data[:1])
+            elif _type in (TDS_NUMERICNTYPE, TDS_DECIMALNTYPE):
+                valueLen = data[0]
                 data = data[1:]
-                value = data[:valueLen]
-                data = data[valueLen:]
-                precision = ord(col['TypeData'][1:2])
-                scale = ord(col['TypeData'][2:3])
-                if valueLen > 0:
-                    isPositiveSign = ord(value[0:1])
-                    if (valueLen-1) == 2:
-                        fmt = '<H'
-                    elif (valueLen-1) == 4:
-                        fmt = '<L'
-                    elif (valueLen-1) == 8:
-                        fmt = '<Q'
-                    else:
-                        # Still don't know how to handle higher values
-                        value = "TODO: Interpret TDS_NUMERICNTYPE correctly"
-                    number = struct.unpack(fmt, value[1:])[0]
-                    number //= math.pow(precision, scale)
-                    if isPositiveSign == 0:
-                        number *= -1
-                    value = number
+
+                if valueLen == 0:
+                    value = "NULL"
                 else:
-                    value = 'NULL'
+                    raw = data[:valueLen]
+                    data = data[valueLen:]
+
+                    precision = col["TypeData"][1]
+                    scale = col["TypeData"][2]
+
+                    sign = 1 if raw[0] == 1 else -1
+                    integer = int.from_bytes(raw[1:], byteorder="little", signed=False)
+
+                    getcontext().prec = precision
+                    number = Decimal(integer)
+
+                    if scale:
+                        number /= Decimal(10) ** scale
+
+                    value = number if sign > 0 else -number
 
             elif _type == TDS_BITNTYPE:
-                #print "BITNTYPE"
+                # print "BITNTYPE"
                 valueSize = ord(data[:1])
                 data = data[1:]
                 if valueSize > 0:
@@ -1792,47 +2024,46 @@ class MSSQL:
                     else:
                         value = data[:valueSize]
                 else:
-                    value = 'NULL'
+                    value = "NULL"
                 data = data[valueSize:]
 
             elif _type == TDS_INTNTYPE:
                 valueSize = ord(data[:1])
                 if valueSize == 1:
-                    fmt = '<B'
+                    fmt = "<B"
                 elif valueSize == 2:
-                    fmt = '<h'
+                    fmt = "<h"
                 elif valueSize == 4:
-                    fmt = '<l'
+                    fmt = "<l"
                 elif valueSize == 8:
-                    fmt = '<q'
+                    fmt = "<q"
                 else:
-                    fmt = ''
+                    fmt = ""
 
                 data = data[1:]
 
                 if valueSize > 0:
-                    value = struct.unpack(fmt,data[:valueSize])[0]
+                    value = struct.unpack(fmt, data[:valueSize])[0]
                     data = data[valueSize:]
                 else:
-                    value = 'NULL'
+                    value = "NULL"
             elif _type == TDS_SSVARIANTTYPE:
-                totalLength = struct.unpack('<L', data[:4])[0]
+                totalLength = struct.unpack("<L", data[:4])[0]
 
                 # Create variant structure with the entire variant data
-                variantData = data[:4 + totalLength]
+                variantData = data[: 4 + totalLength]
                 variant = TDS_SSVARIANT(variantData)
 
                 value = variant.parse()
 
-                data = data[4 + totalLength:]
+                data = data[4 + totalLength :]
             else:
                 raise Exception("ParseROW: Unsupported data type: 0%x" % _type)
 
             if tuplemode:
                 row.append(value)
             else:
-                row[col['Name']] = value
-
+                row[col["Name"]] = value
 
         self.rows.append(row)
 
@@ -1840,42 +2071,46 @@ class MSSQL:
 
     def parseColMetaData(self, token):
         # TODO Add support for more data types!
-        count = token['Count']
+        count = token["Count"]
         if count == 0xFFFF:
             return 0
 
         self.colMeta = []
-        origDataLen = len(token['Data'])
-        data = token['Data']
+        origDataLen = len(token["Data"])
+        data = token["Data"]
         for i in range(count):
             column = {}
-            userType = struct.unpack('<H',data[:struct.calcsize('<H')])[0]
-            data = data[struct.calcsize('<H'):]
-            flags = struct.unpack('<H',data[:struct.calcsize('<H')])[0]
-            data = data[struct.calcsize('<H'):]
-            colType = struct.unpack('<B',data[:struct.calcsize('<B')])[0]
-            data = data[struct.calcsize('<B'):]
-            if (colType == TDS_BITTYPE)    |\
-                 (colType == TDS_INT1TYPE)   |\
-                 (colType == TDS_INT2TYPE)   |\
-                 (colType == TDS_INT8TYPE)   |\
-                 (colType == TDS_DATETIMETYPE) |\
-                 (colType == TDS_DATETIM4TYPE) |\
-                 (colType == TDS_FLT4TYPE)   |\
-                 (colType == TDS_FLT8TYPE)   |\
-                 (colType == TDS_MONEYTYPE)  |\
-                 (colType == TDS_MONEY4TYPE) |\
-                 (colType == TDS_DATENTYPE)  |\
-                 (colType == TDS_INT4TYPE):
-                typeData = ''
-            elif (colType == TDS_INTNTYPE) |\
-                 (colType == TDS_TIMENTYPE) |\
-                 (colType == TDS_DATETIME2NTYPE) |\
-                 (colType == TDS_DATETIMEOFFSETNTYPE) |\
-                 (colType == TDS_FLTNTYPE) |\
-                 (colType == TDS_MONEYNTYPE) |\
-                 (colType == TDS_GUIDTYPE) |\
-                 (colType == TDS_BITNTYPE):
+            userType = struct.unpack("<H", data[: struct.calcsize("<H")])[0]
+            data = data[struct.calcsize("<H") :]
+            flags = struct.unpack("<H", data[: struct.calcsize("<H")])[0]
+            data = data[struct.calcsize("<H") :]
+            colType = struct.unpack("<B", data[: struct.calcsize("<B")])[0]
+            data = data[struct.calcsize("<B") :]
+            if (
+                (colType == TDS_BITTYPE)
+                | (colType == TDS_INT1TYPE)
+                | (colType == TDS_INT2TYPE)
+                | (colType == TDS_INT8TYPE)
+                | (colType == TDS_DATETIMETYPE)
+                | (colType == TDS_DATETIM4TYPE)
+                | (colType == TDS_FLT4TYPE)
+                | (colType == TDS_FLT8TYPE)
+                | (colType == TDS_MONEYTYPE)
+                | (colType == TDS_MONEY4TYPE)
+                | (colType == TDS_DATENTYPE)
+                | (colType == TDS_INT4TYPE)
+            ):
+                typeData = ""
+            elif (
+                (colType == TDS_INTNTYPE)
+                | (colType == TDS_TIMENTYPE)
+                | (colType == TDS_DATETIME2NTYPE)
+                | (colType == TDS_DATETIMEOFFSETNTYPE)
+                | (colType == TDS_FLTNTYPE)
+                | (colType == TDS_MONEYNTYPE)
+                | (colType == TDS_GUIDTYPE)
+                | (colType == TDS_BITNTYPE)
+            ):
                 typeData = ord(data[0:1])
                 data = data[1:]
 
@@ -1885,73 +2120,90 @@ class MSSQL:
                 typeData = ord(data[0:1])
                 data = data[1:]
 
-            elif (colType == TDS_BIGVARBINTYPE) |\
-                 (colType == TDS_BIGBINARYTYPE) |\
-                 (colType == TDS_NCHARTYPE)     |\
-                 (colType == TDS_NVARCHARTYPE)  |\
-                 (colType == TDS_BIGVARCHRTYPE) |\
-                 (colType == TDS_BIGCHARTYPE):
-                typeData = struct.unpack('<H',data[:2])[0]
+            elif (
+                (colType == TDS_BIGVARBINTYPE)
+                | (colType == TDS_BIGBINARYTYPE)
+                | (colType == TDS_NCHARTYPE)
+                | (colType == TDS_NVARCHARTYPE)
+                | (colType == TDS_BIGVARCHRTYPE)
+                | (colType == TDS_BIGCHARTYPE)
+            ):
+                typeData = struct.unpack("<H", data[:2])[0]
                 data = data[2:]
-            elif (colType == TDS_DECIMALNTYPE) |\
-                 (colType == TDS_NUMERICNTYPE) |\
-                 (colType == TDS_DECIMALTYPE):
+            elif (
+                (colType == TDS_DECIMALNTYPE)
+                | (colType == TDS_NUMERICNTYPE)
+                | (colType == TDS_DECIMALTYPE)
+            ):
                 typeData = data[:3]
                 data = data[3:]
-            elif (colType == TDS_IMAGETYPE) |\
-                 (colType == TDS_TEXTTYPE) |\
-                 (colType == TDS_XMLTYPE)  |\
-                 (colType == TDS_SSVARIANTTYPE) |\
-                 (colType == TDS_NTEXTTYPE):
-                typeData = struct.unpack('<L',data[:4])[0]
+            elif (
+                (colType == TDS_IMAGETYPE)
+                | (colType == TDS_TEXTTYPE)
+                | (colType == TDS_XMLTYPE)
+                | (colType == TDS_SSVARIANTTYPE)
+                | (colType == TDS_NTEXTTYPE)
+            ):
+                typeData = struct.unpack("<L", data[:4])[0]
                 data = data[4:]
             else:
                 raise Exception("Unsupported data type: 0x%x" % colType)
 
             # Collation exceptions:
-            if (colType == TDS_NTEXTTYPE) |\
-               (colType == TDS_BIGCHARTYPE)  |\
-               (colType == TDS_BIGVARCHRTYPE)  |\
-               (colType == TDS_NCHARTYPE)  |\
-               (colType == TDS_NVARCHARTYPE)  |\
-               (colType == TDS_TEXTTYPE):
+            if (
+                (colType == TDS_NTEXTTYPE)
+                | (colType == TDS_BIGCHARTYPE)
+                | (colType == TDS_BIGVARCHRTYPE)
+                | (colType == TDS_NCHARTYPE)
+                | (colType == TDS_NVARCHARTYPE)
+                | (colType == TDS_TEXTTYPE)
+            ):
                 # Skip collation
                 data = data[5:]
 
             # PartTableName exceptions:
-            if (colType == TDS_IMAGETYPE) |\
-               (colType == TDS_TEXTTYPE) |\
-               (colType == TDS_NTEXTTYPE):
+            if (
+                (colType == TDS_IMAGETYPE)
+                | (colType == TDS_TEXTTYPE)
+                | (colType == TDS_NTEXTTYPE)
+            ):
                 # This types have Table Elements, we just discard them for now.
                 # ToDo parse this correctly!
                 # Get the Length
-                dataLen = struct.unpack('<H',data[:2])[0]
+                dataLen = struct.unpack("<H", data[:2])[0]
                 data = data[2:]
                 # skip the text
-                data = data[dataLen*2:]
+                data = data[dataLen * 2 :]
 
-            colNameLength = struct.unpack('<B',data[:struct.calcsize('<B')])[0]
-            data = data[struct.calcsize('<B'):]
-            colName = data[:colNameLength*2].decode('utf-16le')
-            data = data[colNameLength*2:]
-            column['Name'] = colName
-            column['Type'] = colType
-            column['TypeData'] = typeData
-            column['Flags'] = flags
+            colNameLength = struct.unpack("<B", data[: struct.calcsize("<B")])[0]
+            data = data[struct.calcsize("<B") :]
+            colName = data[: colNameLength * 2].decode("utf-16le")
+            data = data[colNameLength * 2 :]
+            column["Name"] = colName
+            column["Type"] = colType
+            column["TypeData"] = typeData
+            column["Flags"] = flags
             self.colMeta.append(column)
 
         return origDataLen - len(data)
 
-    def parseReply(self, tokens,tuplemode=False):
+    def parseReply(self, tokens, tuplemode=False):
         if len(tokens) == 0:
             return False
 
         replies = {}
         while len(tokens) > 0:
-            tokenID = struct.unpack('B',tokens[0:1])[0]
+            tokenID = struct.unpack("B", tokens[0:1])[0]
             if tokenID == TDS_ERROR_TOKEN:
                 token = TDS_INFO_ERROR(tokens)
-                self.lastError = SQLErrorException("ERROR(%s): Line %d: %s" % (token['ServerName'].decode('utf-16le'), token['LineNumber'], token['MsgText'].decode('utf-16le')))
+                self.lastError = SQLErrorException(
+                    "ERROR(%s): Line %d: %s"
+                    % (
+                        token["ServerName"].decode("utf-16le"),
+                        token["LineNumber"],
+                        token["MsgText"].decode("utf-16le"),
+                    )
+                )
             elif tokenID == TDS_RETURNSTATUS_TOKEN:
                 token = TDS_RETURNSTATUS(tokens)
             elif tokenID == TDS_INFO_TOKEN:
@@ -1960,28 +2212,27 @@ class MSSQL:
                 token = TDS_LOGIN_ACK(tokens)
             elif tokenID == TDS_ENVCHANGE_TOKEN:
                 token = TDS_ENVCHANGE(tokens)
-                if token['Type'] is TDS_ENVCHANGE_PACKETSIZE:
-                    record = TDS_ENVCHANGE_VARCHAR(token['Data'])
-                    self.packetSize = int( record['NewValue'].decode('utf-16le') )
-                elif token['Type'] is TDS_ENVCHANGE_DATABASE:
-                    record = TDS_ENVCHANGE_VARCHAR(token['Data'])
-                    self.currentDB =  record['NewValue'].decode('utf-16le')
+                if token["Type"] is TDS_ENVCHANGE_PACKETSIZE:
+                    record = TDS_ENVCHANGE_VARCHAR(token["Data"])
+                    self.packetSize = int(record["NewValue"].decode("utf-16le"))
+                elif token["Type"] is TDS_ENVCHANGE_DATABASE:
+                    record = TDS_ENVCHANGE_VARCHAR(token["Data"])
+                    self.currentDB = record["NewValue"].decode("utf-16le")
 
-            elif (tokenID == TDS_DONEINPROC_TOKEN) |\
-                 (tokenID == TDS_DONEPROC_TOKEN):
+            elif (tokenID == TDS_DONEINPROC_TOKEN) | (tokenID == TDS_DONEPROC_TOKEN):
                 token = TDS_DONEINPROC(tokens)
             elif tokenID == TDS_ORDER_TOKEN:
                 token = TDS_ORDER(tokens)
             elif tokenID == TDS_ROW_TOKEN:
-                #print "ROW"
+                # print "ROW"
                 token = TDS_ROW(tokens)
-                tokenLen = self.parseRow(token,tuplemode)
-                token['Data'] = token['Data'][:tokenLen]
+                tokenLen = self.parseRow(token, tuplemode)
+                token["Data"] = token["Data"][:tokenLen]
             elif tokenID == TDS_COLMETADATA_TOKEN:
-                #print "COLMETA"
+                # print "COLMETA"
                 token = TDS_COLMETADATA(tokens)
                 tokenLen = self.parseColMetaData(token)
-                token['Data'] = token['Data'][:tokenLen]
+                token["Data"] = token["Data"][:tokenLen]
             elif tokenID == TDS_DONE_TOKEN:
                 token = TDS_DONE(tokens)
             else:
@@ -1992,49 +2243,47 @@ class MSSQL:
                 replies[tokenID] = list()
 
             replies[tokenID].append(token)
-            tokens = tokens[len(token):]
-            #print "TYPE 0x%x, LEN: %d" %(tokenID, len(token))
-            #print repr(tokens[:10])
+            tokens = tokens[len(token) :]
+            # print "TYPE 0x%x, LEN: %d" %(tokenID, len(token))
+            # print repr(tokens[:10])
 
         return replies
 
-    def batch(self, cmd,tuplemode=False,wait=True):
+    def batch(self, cmd, tuplemode=False, wait=True):
         # First of all we clear the rows, colMeta and lastError
         self.rows = []
         self.colMeta = []
         self.lastError = False
-        self.sendTDS(TDS_SQL_BATCH, (cmd+'\r\n').encode('utf-16le'))
+        self.sendTDS(TDS_SQL_BATCH, (cmd + "\r\n").encode("utf-16le"))
         if wait:
             tds = self.recvTDS()
-            self.replies = self.parseReply(tds['Data'],tuplemode)
+            self.replies = self.parseReply(tds["Data"], tuplemode)
             return self.rows
         else:
             return True
 
-
-    def batchStatement(self, cmd,tuplemode=False):
+    def batchStatement(self, cmd, tuplemode=False):
         # First of all we clear the rows, colMeta and lastError
         self.rows = []
         self.colMeta = []
         self.lastError = False
-        self.sendTDS(TDS_SQL_BATCH, (cmd+'\r\n').encode('utf-16le'))
-        #self.recvTDS()
-
+        self.sendTDS(TDS_SQL_BATCH, (cmd + "\r\n").encode("utf-16le"))
+        # self.recvTDS()
 
     # Handy alias
     sql_query = batch
 
     def changeDB(self, db):
         if db != self.currentDB:
-            chdb = 'use %s' % db
+            chdb = "use %s" % db
             self.batch(chdb)
             self.printReplies()
 
-    def RunSQLQuery(self,db,sql_query,tuplemode=False,wait=True,**kwArgs):
-        db = db or 'master'
+    def RunSQLQuery(self, db, sql_query, tuplemode=False, wait=True, **kwArgs):
+        db = db or "master"
         self.changeDB(db)
         self.printReplies()
-        ret = self.batch(sql_query,tuplemode,wait)
+        ret = self.batch(sql_query, tuplemode, wait)
         if wait:
             self.printReplies()
         if self.lastError:
@@ -2043,8 +2292,8 @@ class MSSQL:
             raise self.lastError
         return ret
 
-    def RunSQLStatement(self,db,sql_query,wait=True,**kwArgs):
-        self.RunSQLQuery(db,sql_query,wait=wait)
+    def RunSQLStatement(self, db, sql_query, wait=True, **kwArgs):
+        self.RunSQLQuery(db, sql_query, wait=wait)
         if self.lastError:
             raise self.lastError
         return True


### PR DESCRIPTION
Hello @gabrielg5 👋

This pull request adds support for parsing SQL Server `sql_variant` types in the TDS protocol implementation. The main change is the introduction of the `TDS_SSVARIANT` class, which can parse and extract the value of a `sql_variant` field according to the [MS-TDS] specification: https://learn.microsoft.com/fr-fr/openspecs/windows_protocols/ms-tds/2435e85d-9e61-492c-acb2-627ffccb5b92

I is useful for queries such as:
```sql
SELECT value_in_use FROM sys.configurations WHERE name = 'show advanced options';
```

Of course, for this specific case, it could be "bypassed" using `CAST(value_in_use AS INT)`, but i thought it could be great to add this type inside the code directly.

Before:
<img width="1157" height="90" alt="image" src="https://github.com/user-attachments/assets/7e51a659-77de-403a-8723-f1264c114f9d" />

After:
<img width="1153" height="112" alt="image" src="https://github.com/user-attachments/assets/869da41b-2b93-4f4a-b177-a6f3560cc468" />


Best regards