### PR TITLE
Add support for SASL and SIMPLE authentication and RootDSE queries in ntlmrelayx.py LDAP(s) SOCKS

### DIFF
--- a/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
@@ -51,6 +51,14 @@ class LDAPRelayClient(ProtocolClient):
         self.authenticateMessageBlob = None
         self.server = None
 
+    def getServerInfoUnauth(self):
+        with Connection(self.server, authentication='ANONYMOUS') as conn:
+            conn.search(search_base='',
+                        search_filter='(objectClass=*)',
+                        search_scope='BASE',
+                        attributes=['*'])
+            self.sessionData['LDAP_INFO'] = conn.entries[0]
+
     def killConnection(self):
         if self.session is not None:
             self.session.socket.close()
@@ -59,6 +67,7 @@ class LDAPRelayClient(ProtocolClient):
     def initConnection(self):
         self.server = Server("ldap://%s:%s" % (self.targetHost, self.targetPort), get_info=ALL)
         self.session = Connection(self.server, user="a", password="b", authentication=NTLM)
+        self.getServerInfoUnauth()
         self.session.open(False)
         return True
 
@@ -163,7 +172,7 @@ class LDAPRelayClient(ProtocolClient):
             search_filter='(objectClass=*)',
             search_scope='BASE',
             attributes=['namingContexts'])
-
+    
 class LDAPSRelayClient(LDAPRelayClient):
     PLUGIN_NAME = "LDAPS"
     MODIFY_ADD = MODIFY_ADD

--- a/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
@@ -184,5 +184,6 @@ class LDAPSRelayClient(LDAPRelayClient):
     def initConnection(self):
         self.server = Server("ldaps://%s:%s" % (self.targetHost, self.targetPort), get_info=ALL)
         self.session = Connection(self.server, user="a", password="b", authentication=NTLM)
+        self.performRootDSEQuery()
         self.session.open(False)
         return True

--- a/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
@@ -172,7 +172,7 @@ class LDAPRelayClient(ProtocolClient):
             search_filter='(objectClass=*)',
             search_scope='BASE',
             attributes=['namingContexts'])
-    
+
 class LDAPSRelayClient(LDAPRelayClient):
     PLUGIN_NAME = "LDAPS"
     MODIFY_ADD = MODIFY_ADD

--- a/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
@@ -51,8 +51,9 @@ class LDAPRelayClient(ProtocolClient):
         self.authenticateMessageBlob = None
         self.server = None
 
-    def getServerInfoUnauth(self):
+    def performRootDSEQuery(self):
         with Connection(self.server, authentication='ANONYMOUS') as conn:
+            LOG.debug('LDAP: Performing RootDSE query')
             conn.search(search_base='',
                         search_filter='(objectClass=*)',
                         search_scope='BASE',
@@ -67,7 +68,7 @@ class LDAPRelayClient(ProtocolClient):
     def initConnection(self):
         self.server = Server("ldap://%s:%s" % (self.targetHost, self.targetPort), get_info=ALL)
         self.session = Connection(self.server, user="a", password="b", authentication=NTLM)
-        self.getServerInfoUnauth()
+        self.performRootDSEQuery()
         self.session.open(False)
         return True
 

--- a/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
@@ -57,7 +57,7 @@ class LDAPRelayClient(ProtocolClient):
             conn.search(search_base='',
                         search_filter='(objectClass=*)',
                         search_scope='BASE',
-                        attributes=['*'])
+                        attributes=['*', '+'])
             self.sessionData['LDAP_INFO'] = conn.entries[0]
 
     def killConnection(self):

--- a/impacket/examples/ntlmrelayx/servers/socksplugins/ldap.py
+++ b/impacket/examples/ntlmrelayx/servers/socksplugins/ldap.py
@@ -278,52 +278,6 @@ class LDAPSocksRelay(SocksRelay):
                         except Exception as e:
                             LOG.error(f"[EXCEPTION]: {str(e)}")
                             return False
