### PR TITLE
Add CRUD methods to ldap

### DIFF
--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -610,12 +610,12 @@ class LDAPConnection:
 
                 # prepare changed values. Integer values need to be converted to string
                 vals = []
-                for op in ops:
-                    if isinstance(op[1], list):
-                        vals.extend([str(val) if isinstance(val, int) else val for val in op[1]])
-                    else:
-                        vals.append(str(op[1]) if isinstance(op[1], int) else op[1])
+                if isinstance(op[1], list):
+                    vals.extend([str(val) if isinstance(val, int) else val for val in op[1]])
+                else:
+                    vals.append(str(op[1]) if isinstance(op[1], int) else op[1])
                 modifyRequest['changes'][idx]['modification']['vals'].setComponents(*vals)
+                idx += 1
 
         response = self.sendReceive(modifyRequest, controls)[0]['protocolOp']
         if response['modifyResponse']['resultCode'] != ResultCode('success'):
@@ -624,6 +624,7 @@ class LDAPConnection:
                 errorString=f"Error in modifyRequest -> {response['modifyResponse']['resultCode'].prettyPrint()}: {response['modifyResponse']['diagnosticMessage']}"
             )
         return True
+
     def modify_dn(self, dn, newrdn, deleteoldrdn=True, newSuperior=None, controls=None):
         """
         Modify the Distinguished Name of an entry in the LDAP directory.


### PR DESCRIPTION
Until now for all modification operations ldap3 must be used, due to the lack of CRUD methods in ldap (yeah R=read exists, but w/e).

This is now supported!
The implementation is very close to the syntax of the corresponding ldap3 calls in order to be a drop-in-place. Therefore, all existing calls should be able to be replaced by simply switching to impackets ldap. Keep in mind that ldap3 returns `False` together with populating `connection.last_error`, while impackets implementation raises an error. Therefore, error handling must be adjusted. If there are issues (now or in the future) where impackets ldap does not behave similar to ldap3 please hit me up.

Subsequently, all existing ldap3 adaptations inside of impacket and NetExec can gradually be replaced by impackets ldap implementation.
Example of adding, modifying and deleting a computer object from NetExec:
<img width="2713" height="1048" alt="image" src="https://github.com/user-attachments/assets/43abffae-9d60-44a2-b851-bbe6833810b1" />

Note that i have not tested the `modify_dn()` function because i had no proper use-case (at least that worked). Since it is pretty simple, i don't think i have messed it up.