### PR TITLE
Remove run-time dependency on setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     data_files=data_files,
 
     install_requires=['pyasn1>=0.2.3', 'pyasn1_modules', 'pycryptodomex', 'pyOpenSSL', 'six', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6',
-                      'ldapdomaindump>=0.9.0', 'flask>=1.0', 'setuptools', 'charset_normalizer'],
+                      'ldapdomaindump>=0.9.0', 'flask>=1.0', 'charset_normalizer'],
     extras_require={':sys_platform=="win32"': ['pyreadline3'],
                     },
     classifiers=[


### PR DESCRIPTION
It's needed to run `setup.py` itself, but that's not what `install_requires` is for, and the rest of the package no longer uses it (since #2036).

I deliberately left the entry in `requirements.txt` in place, since that's used by CI.