-                        '''
-                        username = chall_response['user_name'].decode('utf-16le')
-                        domain = chall_response['domain_name'].decode('utf-16le')
-                        self.username = f'{domain}/{username}'
-
-                        # Checking for the two formats the domain can have (taken from both HTTP and SMB socks plugins)
-                        if f'{domain}/{username}'.upper() in self.activeRelays:
-                            self.username = f'{domain}/{username}'.upper()
-                        elif f'{domain.split(".", 1)[0]}/{username}'.upper() in self.activeRelays:
-                            self.username = f'{domain.split(".", 1)[0]}/{username}'.upper()
-                        else:
-                            # Username not in active relays
-                            LOG.error('LDAP: No session for %s@%s(%s) available' % (
-                                username, self.targetHost, self.targetPort))
-                            return False
-
-                        if self.activeRelays[self.username]['inUse'] is True:
-                            LOG.error('LDAP: Connection for %s@%s(%s) is being used at the moment!' % (
-                                self.username, self.targetHost, self.targetPort))
-                            return False
-                        else:
-                            LOG.info('LDAP: Proxying client session for %s@%s(%s)' % (
-                                self.username, self.targetHost, self.targetPort))
-                            self.activeRelays[self.username]['inUse'] = True
-                            self.session = self.activeRelays[self.username]['protocolClient'].session.socket
-
-                        # Load negotiate message
-                        bindresponse = BindResponse()
-                        bindresponse['resultCode'] = ResultCode('saslBindInProgress')
-                        bindresponse['matchedDN'] = LDAPDN('')
-                        bindresponse['diagnosticMessage'] = LDAPString('')
-                       # bindresponse['serverSaslCreds'] = 
-
-                        SPNEGO_wrapped_negotiateMessage = SPNEGO_NegTokenInit()
-                        SPNEGO_wrapped_negotiateMessage['MechTypes'] = [TypesMech['NTLMSSP - Microsoft NTLM Security Support Provider']]
-                        SPNEGO_wrapped_negotiateMessage['MechToken'] = self.negotiateMessage
-
-                        bindRequest = BindRequest()
-                        bindRequest['version'] = 3
-                        bindRequest["name"] = b""
-                        bindRequest['authentication'] = msg_component['authentication']
-                        bindRequest['authentication']['sasl']['mechanism'] = 'GSS-SPNEGO'
-                        bindRequest['authentication']['sasl']['credentials'] = SPNEGO_wrapped_negotiateMessage.getData()
-
-                        #req = self.
-                        '''
                     else:
                         LOG.error('LDAP: Received an unknown LDAP binding request, cannot continue')
                         return False

--- a/impacket/examples/ntlmrelayx/servers/socksplugins/ldap.py
+++ b/impacket/examples/ntlmrelayx/servers/socksplugins/ldap.py
@@ -239,8 +239,8 @@ class LDAPSocksRelay(SocksRelay):
 
                             response['attributes'].append(attribs)
                         elif msg_component['scope'] == Scope('baseObject') and msg_component['baseObject'] == LDAPDN(''):
-                            # Initial Unauth searchRequest
-                            LOG.debug('LDAP: Client requested server information')
+                            # RootDSE Query
+                            LOG.debug('LDAP: Client performed RootDSE query')
                             response = SearchResultEntry()
                             response['objectName'] = LDAPDN('')
                             response['attributes'] = PartialAttributeList()

--- a/impacket/examples/ntlmrelayx/servers/socksplugins/ldap.py
+++ b/impacket/examples/ntlmrelayx/servers/socksplugins/ldap.py
@@ -2,6 +2,7 @@ import select
 from pyasn1.codec.ber import encoder, decoder
 from pyasn1.error import SubstrateUnderrunError
 from pyasn1.type import univ
+from ldap3.core.exceptions import LDAPKeyError
 
 from impacket import LOG, ntlm
 from impacket.examples.ntlmrelayx.servers.socksserver import SocksRelay
@@ -138,7 +139,25 @@ class LDAPSocksRelay(SocksRelay):
                         # Received a SASL NTLM bindRequest
 
                         # Parsing authentication method
