### PR TITLE
Fix LDAP add() failing with TypeError when using list-valued attributes

### DIFF
--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -570,7 +570,7 @@ class LDAPConnection:
         for key, value in attributes.items():
             addRequest['attributes'][index]['type'] = key
             if isinstance(value, list):
-                addRequest['attributes'][index]['vals'].setComponents(str(val) if isinstance(val, int) else val for val in value)
+                addRequest['attributes'][index]['vals'].setComponents(*(str(val) if isinstance(val, int) else val for val in value))
             else:
                 addRequest['attributes'][index]['vals'].setComponents(str(value) if isinstance(value, int) else value)
             index += 1


### PR DESCRIPTION
When using the `LDAP add()` method with attributes whose values are lists (e.g. servicePrincipalName when adding a computer account), the call raises a TypeError.

Cause : `In setComponents()`, a generator expression was passed directly instead of being unpacked. `pyasn1's setComponents()` expects each value as a separate argument, not a single generator object.

Fix : Use the unpacking operator `(*)` so the generator’s values are passed as individual arguments :

```
addRequest['attributes'][index]['vals'].setComponents(*(str(val) if isinstance(val, int) else val for val in value))
```

For example on Netexec : 

Before : 

<img width="1639" height="98" alt="image" src="https://github.com/user-attachments/assets/bf6909e7-694c-40f3-b633-e6d1f6c65b06" />

After : 

<img width="1636" height="105" alt="image" src="https://github.com/user-attachments/assets/3f8f5f8e-2aac-407b-b472-c8e59b753b2a" />
