### PR TITLE
ntlmrelayx.py: Fix SMB relay server not gracefully replying to SMB packets

### DIFF
--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -154,7 +154,9 @@ class SMBRelayServer(Thread):
                     self.target = self.targetprocessor.getTarget(multiRelay=False)
                 else:
                     LOG.info('(SMB): Connection from %s controlled, but there are no more targets left!' % connData['ClientIP'])
-                    return [SMB2Error()], None, STATUS_BAD_NETWORK_NAME
+                    respPacket['Status'] = STATUS_BAD_NETWORK_NAME
+                    respPacket['Data'] = SMB2Error()
+                    return None, [respPacket], STATUS_BAD_NETWORK_NAME
 
             LOG.info("(SMB): Received connection from %s, attacking target %s://%s" % (connData['ClientIP'], self.target.scheme, self.target.netloc))
 


### PR DESCRIPTION
If a negotiate SMB packet is incoming, smb2support is enabled and no targets are remaining, before this would throw an exception while trying to parse the SMB packet as an SMB2 packet:
```
Traceback (most recent call last):
  File
"/Users/roman/.local/pipx/venvs/impacket/lib/python3.13/site-packages/impacket/smbserver.py",
line 4191, in handle
    resp = self.__SMB.processRequest(self.__connId, p.get_trailer())
  File
"/Users/roman/.local/pipx/venvs/impacket/lib/python3.13/site-packages/impacket/smbserver.py",
line 4865, in processRequest
    respPacket['CreditRequestResponse'] =
packet['CreditRequestResponse']

~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File
"/Users/roman/.local/pipx/venvs/impacket/lib/python3.13/site-packages/impacket/structure.py",
line 186, in __getitem__
    return self.fields[key]
           ~~~~~~~~~~~^^^^^
KeyError: 'CreditRequestResponse'
```
By sending the SMB2 packet response directly instead of the command, this should now work properly.

Seems to be only surfacing now as the exceptions were commented out before:
https://github.com/fortra/impacket/blame/a023ef32f230ac8bbbd4d19c5ebfc4e6673e6397/impacket/smbserver.py#L4199-L4204