-                        saslCredentials = msg_component['authentication']['sasl']['credentials'].asOctets()
+                        saslCredentialsField = msg_component['authentication']['sasl']['credentials']
+                        if not saslCredentialsField.isValue:
+                            LOG.error('LDAP: Received SASL bind request without credentials')
+                            bindresponse = BindResponse()
+                            bindresponse['resultCode'] = ResultCode('protocolError')
+                            bindresponse['matchedDN'] = LDAPDN('')
+                            bindresponse['diagnosticMessage'] = LDAPString('SASL credentials are required')
+                            self.send_ldap_msg(bindresponse, message['messageID'])
+                            return False
+
+                        saslCredentials = saslCredentialsField.asOctets()
+                        if len(saslCredentials) == 0:
+                            LOG.error('LDAP: Received SASL bind request with empty credentials')
+                            bindresponse = BindResponse()
+                            bindresponse['resultCode'] = ResultCode('protocolError')
+                            bindresponse['matchedDN'] = LDAPDN('')
+                            bindresponse['diagnosticMessage'] = LDAPString('SASL credentials are required')
+                            self.send_ldap_msg(bindresponse, message['messageID'])
+                            return False
 
                         if saslCredentials[0] == 0x60: # SPNEGO_NEG_TOKEN_INIT
                             LOG.debug('LDAP: Got SASL bind request')
@@ -241,19 +260,7 @@ class LDAPSocksRelay(SocksRelay):
                         elif msg_component['scope'] == Scope('baseObject') and msg_component['baseObject'] == LDAPDN(''):
                             # RootDSE Query
                             LOG.debug('LDAP: Client performed RootDSE query')
-                            response = SearchResultEntry()
-                            response['objectName'] = LDAPDN('')
-                            response['attributes'] = PartialAttributeList()
-
-                            # Return all requested attributes
-                            for attribute in msg_component['attributes']:
-                                reqAttrStr = attribute.asOctets().decode('utf-8')
-                                attrVal = self.sessionData['LDAP_INFO'][reqAttrStr]
-                                partialAttr = PartialAttribute()
-                                partialAttr.setComponentByName('type', attribute)
-                                partialAttr.setComponentByName('vals', univ.SetOf(componentType=AttributeValue()))
-                                partialAttr.getComponentByName('vals').setComponentByPosition(0, AttributeValue(str(attrVal).encode('utf-8')))
-                                response['attributes'].append(partialAttr)
+                            response = self.build_RootDSE_response(msg_component['attributes'])
                         else:
                             # Any other message triggers the closing of client connection
                             return False
@@ -398,6 +405,114 @@ class LDAPSocksRelay(SocksRelay):
             pass
 
         return True
