### PR TITLE
Fix KeyError 'identity' in ImpacketFormatter to support external tools

### DIFF
--- a/impacket/examples/logger.py
+++ b/impacket/examples/logger.py
@@ -43,6 +43,8 @@ class ImpacketFormatter(logging.Formatter):
     else:
       record.bullet = '[-]'
 
+    if not hasattr(record, 'identity'): record.identity = ''
+
     return logging.Formatter.format(self, record)
 
 class ImpacketFormatterTimeStamp(ImpacketFormatter):


### PR DESCRIPTION
Issue: The recent addition of %(identity)s to the log format string causes a ValueError in external tools (e.g., krbrelayx) that utilize Impacket's logger but do not populate this attribute.

Fix: Added a fallback in ImpacketFormatter.format to default record.identity to an empty string if the attribute is undefined.