### PR TITLE
Fix Kerberos key decryption from LSA when using Kerberos auth

### DIFF
--- a/impacket/examples/regsecrets.py
+++ b/impacket/examples/regsecrets.py
@@ -77,7 +77,12 @@ class RemoteOperations:
         """
         if self.__smbConnection.getServerName() == '':
             host, _ = self.getMachineNameAndDomain()
-            domain = self.__smbConnection.getRemoteName().split(f"{host}.")[1]
+            remoteName = self.__smbConnection.getRemoteName()
+            # Check if remoteName is FQDN, otherwise it will likely be the hostname only and we can't build the salt
+            if remoteName.lower().startswith(f"{host.lower()}."):
+                domain = ".".join(remoteName.split(".")[1:])
+            else:
+                return b''
         else:
             host = self.__smbConnection.getServerName()
             domain = self.__smbConnection.getServerDNSDomainName()

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -762,7 +762,12 @@ class RemoteOperations:
         """
         if self.__smbConnection.getServerName() == '':
             host, _ = self.getMachineNameAndDomain()
-            domain = self.__smbConnection.getRemoteName().split(f"{host}.")[1]
+            remoteName = self.__smbConnection.getRemoteName()
+            # Check if remoteName is FQDN, otherwise it will likely be the hostname only
+            if remoteName.lower().startswith(f"{host.lower()}."):
+                domain = ".".join(remoteName.split(".")[1:])
+            else:
+                return b''
         else:
             host = self.__smbConnection.getServerName()
             domain = self.__smbConnection.getServerDNSDomainName()


### PR DESCRIPTION
Until now dumping LSA secrets did not retrieve Kerberos keys (AES and DES keys) when using Kerberos auth. This is due to a missing implementation of creating the salt value when we can not simply get the server and domain names from the SMB connection (likely populated with values from the NTLM handshake).

This PR fixes salt creation when using kerberos by crafting the salt with the NetBIOS name and remoteName of the machine, if the remoteName is the FQDN of the host.

Related PR issue: https://github.com/Pennyw0rth/NetExec/issues/55

Before patch using NetExec:
<img width="1590" height="681" alt="image" src="https://github.com/user-attachments/assets/e51517a3-73b7-4d67-ade3-7497ab01378b" />

After patch using NetExec:
<img width="1593" height="781" alt="image" src="https://github.com/user-attachments/assets/f61950e6-c738-457b-908e-13e95b420ac5" />

Before Patch secretsdump/regsecrets:
<img width="1585" height="667" alt="image" src="https://github.com/user-attachments/assets/efaba170-390d-4462-b4e4-4926debdec7b" />
<img width="1584" height="566" alt="image" src="https://github.com/user-attachments/assets/7e02fd8d-41d1-4c59-84c2-49457ef08299" />

After Patch secretsdump/regsecrets:
<img width="1585" height="724" alt="image" src="https://github.com/user-attachments/assets/2a3aab93-262e-4a5e-8539-91e16fe1e06c" />
<img width="1584" height="618" alt="image" src="https://github.com/user-attachments/assets/a4c64ced-07bb-49d2-bae4-7e1e2521afaa" />