+
+    def build_RootDSE_response(self, requested_attributes):
+        response = SearchResultEntry()
+        response['objectName'] = LDAPDN('')
+        response['attributes'] = PartialAttributeList()
+
+        for attribute_name in self.get_RootDSE_attribute_names(requested_attributes):
+            values = self.get_RootDSE_attribute_values(attribute_name)
+            if values is None:
+                LOG.debug('LDAP: Skipping unavailable RootDSE attribute %s' % attribute_name)
+                continue
+
+            partialAttr = PartialAttribute()
+            partialAttr.setComponentByName('type', attribute_name)
+            partialAttr.setComponentByName('vals', univ.SetOf(componentType=AttributeValue()))
+            for pos, value in enumerate(values):
+                partialAttr.getComponentByName('vals').setComponentByPosition(pos, AttributeValue(value))
+            response['attributes'].append(partialAttr)
+
+        return response
+
+    def get_RootDSE_attribute_names(self, requested_attributes):
+        if len(requested_attributes) == 0:
+            return self.get_cached_RootDSE_attribute_names()
+
+        attribute_names = []
+        for attribute in requested_attributes:
+            attribute_name = attribute.asOctets().decode('utf-8')
+            if attribute_name == '1.1':
+                return []
+            elif attribute_name in ('*', '+'):
+                attribute_names.extend(self.get_cached_RootDSE_attribute_names())
+            else:
+                attribute_names.append(attribute_name)
+
+        seen = set()
+        unique_attribute_names = []
+        for attribute_name in attribute_names:
+            lower_attribute_name = attribute_name.lower()
+            if lower_attribute_name not in seen:
+                seen.add(lower_attribute_name)
+                unique_attribute_names.append(attribute_name)
+
+        return unique_attribute_names
+
+    def get_cached_RootDSE_attribute_names(self):
+        rootDSE = self.sessionData['LDAP_INFO']
+        if isinstance(rootDSE, dict):
+            return list(rootDSE.keys())
+        elif hasattr(rootDSE, 'entry_attributes'):
+            return list(rootDSE.entry_attributes)
+        elif hasattr(rootDSE, 'entry_raw_attributes'):
+            return list(rootDSE.entry_raw_attributes.keys())
+        else:
+            return []
+
+    def get_RootDSE_attribute_values(self, attribute_name):
+        rootDSE = self.sessionData['LDAP_INFO']
+
+        if attribute_name.lower() == 'supportedcapabilities':
+            return [
+                b'1.2.840.113556.1.4.800',
+                b'1.2.840.113556.1.4.1670',
+                b'1.2.840.113556.1.4.1791',
+                b'1.2.840.113556.1.4.1935',
+                b'1.2.840.113556.1.4.2080',
+                b'1.2.840.113556.1.4.2237',
+            ]
+        elif attribute_name.lower() == 'supportedsaslmechanisms':
+            # Force NTLMSSP to avoid parsing every type of authentication.
+            return [b'NTLM']
+
+        try:
+            attribute_value = rootDSE[attribute_name]
+        except (KeyError, LDAPKeyError):
+            attribute_value = self.get_case_insensitive_RootDSE_attribute(attribute_name)
+
+        if attribute_value is None:
+            return None
+
+        if hasattr(attribute_value, 'raw_values'):
+            values = attribute_value.raw_values
+        elif hasattr(attribute_value, 'values'):
+            values = attribute_value.values
+        elif isinstance(attribute_value, (list, tuple, set)):
+            values = attribute_value
+        else:
+            values = [attribute_value]
+
+        return [self.encode_RootDSE_attribute_value(value) for value in values]
+
+    def get_case_insensitive_RootDSE_attribute(self, attribute_name):
+        rootDSE = self.sessionData['LDAP_INFO']
+        if not isinstance(rootDSE, dict):
+            return None
+
+        for key, value in rootDSE.items():
+            if key.lower() == attribute_name.lower():
+                return value
+
+        return None
+
+    @staticmethod
+    def encode_RootDSE_attribute_value(value):
+        if isinstance(value, bytes):
+            return value
+        else:
+            return str(value).encode('utf-8')
 
     def build_NTLM_challenge(self, isSicily):
         # Reuse the challenge message from the real authentication with the server

--- a/impacket/examples/ntlmrelayx/servers/socksplugins/ldaps.py
+++ b/impacket/examples/ntlmrelayx/servers/socksplugins/ldaps.py
@@ -27,6 +27,9 @@ class LDAPSSocksRelay(SSLServerMixin, LDAPSocksRelay):
                 # Shut down TLS connection
                 self.socksSocket.shutdown()
                 return False
+        except SSL.ZeroReturnError:
+            LOG.warning('LDAPS: Client closed TLS/SSL connection')
+            return False
         except SSL.SysCallError:
             LOG.warning('Cannot wrap client socket in TLS/SSL')
             return False

