### PR TITLE
Make KeyCreds compatible with January 2026 patch

### DIFF
--- a/impacket/examples/ntlmrelayx/utils/shadow_credentials.py
+++ b/impacket/examples/ntlmrelayx/utils/shadow_credentials.py
@@ -20,6 +20,7 @@ from cryptography.hazmat.backends import default_backend
 from Cryptodome.IO import PEM
 from cryptography.hazmat.primitives.serialization import pkcs12
 
+
 def getTicksNow():
     # https://learn.microsoft.com/en-us/dotnet/api/system.datetime.ticks?view=net-5.0#system-datetime-ticks
     dt_now = datetime.datetime.now(datetime.timezone.utc)
@@ -82,8 +83,7 @@ class KeyCredential():
         self.__usage = (0x4,pack("<B",0x01))
         self.__source = (0x5,pack("<B",0x0))
         self.__deviceId = (0x6,deviceId)
-        self.__customKeyInfo = (0x7,pack("<BB",0x1,0x0))
-        self.__lastLogonTime = (0x8,pack("<Q",currentTime))
+        self.__customKeyInfo = (0x7,pack("<BB",0x1,0x2))
         self.__creationTime = (0x9,pack("<Q",currentTime))
 
         self.__version = 0x200
@@ -109,7 +109,6 @@ class KeyCredential():
                             self.__source,
                             self.__deviceId,
                             self.__customKeyInfo,
-                            self.__lastLogonTime,
                             self.__creationTime,
                          ])
 


### PR DESCRIPTION
Fix shadow credentials to comply with validated write requirements

Changes based on keycred commit e2e477c:

1. Set CustomKeyInformation flags to 0x02 (MFA_NOT_USED) instead of 0x00
2. Remove KeyApproximateLastLogonTimeStamp entry (violates validated write rules)

References:
- https://github.com/RedTeamPentesting/keycred/commit/e2e477c01f8462f8cd54775214612c25a4622b31
- https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/f70afbcc-780e-4d91-850c-cfadce5bb15c


<img width="1643" height="449" alt="image" src="https://github.com/user-attachments/assets/fb696e86-7468-4099-9bb3-ad614f3b7d7c" />
