### PR TITLE
Set lastError when parsing mssql replies

### DIFF
--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -1618,6 +1618,7 @@ class MSSQL:
             tokenID = struct.unpack('B',tokens[0:1])[0]
             if tokenID == TDS_ERROR_TOKEN:
                 token = TDS_INFO_ERROR(tokens)
+                self.lastError = SQLErrorException("ERROR(%s): Line %d: %s" % (token['ServerName'].decode('utf-16le'), token['LineNumber'], token['MsgText'].decode('utf-16le')))
             elif tokenID == TDS_RETURNSTATUS_TOKEN:
                 token = TDS_RETURNSTATUS(tokens)
             elif tokenID == TDS_INFO_TOKEN:


### PR DESCRIPTION
When executing `sql_query()` (`batch()`), the `self.lastError` attribute is not being set when parsing replies with `parseReplies()`. Therefore, you can't check if errors occured during execution without calling `printReplies()` (see line 1198), which does this check.

This is fixed now so 3rd party applications like NetExec can check if error occurred (or for that matter example scripts as well):
Before&After with some changes to the NetExec logic:
<img width="1186" height="173" alt="image" src="https://github.com/user-attachments/assets/51110b5e-eea5-4e29-a267-12a42f71cd66" />
