### PR TITLE
Fix connection issue when Smb2DialectMin is SMB311 on target SMB server

### DIFF
--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -583,55 +583,62 @@ class SMB3:
             negSession['ClientGuid'] = self.ClientGuid
             if preferredDialect is not None:
                 negSession['Dialects'] = [preferredDialect]
-                if preferredDialect == SMB2_DIALECT_311:
-                    # Build the Contexts
-                    contextData = SMB311ContextData()
-                    contextData['NegotiateContextOffset'] = 64+38+2
-                    contextData['NegotiateContextCount'] = 0
-                    # Add an SMB2_NEGOTIATE_CONTEXT with ContextType as SMB2_PREAUTH_INTEGRITY_CAPABILITIES
-                    # to the negotiate request as specified in section 2.2.3.1:
-                    negotiateContext = SMB2NegotiateContext()
-                    negotiateContext['ContextType'] = SMB2_PREAUTH_INTEGRITY_CAPABILITIES
-
-                    preAuthIntegrityCapabilities = SMB2PreAuthIntegrityCapabilities()
-                    preAuthIntegrityCapabilities['HashAlgorithmCount'] = 1
-                    preAuthIntegrityCapabilities['SaltLength'] = 32
-                    preAuthIntegrityCapabilities['HashAlgorithms'] = b'\x01\x00'
-                    preAuthIntegrityCapabilities['Salt'] = ''.join([rand.choice(string.ascii_letters) for _ in
-                                                                     range(preAuthIntegrityCapabilities['SaltLength'])])
-
-                    negotiateContext['Data'] = preAuthIntegrityCapabilities.getData()
-                    negotiateContext['DataLength'] = len(negotiateContext['Data'])
-                    contextData['NegotiateContextCount'] += 1
-                    pad = b'\xFF' * ((8 - (negotiateContext['DataLength'] % 8)) % 8)
-
-                    # Add an SMB2_NEGOTIATE_CONTEXT with ContextType as SMB2_ENCRYPTION_CAPABILITIES
-                    # to the negotiate request as specified in section 2.2.3.1 and initialize
-                    # the Ciphers field with the ciphers supported by the client in the order of preference.
-
-                    negotiateContext2 = SMB2NegotiateContext()
-                    negotiateContext2['ContextType'] = SMB2_ENCRYPTION_CAPABILITIES
-
-                    encryptionCapabilities = SMB2EncryptionCapabilities()
-                    encryptionCapabilities['CipherCount'] = 1
-                    encryptionCapabilities['Ciphers'] = b'\x01\x00'
-
-                    negotiateContext2['Data'] = encryptionCapabilities.getData()
-                    negotiateContext2['DataLength'] = len(negotiateContext2['Data'])
-                    contextData['NegotiateContextCount'] += 1
-
-                    negSession['ClientStartTime'] = contextData.getData()
-                    negSession['Padding'] = b'\xFF\xFF'
-                    # Subsequent negotiate contexts MUST appear at the first 8-byte aligned offset following the
-                    # previous negotiate context.
-                    negSession['NegotiateContextList'] = negotiateContext.getData() + pad + negotiateContext2.getData()
-
-                    # Do you want to enforce encryption? Uncomment here:
-                    #self._Connection['SupportsEncryption'] = True
-
             else:
-                negSession['Dialects'] = [SMB2_DIALECT_002, SMB2_DIALECT_21, SMB2_DIALECT_30]
+                # Offer all supported dialects
+                negSession['Dialects'] = [SMB2_DIALECT_002, SMB2_DIALECT_21, SMB2_DIALECT_30, SMB2_DIALECT_302, SMB2_DIALECT_311]
+            
             negSession['DialectCount'] = len(negSession['Dialects'])
+            # If SMB 3.1.1 is in the dialect list, we must include contexts
+            if SMB2_DIALECT_311 in negSession['Dialects']:
+                # Build the Contexts
+                contextData = SMB311ContextData()
+                # Calculate offset if all dialects or preferred dialect
+                # Note that this assumes 5 dialects are offered
+                if len(negSession['Dialects']) > 1:
+                    contextData['NegotiateContextOffset'] = 64 + 38 + 10
+                else :
+                    contextData['NegotiateContextOffset'] = 64 + 38 + 2
+                contextData['NegotiateContextCount'] = 0
+                # Add an SMB2_NEGOTIATE_CONTEXT with ContextType as SMB2_PREAUTH_INTEGRITY_CAPABILITIES
+                # to the negotiate request as specified in section 2.2.3.1:
+                negotiateContext = SMB2NegotiateContext()
+                negotiateContext['ContextType'] = SMB2_PREAUTH_INTEGRITY_CAPABILITIES
+
+                preAuthIntegrityCapabilities = SMB2PreAuthIntegrityCapabilities()
+                preAuthIntegrityCapabilities['HashAlgorithmCount'] = 1
+                preAuthIntegrityCapabilities['SaltLength'] = 32
+                preAuthIntegrityCapabilities['HashAlgorithms'] = b'\x01\x00'
+                preAuthIntegrityCapabilities['Salt'] = ''.join([rand.choice(string.ascii_letters) for _ in
+                                                                    range(preAuthIntegrityCapabilities['SaltLength'])])
+
+                negotiateContext['Data'] = preAuthIntegrityCapabilities.getData()
+                negotiateContext['DataLength'] = len(negotiateContext['Data'])
+                contextData['NegotiateContextCount'] += 1
+                pad = b'\xFF' * ((8 - (negotiateContext['DataLength'] % 8)) % 8)
+
+                # Add an SMB2_NEGOTIATE_CONTEXT with ContextType as SMB2_ENCRYPTION_CAPABILITIES
+                # to the negotiate request as specified in section 2.2.3.1 and initialize
+                # the Ciphers field with the ciphers supported by the client in the order of preference.
+
+                negotiateContext2 = SMB2NegotiateContext()
+                negotiateContext2['ContextType'] = SMB2_ENCRYPTION_CAPABILITIES
+
+                encryptionCapabilities = SMB2EncryptionCapabilities()
+                encryptionCapabilities['CipherCount'] = 1
+                encryptionCapabilities['Ciphers'] = b'\x01\x00'
+
+                negotiateContext2['Data'] = encryptionCapabilities.getData()
+                negotiateContext2['DataLength'] = len(negotiateContext2['Data'])
+                contextData['NegotiateContextCount'] += 1
+
+                negSession['ClientStartTime'] = contextData.getData()
+                negSession['Padding'] = b'\xFF\xFF'
+                # Subsequent negotiate contexts MUST appear at the first 8-byte aligned offset following the
+                # previous negotiate context.
+                negSession['NegotiateContextList'] = negotiateContext.getData() + pad + negotiateContext2.getData()
+
+                # Do you want to enforce encryption? Uncomment here:
+                #self._Connection['SupportsEncryption'] = True
             packet['Data'] = negSession
 
             packetID = self.sendSMB(packet)


### PR DESCRIPTION
I noticed an error of STATUS_NOT_SUPPORTED when the target SMB server had a minimum dialect of SMB311 (mainly newer windows 11 clients). I made some changes so that if SMB311 is not the preferredDialect, it still gets offered and builds the contexts needed to establish an SMB3.1.1 connection.
<img width="1643" height="793" alt="image" src="https://github.com/user-attachments/assets/07086e00-69cf-4b31-a6e4-2d403f0696e9" />