--- a/tests/test_ntlmrelayx_ldap_socks.py
+++ b/tests/test_ntlmrelayx_ldap_socks.py
@@ -1,0 +1,146 @@
+from pyasn1.codec.ber import decoder, encoder
+
+from impacket.examples.ntlmrelayx.servers.socksplugins.ldap import LDAPSocksRelay
+from impacket.ldap.ldapasn1 import (
+    AttributeSelection,
+    BindRequest,
+    LDAPDN,
+    LDAPMessage,
+    LDAPString,
+    ResultCode,
+)
+
+
+class FakeSocket:
+    def __init__(self, recv_data):
+        self.recv_data = list(recv_data)
+        self.sent_data = []
+
+    def recv(self, _size):
+        if len(self.recv_data) == 0:
+            return b''
+        return self.recv_data.pop(0)
+
+    def sendall(self, data):
+        self.sent_data.append(data)
+
+
+def get_relay(root_dse=None, sock=None):
+    active_relays = {'data': {'LDAP_INFO': root_dse or {}}}
+    return LDAPSocksRelay('dc.test.local', 389, sock, active_relays)
+
+
+def get_requested_attributes(*attributes):
+    selection = AttributeSelection()
+    for pos, attribute in enumerate(attributes):
+        selection.setComponentByPosition(pos, LDAPString(attribute))
+    return selection
+
+
+def get_response_attributes(response):
+    attributes = {}
+    for partial_attribute in response['attributes']:
+        name = partial_attribute['type'].asOctets().decode('utf-8')
+        values = [
+            value.asOctets().decode('utf-8')
+            for value in partial_attribute['vals']
+        ]
+        attributes[name] = values
+    return attributes
+
+
+def test_rootdse_wildcard_expands_cached_attributes():
+    relay = get_relay({
+        'namingContexts': [
+            'DC=test,DC=local',
+            'CN=Configuration,DC=test,DC=local',
+        ],
+        'defaultNamingContext': 'DC=test,DC=local',
+    })
+
+    response = relay.build_RootDSE_response(get_requested_attributes('*'))
+    attributes = get_response_attributes(response)
+
+    assert '*' not in attributes
+    assert attributes['namingContexts'] == [
+        'DC=test,DC=local',
+        'CN=Configuration,DC=test,DC=local',
+    ]
+    assert attributes['defaultNamingContext'] == ['DC=test,DC=local']
+
+
+def test_rootdse_empty_attribute_selection_expands_cached_attributes():
+    relay = get_relay({'defaultNamingContext': 'DC=test,DC=local'})
+
+    response = relay.build_RootDSE_response(AttributeSelection())
+    attributes = get_response_attributes(response)
+
+    assert attributes == {'defaultNamingContext': ['DC=test,DC=local']}
+
+
+def test_rootdse_multivalued_attributes_are_encoded_separately():
+    relay = get_relay({
+        'namingContexts': [
+            'DC=test,DC=local',
+            'CN=Configuration,DC=test,DC=local',
+        ],
+        'supportedControl': [
+            '1.2.840.113556.1.4.319',
+            '1.2.840.113556.1.4.473',
+        ],
+    })
+
+    response = relay.build_RootDSE_response(
+        get_requested_attributes('namingContexts', 'supportedControl')
+    )
+    attributes = get_response_attributes(response)
+
+    assert attributes['namingContexts'] == [
+        'DC=test,DC=local',
+        'CN=Configuration,DC=test,DC=local',
+    ]
+    assert attributes['supportedControl'] == [
+        '1.2.840.113556.1.4.319',
+        '1.2.840.113556.1.4.473',
+    ]
+
+
+def test_rootdse_missing_attributes_are_omitted():
+    relay = get_relay({'defaultNamingContext': 'DC=test,DC=local'})
+
+    response = relay.build_RootDSE_response(
+        get_requested_attributes('missingAttribute', 'defaultNamingContext')
+    )
+    attributes = get_response_attributes(response)
+
+    assert attributes == {'defaultNamingContext': ['DC=test,DC=local']}
+
+
+def test_rootdse_no_attrs_selector_returns_no_attributes():
+    relay = get_relay({'defaultNamingContext': 'DC=test,DC=local'})
+
+    response = relay.build_RootDSE_response(get_requested_attributes('1.1'))
+
+    assert len(response['attributes']) == 0
+
+
+def test_sasl_bind_without_credentials_returns_protocol_error():
+    bind_request = BindRequest()
+    bind_request['version'] = 3
+    bind_request['name'] = LDAPDN('')
+    sasl = bind_request['authentication'].getComponentByName('sasl')
+    sasl['mechanism'] = LDAPString('GSS-SPNEGO')
+    bind_request['authentication'].setComponentByName('sasl', sasl)
+
+    message = LDAPMessage()
+    message['messageID'] = 1
+    message['protocolOp'].setComponentByType(bind_request.getTagSet(), bind_request)
+
+    sock = FakeSocket([encoder.encode(message)])
+    relay = get_relay(sock=sock)
+
+    assert relay.skipAuthentication() is False
+
+    response_message, _ = decoder.decode(sock.sent_data[0], asn1Spec=LDAPMessage())
+    bind_response = response_message['protocolOp'].getComponent()
+    assert bind_response['resultCode'] == ResultCode('protocolError')


