### PR TITLE
Support channel binding in init_ldap_session()

### DIFF
--- a/examples/dacledit.py
+++ b/examples/dacledit.py
@@ -716,6 +716,7 @@ def parse_args():
     parser = argparse.ArgumentParser(add_help=True, description='Python editor for a principal\'s DACL.')
     parser.add_argument('identity', action='store', help='domain.local/username[:password]')
     parser.add_argument('-use-ldaps', action='store_true', help='Use LDAPS instead of LDAP')
+    parser.add_argument('-use-channel-binding', action='store_true', help='Enable LDAPS Channel Binding')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
 
@@ -769,7 +770,7 @@ def main():
     domain, username, password, lmhash, nthash, args.k = parse_identity(args.identity, args.hashes, args.no_pass, args.aesKey, args.k)
 
     try:
-        ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.dc_host, args.aesKey, args.use_ldaps)
+        ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.dc_host, args.aesKey, args.use_ldaps, args.use_channel_binding)
         dacledit = DACLedit(ldap_server, ldap_session, args)
         if args.action == 'read':
             dacledit.read()

--- a/examples/owneredit.py
+++ b/examples/owneredit.py
@@ -230,6 +230,7 @@ def parse_args():
     parser = argparse.ArgumentParser(add_help=True, description='Python editor for a principal\'s DACL.')
     parser.add_argument('identity', action='store', help='domain.local/username[:password]')
     parser.add_argument('-use-ldaps', action='store_true', help='Use LDAPS instead of LDAP')
+    parser.add_argument('-use-channel-binding', action='store_true', help='Enable LDAPS Channel Binding')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
 
@@ -278,7 +279,7 @@ def main():
     domain, username, password, lmhash, nthash, args.k = parse_identity(args.identity, args.hashes, args.no_pass, args.aesKey, args.k)
 
     try:
-        ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.dc_host, args.aesKey, args.use_ldaps)
+        ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.dc_host, args.aesKey, args.use_ldaps, args.use_channel_binding)
         owneredit = OwnerEdit(ldap_server, ldap_session, args)
         if args.action == 'read':
             owneredit.read()

--- a/examples/rbcd.py
+++ b/examples/rbcd.py
@@ -272,6 +272,7 @@ def parse_args():
                         help='Action to operate on msDS-AllowedToActOnBehalfOfOtherIdentity')
 
     parser.add_argument('-use-ldaps', action='store_true', help='Use LDAPS instead of LDAP')
+    parser.add_argument('-use-channel-binding', action='store_true', help='Enable LDAPS Channel Binding')
 
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
@@ -314,7 +315,7 @@ def main():
     domain, username, password, lmhash, nthash, args.k = parse_identity(args.identity, args.hashes, args.no_pass, args.aesKey, args.k)
 
     try:
-        ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.dc_host, args.aesKey, args.use_ldaps)
+        ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.dc_host, args.aesKey, args.use_ldaps, args.use_channel_binding)
         rbcd = RBCD(ldap_server, ldap_session, args.delegate_to)
         if args.action == 'read':
             rbcd.read()


### PR DESCRIPTION
This PR uses cannatag/ldap3#1087 to enable LDAP Channel Binding in multiple example scripts.

<img width="1919" height="365" alt="image" src="https://github.com/user-attachments/assets/97f337b6-0f06-48fa-a072-7e2624273449" />

#1657 was closed accidentally. This PR is the successor.