### PR TITLE
All Kerberos tickets use chmod 600 by default

### DIFF
--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -227,7 +227,7 @@ class GetUserSPNs:
             ccache = CCache()
             try:
                 ccache.fromTGS(ticket, oldSessionKey, sessionKey)
-                ccache.saveFile('%s.ccache' % username)
+                ccache.saveFile('%s.ccache' % username, chmod=0o600)
             except Exception as e:
                 logging.error(str(e))
 

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -170,7 +170,7 @@ class GETST:
                 service = "%s/%s@%s" % (service_class, service_hostname, service_realm)
             self.__saveFileName += "@" + service.replace("/", "_")
         logging.info('Saving ticket in %s' % (self.__saveFileName + '.ccache'))
-        ccache.saveFile(self.__saveFileName + '.ccache')
+        ccache.saveFile(self.__saveFileName + '.ccache', chmod=0o600)
 
     def doS4U2ProxyWithAdditionalTicket(self, tgt, cipher, oldSessionKey, sessionKey, nthash, aesKey, kdcHost, additional_ticket_path):
         if not os.path.isfile(additional_ticket_path):

--- a/examples/getTGT.py
+++ b/examples/getTGT.py
@@ -54,7 +54,7 @@ class GETTGT:
         ccache = CCache()
 
         ccache.fromTGT(ticket, sessionKey, sessionKey)
-        ccache.saveFile(self.__user + '.ccache')
+        ccache.saveFile(self.__user + '.ccache', chmod=0o600)
 
     def run(self):
         userName = Principal(self.__user, type=options.principalType.value)

--- a/examples/goldenPac.py
+++ b/examples/goldenPac.py
@@ -1009,7 +1009,7 @@ class MS14_068:
                         from impacket.krb5.ccache import CCache
                         ccache = CCache()
                         ccache.fromTGS(tgs, oldSessionKey, sessionKey)
-                        ccache.saveFile(self.__writeTGT)
+                        ccache.saveFile(self.__writeTGT, chmod=0o600)
                     break
             if exception is None:
                 # Success!

--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -1233,7 +1233,7 @@ class RAISECHILD:
             from impacket.krb5.ccache import CCache
             ccache = CCache()
             ccache.fromTGT(parentTGT['KDC_REP'], parentTGT['oldSessionKey'], parentTGT['sessionKey'])
-            ccache.saveFile(self.__writeTGT)
+            ccache.saveFile(self.__writeTGT, chmod=0o600)
 
         # 8) If target was specified, a PSEXEC shell is launched
         if self.__target is not None:

--- a/examples/ticketConverter.py
+++ b/examples/ticketConverter.py
@@ -72,7 +72,7 @@ def is_ccache_file(filename):
 
 def convert_kirbi_to_ccache(input_filename, output_filename):
     ccache = CCache.loadKirbiFile(input_filename)
-    ccache.saveFile(output_filename)
+    ccache.saveFile(output_filename, chmod=0o600)
 
 
 def convert_ccache_to_kirbi(input_filename, output_filename):

--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -1092,7 +1092,7 @@ class TICKETER:
             ccache.fromTGT(ticket, sessionKey, sessionKey)
         else:
             ccache.fromTGS(ticket, sessionKey, sessionKey)
-        ccache.saveFile(self.__target.replace('/','.') + '.ccache')
+        ccache.saveFile(self.__target.replace('/','.') + '.ccache', chmod=0o600)
 
     def run(self):
         ticket, adIfRelevant = self.createBasicTicket()

--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -590,10 +590,12 @@ class CCache:
         except FileNotFoundError as e:
             raise e
 
-    def saveFile(self, fileName):
+    def saveFile(self, fileName, chmod=None):
         f = open(fileName, 'wb+')
         f.write(self.getData())
         f.close()
+        if chmod is not None:
+            os.chmod(fileName, chmod)
 
     @classmethod
     def parseFile(cls, domain='', username='', target=''):

--- a/impacket/krb5/keytab.py
+++ b/impacket/krb5/keytab.py
@@ -22,11 +22,13 @@ from datetime import datetime
 from enum import Enum
 from six import b
 
-from struct import pack, unpack, calcsize
+from struct import unpack
 from binascii import hexlify
 
 from impacket.structure import Structure
 from impacket import LOG
+
+import os
 
 
 class Enctype(Enum):
@@ -281,10 +283,12 @@ class Keytab:
             LOG.warning("No matching key for SPN '%s' in given keytab found!", username)
 
 
-    def saveFile(self, fileName):
+    def saveFile(self, fileName, chmod=0o600):
         f = open(fileName, 'wb+')
         f.write(self.getData())
         f.close()
+        if chmod is not None:
+            os.chmod(fileName, chmod)
 
     def prettyPrint(self):
         print("Keytab Entries:")


### PR DESCRIPTION
When forging or retrieving Kerberos tickets using impacket, they are created without specific umask.
This PR forces the use of 600 chmod by default to improve:

- Security of tickets
- The use of samba related tools. Indeed, smbclient and other binaries of the suite will refuse tickets having wrong permissions but the error message is not explicit. This may mislead users.