### PR TITLE
GetUserSPNs.py - Added a switch not to force RC4-HMAC when requesting a TGT

### DIFF
--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -81,6 +81,7 @@ class GetUserSPNs:
         self.__nthash = ''
         self.__no_preauth = cmdLineOptions.no_preauth
         self.__outputFileName = cmdLineOptions.outputfile
+        self.__noRC4 = cmdLineOptions.no_rc4
         self.__usersFile = cmdLineOptions.usersfile
         self.__aesKey = cmdLineOptions.aesKey
         self.__doKerberos = cmdLineOptions.k
@@ -134,6 +135,9 @@ class GetUserSPNs:
         # If no clear text password is provided, we just go with the defaults.
         if self.__password != '' and (self.__lmhash == '' and self.__nthash == ''):
             try:
+                if (self.__noRC4):
+                    raise
+
                 tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, '', self.__domain,
                                                                         compute_lmhash(self.__password),
                                                                         compute_nthash(self.__password), self.__aesKey,
@@ -473,6 +477,7 @@ if __name__ == '__main__':
                                                                           '<username>.ccache. Auto selects -request')
     parser.add_argument('-outputfile', action='store',
                         help='Output filename to write ciphers in JtR/hashcat format. Auto selects -request')
+    parser.add_argument('-no-rc4', action='store_true', default=False, help='Does not force RC4-HMAC for the TGT')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output.')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
 

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -133,11 +133,8 @@ class GetUserSPNs:
         # password to ntlm hashes (that will force to use RC4 for the TGT). If that doesn't work, we use the
         # cleartext password.
         # If no clear text password is provided, we just go with the defaults.
-        if self.__password != '' and (self.__lmhash == '' and self.__nthash == ''):
+        if self.__password != '' and (self.__lmhash == '' and self.__nthash == '') and not self.__noRC4:
             try:
-                if (self.__noRC4):
-                    raise
-
                 tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, '', self.__domain,
                                                                         compute_lmhash(self.__password),
                                                                         compute_nthash(self.__password), self.__aesKey,


### PR DESCRIPTION
Newer servers (e.g., 2025) won't issue service tickets when provided with RC4-HMAC TGT. Default functionality stays the same unless the script is provided with the `-no-rc4` argument.