### PR TITLE
Add -basic switch to use Basic Authentication in exchanger

### DIFF
--- a/examples/exchanger.py
+++ b/examples/exchanger.py
@@ -922,7 +922,7 @@ if __name__ == '__main__':
 
     list_tables = nspi_attacks.add_parser('list-tables', help='List Address Books')
     list_tables.add_argument('-count', action='store_true', help='Request total number of records in each table')
-    list_tables.add_argument('-basic', action='store_true', help='Authenticate with Basic Auth instead of NTLM')
+    parser.add_argument('-basic', action='store_true', help='Authenticate with Basic Auth instead of NTLM')
 
 
     dump_tables = nspi_attacks.add_parser('dump-tables', formatter_class=SmartFormatter, help='Dump Address Books')


### PR DESCRIPTION
This pull request adds a new command-line switch, _-basic_, to the exchanger script.
When this option is provided, the tool uses HTTP Basic Authentication instead of NTLM.
If the option is not specified, the default NTLM authentication flow remains unchanged.

Some Exchange environments require Basic Authentication instead of NTLM.
This option improves compatibility with such configurations while keeping existing functionality intact.