### PR TITLE
Several ntlmrelayx SMBv1 server fixes

### DIFF
--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -783,7 +783,7 @@ class SMBRelayServer(Thread):
         self.authUser = authenticateMessage.getUserString()
 
         if self.config.disableMulti:
-            return self.smbComTreeConnectAndX(connId, smbServer, SMBCommand, recvPacket)
+            return self.origsmbComTreeConnectAndX(connId, smbServer, SMBCommand, recvPacket)
         # Uncommenting this will stop at the first connection relayed and won't relaying until all targets
         # are processed. There might be a use case for this
         #if 'relayToHost' in connData:

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -766,8 +766,8 @@ class SMBRelayServer(Thread):
                 # Now continue with the server
             #############################################################
 
-        respData['NativeOS']     = smbServer.getServerOS()
-        respData['NativeLanMan'] = smbServer.getServerOS()
+        #respData['NativeOS']     = smbServer.getServerOS()
+        #respData['NativeLanMan'] = smbServer.getServerOS()
         respSMBCommand['Parameters'] = respParameters
         respSMBCommand['Data']       = respData
 

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -235,7 +235,7 @@ class SMBRelayServer(Thread):
         #############################################################
         # SMBRelay
         # Are we ready to relay or should we just do local auth?
-        if not self.config.disableMulti and 'relayToHost' not in connData:
+        if not self.config.disableMulti and (('relayToHost' not in connData) or not connData['relayToHost']):
             # Just call the original SessionSetup
             respCommands, respPackets, errorCode = self.origSmbSessionSetup(connId, smbServer, recvPacket)
             # We remove the Guest flag
@@ -386,7 +386,7 @@ class SMBRelayServer(Thread):
 
                 connData['Authenticated'] = True
                 if not self.config.disableMulti:
-                    del(connData['relayToHost'])
+                    connData['relayToHost'] = False
                 self.do_attack(client)
                 # Now continue with the server
             #############################################################
@@ -555,7 +555,7 @@ class SMBRelayServer(Thread):
         #############################################################
         # SMBRelay
         # Are we ready to relay or should we just do local auth?
-        if not self.config.disableMulti and 'relayToHost' not in connData:
+        if not self.config.disableMulti and (('relayToHost' not in connData) or not connData['relayToHost']):
             # Just call the original SessionSetup
             return self.origSmbSessionSetupAndX(connId, smbServer, SMBCommand, recvPacket)
         # We have confirmed we want to relay to the target host.
@@ -689,7 +689,7 @@ class SMBRelayServer(Thread):
 
                 # Done with the relay for now.
                 connData['Authenticated'] = True
-                del(connData['relayToHost'])
+                connData['relayToHost'] = False
 
                 # Status SUCCESS
                 errorCode = STATUS_SUCCESS
@@ -761,7 +761,7 @@ class SMBRelayServer(Thread):
                 # Done with the relay for now.
                 connData['Authenticated'] = True
                 if not self.config.disableMulti:
-                    del(connData['relayToHost'])
+                    connData['relayToHost'] = False
                 self.do_attack(client)
                 # Now continue with the server
             #############################################################


### PR DESCRIPTION
* `relayToHost` was sometimes not properly set, so I changed it to how it is done in the other smbrelayservers.

* The infinite loop seems like a copy paste error.

* The `NativeOS`/`NativeLanMan` related changes caused a MacOS Samba Server to not respond and Wireshark marks the packet also as malformed, but I did not look forther into this, so this could also be ignored from the commits.
