### PR TITLE
Fix parsing STs from S4U2Self

### DIFF
--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -435,13 +435,13 @@ class CCache:
                     if cachedSPN == b(searchSPN):
                         LOG.debug('Returning cached credential for %s' % c['server'].prettyPrint().upper().decode('utf-8'))
                         return c
-                    else:
-                        # Should be of form 'hostname$@REALM'
-                        cachedSPN = (c['server'].prettyPrint().upper().split(b'@')[0].split(b':')[0] + b'@' + c['server'].prettyPrint().upper().split(b'@')[1])
-                        searchSPN = f"{server.upper().split('/')[1].split('@')[0].split(':')[0].split('.')[0]}$@{server.upper().split('/')[1].split('@')[1]}"
-                        if cachedSPN == b(searchSPN):
-                            LOG.debug('Returning cached credential for %s' % c['server'].prettyPrint().upper().decode('utf-8'))
-                            return c
+                else:
+                    # Should be of form 'hostname$@REALM'
+                    cachedSPN = (c['server'].prettyPrint().upper().split(b'@')[0].split(b':')[0] + b'@' + c['server'].prettyPrint().upper().split(b'@')[1])
+                    searchSPN = f"{server.upper().split('/')[1].split('@')[0].split(':')[0].split('.')[0]}$@{server.upper().split('/')[1].split('@')[1]}"
+                    if cachedSPN == b(searchSPN):
+                        LOG.debug('Returning cached credential for %s' % c['server'].prettyPrint().upper().decode('utf-8'))
+                        return c
 
         return None
 


### PR DESCRIPTION
When debugging and fixing https://github.com/Pennyw0rth/NetExec/pull/1014 i realized that Service Tickets generated by the S4U2Self extension are of form `hostname$@REALM` which therefore were not parsed by the Ccache parsing logic, which is looking for the full SPN `service/fqdn`.

This is fixed by assuming a credential without a slash is not in the typical SPN format. Upon checking if the host matches the `hostname$@REALM` it is returned as such a ticket is valid for any service.

Before&After in NetExec:
<img width="1568" height="310" alt="image" src="https://github.com/user-attachments/assets/aaf37920-7b71-4dc2-bb2c-37a4ab358442" />

The generated ticket:
<img width="1589" height="573" alt="image" src="https://github.com/user-attachments/assets/44818546-d60d-4ea8-9f75-11d8021f1be7" />
Normal ticket:
<img width="1576" height="227" alt="image" src="https://github.com/user-attachments/assets/d56e494c-9a37-480d-8e8f-92b667c0938f" />
<img width="1576" height="599" alt="image" src="https://github.com/user-attachments/assets/3da360c5-587f-400b-9edd-526103eaf4c1" />


Sources:
https://eladshamir.com/2019/01/28/Wagging-the-Dog.html#solving-a-sensitive-problem