### PR TITLE
fix: Unhandled ValueError during authentication

### DIFF
--- a/impacket/structure.py
+++ b/impacket/structure.py
@@ -537,7 +537,10 @@ class Structure:
 
         # asciiz specifier
         if format[:1] == 'z':
-            return data.index(self.b('\x00'))+1
+            try:
+                return data.index(self.b('\x00'))+1
+            except ValueError:
+                raise ValueError("Can't find NUL terminator in field '%s'" % field)
 
         # asciiz specifier
         if format[:1] == 'u':
@@ -550,7 +553,7 @@ class Structure:
             # NUL-NUL terminator not found
             hex_data = str(hexlify(data).decode('ascii'))
             utf16_chunks = [hex_data[i:i + 4] for i in range(0, len(hex_data), 4)]
-            raise ValueError("Can't find NUL-NUL terminator in UTF-16le string '%s'" % ' '.join(utf16_chunks))
+            raise ValueError("Can't find NUL-NUL terminator in UTF-16le field '%s': '%s'" % (field, ' '.join(utf16_chunks)))
 
         # DCE-RPC/NDR string specifier
         if format[:1] == 'w':


### PR DESCRIPTION

Fixes #2099

### Problem
When SMB authentication fails due to incomplete server responses (network drops, timeouts), users see:
```
ValueError: subsection not found
```

This error message doesn't indicate what failed or which field caused the issue.

### Solution
Added exception handling to catch the ValueError and provide a clearer error message:
```
ValueError: Can't find NUL terminator in field 'NativeOS'
```

### Changes
- `impacket/structure.py`: Added try/except block for ASCII string parsing (3 lines)
- Additionally modify UTF-16le error