### PR TITLE
feat: added --base64 option to ticketConverter

### DIFF
--- a/examples/ticketConverter.py
+++ b/examples/ticketConverter.py
@@ -27,6 +27,7 @@
 #   - https://github.com/rvazarkar/KrbCredExport
 #
 
+import os
 import argparse
 import base64
 import struct
@@ -52,7 +53,7 @@ def main():
     args = parse_args()
 
     if args.base64:
-        decoded_file = tempfile.NamedTemporaryFile(mode='w+b')
+        decoded_file = tempfile.NamedTemporaryFile(mode='w+b', delete=False)
         print('[*] base64 decoding ticket')
         decoded_file.write(base64_decode_with_unwrap(args.input_file))
         decoded_file.flush()
@@ -69,6 +70,14 @@ def main():
         print('[+] done')
     else:
         print('[X] unknown file format')
+    
+    # Cleanup manually to avoid issues with Windows delete permissions
+    if args.base64:
+        try:
+            decoded_file.close()
+            os.unlink(decoded_file.name)
+        except PermissionError:
+            print('[!] Failed to clean temporary files due to PermissionError')
 
 
 def is_kirbi_file(filename):


### PR DESCRIPTION
# A story of pain and sorrow
Tools like Rubeus write base64-encoded Kirbi tickets to the terminal. I often find myself repeating this sequence:
1. Re-run Rubeus with `/unwrap`
2. Copy the ticket
3. Save into `ticket.kirbi.b64`
4. Decode `base64 -d ticket.kirbi.b64 > ticket.kirbi`
5. `ticketConverter.py ticket.kirbi ticket.ccache`

# `ticketConverter`'s current behavior
`ticketConverter.py` currently only works with binary tickets. If it receives a base64-encoded ticket it fails:
```bash
$ ticketConverter.py ticket.kirbi.b64 ticket.ccache
Impacket v0.13.0.dev0+20251002.113829.eaf2e556 - Copyright Fortra, LLC and its affiliated companies

[X] unknown file format
```

# How this commit ends the pain
Added a new option `-b`/`--base64`:
```bash
$ ticketConverter.py -h
Impacket v0.13.0.dev0+20251002.113829.eaf2e556 - Copyright Fortra, LLC and its affiliated companies

usage: ticketConverter.py [-h] [-b] input_file output_file

positional arguments:
  input_file    File in kirbi (KRB-CRED) or ccache format
  output_file   Output file

options:
  -h, --help    show this help message and exit
  -b, --base64  Decode input ticket from base64 with unwrap support
```

Example with base64-encoded Kirbi ticket:
```bash
$ ticketConverter.py ticket.kirbi.b64 ticket.ccache --base64
Impacket v0.13.0.dev0+20251002.113829.eaf2e556 - Copyright Fortra, LLC and its affiliated companies

[*] base64 decoding ticket
[*] converting kirbi to ccache...
[+] done
```

Seamlessly works the other way too:
```bash
$ ticketConverter.py ticket.ccache.b64 ticket.kirbi --base64
Impacket v0.13.0.dev0+20251002.113829.eaf2e556 - Copyright Fortra, LLC and its affiliated companies

[*] base64 decoding ticket
[*] converting ccache to kirbi...
[+] done
```

# Code edits
I made sure the commit is as non-invasive as possible.

It only adds a new function `base64_decode_with_unwrap` which is only applied if the `-b/--base64` is provided. Otherwise, everything behaves as before.