### PR TITLE
Modified reg-key creation to assume persistent key creation with impacket-reg

### DIFF
--- a/examples/reg.py
+++ b/examples/reg.py
@@ -186,7 +186,7 @@ class RegHandler:
             if self.__action == 'QUERY':
                 self.query(dce, self.__options.keyName)
             elif self.__action == 'ADD':
-                self.add(dce, self.__options.keyName, self.__options.volatile)
+                self.add(dce, self.__options.keyName, self.__options.persistent)
             elif self.__action == 'DELETE':
                 self.delete(dce, self.__options.keyName)
             elif self.__action == 'SAVE':
@@ -256,13 +256,8 @@ class RegHandler:
                     # ans5 = rrp.hBaseRegGetVersion(rpc, ans2['phkResult'])
                     # ans3 = rrp.hBaseRegEnumKey(rpc, ans2['phkResult'], 0)
 
-    def add(self, dce, keyName, volatile):
+    def add(self, dce, keyName, persistent):
         hRootKey, subKey = self.__strip_root_key(dce, keyName)
-        
-        # Convert volatile flag into option.
-        dwOption = 0x00000000
-        if volatile is True:
-            dwOption = 0x00000001
 
 
         # READ_CONTROL | rrp.KEY_SET_VALUE | rrp.KEY_CREATE_SUB_KEY should be equal to KEY_WRITE (0x20006)
@@ -274,6 +269,15 @@ class RegHandler:
                                        samDesired=READ_CONTROL | rrp.KEY_SET_VALUE | rrp.KEY_CREATE_SUB_KEY)
 
             # Should I use ans2?
+
+            # Convert persistant flag into the relevant dwOption.
+            # dwOption 0 = Persistent
+            # dwOption 1 = Volatile
+            dwOption = 0x00000001
+            if persistent is True:
+                dwOption = 0x00000000
+            else:
+                print('[!] The created key is volatile and will not remain after a reboot. ')
 
             ans3 = rrp.hBaseRegCreateKey(
                 dce, hRootKey, subKeyCreate, dwOptions=dwOption,
@@ -576,8 +580,8 @@ if __name__ == '__main__':
     add_parser.add_argument('-vd', action='append', metavar="VALUEDATA", required=False, help='Specifies the registry '
                            'value data that is to be set. In case of adding a REG_MULTI_SZ value, set this option once for each '
                            'line you want to add.', default=[])
-    add_parser.add_argument('--volatile', action='store_true', required=False, help='Specify that the key is intended to be volitile '
-                            'and deleted upon system reboot')
+    add_parser.add_argument('--persistent', action='store_true', required=False, help='Specify that the created key is intended to be persistent '
+                            'through reboot. Default is volatile key creation')
 
     # An delete command
     delete_parser = subparsers.add_parser('delete', help='Deletes a subkey or entries from the registry')


### PR DESCRIPTION
# Pull Request

## Description

When creating registry keys using impacket-reg, the default behavior is to create a registry key that is volatile and as such is deleted upon reboot. This is not specified in the documentation, and limits use of the tooling.

## Change

A flag has been introduced to impacket-reg add functionality that when used specifies that the key created is to be volatile. An assumption has been made that users not specifying this flag desires a persistant key to be created. If this assumption is false, then switching the requirement around would be trivial