### PR DESCRIPTION
Adds two features to the LDAP and LDAPS SOCKS plugins.
- Adds support for SASL and SIMPLE authentication mechanisms
- Adds support for RootDSE queries

This allows tools that do not use Sicily authentication to proxy through the LDAP(s) SOCKS relay, and handles RootDSE queries that are commonly performed prior to authentication. Overall, this increases the compatibility of the LDAP(s) SOCKS plugins.

Some technical details about this update:
- SASL and Sicily authentication send similar `BindResponse` NTLMSSP_CHALLENGE responses, prompting the creation of the `build_NTLM_challenge()` function to reduce code repetition
- Similarly, the creation of the `check_proxy_sessions()` function was needed to reduce the code repetition between all three (3) authentication mechanisms when verifying the authenticating user
- The LDAP relay client will now perform a RootDSE query upon initial connection to the target LDAP server. This is to add support for all future client RootDSE queries performed through the LDAP(s) SOCKS plugin as unauthenticated queries cannot be passed through

Please let me know if there are any improvements or changes that I can make.

Here are some examples of tools that are supported with this PR:

### Netexec
```
$ proxychains -q nxc ldap 10.129.231.186 --port 389 -d certified.htb -u judith.mader -p proxy --simple-bind --users                  
LDAP        10.129.231.186  389    DC01             [*] None (name:DC01) (domain:certified.htb) (signing:None) (channel binding:Unknown) (NTLM:False)
LDAP        10.129.231.186  389    DC01             [+] certified.htb\judith.mader:proxy 
LDAP        10.129.231.186  389    DC01             [*] Enumerated 9 domain users: certified.htb
LDAP        10.129.231.186  389    DC01             -Username-                    -Last PW Set-       -BadPW-  -Description-                                               
LDAP        10.129.231.186  389    DC01             Administrator                 2024-05-13 08:53:16 0        Built-in account for administering the computer/domain      
LDAP        10.129.231.186  389    DC01             Guest                         <never>             0        Built-in account for guest access to the computer/domain    
LDAP        10.129.231.186  389    DC01             krbtgt                        2024-05-13 09:02:51 0        Key Distribution Center Service Account                     
LDAP        10.129.231.186  389    DC01             judith.mader                  2024-05-14 13:22:11 0                                                                    
LDAP        10.129.231.186  389    DC01             management_svc                2024-05-13 09:30:51 0                                                                    
LDAP        10.129.231.186  389    DC01             ca_operator                   2024-05-13 09:32:03 0                                                                    
LDAP        10.129.231.186  389    DC01             alexander.huges               2024-05-14 10:39:08 0                                                                    
LDAP        10.129.231.186  389    DC01             harry.wilson                  2024-05-14 10:39:37 0                                                                    
LDAP        10.129.231.186  389    DC01             gregory.cameron               2024-05-14 10:40:05 0
```

### ldapsearch
```
$ proxychains -q ldapsearch -x -D 'judith.mader@certified.htb' -w test -H ldap://10.129.231.186 -b 'dc=certified,dc=htb' '(samaccountname=judith.mader)' samaccountname 
# extended LDIF
#
# LDAPv3
# base <dc=certified,dc=htb> with scope subtree
# filter: (samaccountname=judith.mader)
# requesting: samaccountname 
#

# Judith Mader, Users, certified.htb
dn: CN=Judith Mader,CN=Users,DC=certified,DC=htb
sAMAccountName: judith.mader

# search reference
ref: ldap://ForestDnsZones.certified.htb/DC=ForestDnsZones,DC=certified,DC=htb

# search reference
ref: ldap://DomainDnsZones.certified.htb/DC=DomainDnsZones,DC=certified,DC=htb

# search reference
ref: ldap://certified.htb/CN=Configuration,DC=certified,DC=htb

# search result
search: 2
result: 0 Success

# numResponses: 5
# numEntries: 1
# numReferences: 3
```