### PR TITLE
Fix TS_ALL_PROCESSES_INFO parsing for RpcWinStationGetAllProcesses

### DIFF
--- a/examples/tstool.py
+++ b/examples/tstool.py
@@ -314,20 +314,20 @@ class TSHandler:
         options = self.__options
         with TSTS.LegacyAPI(self.__smbConnection, options.target_ip, self.__doKerberos) as legacy:
             handle = legacy.hRpcWinStationOpenServer()
-            r = legacy.hRpcWinStationGetAllProcesses(handle)
-            if not len(r):
+            process_entry_list = legacy.hRpcWinStationGetAllProcesses(handle)
+            if not len(process_entry_list):
                 return None
 
             self.sids = {}
-            for procInfo in r:
-                sid = procInfo['pSid']
+            for process_entry in process_entry_list:
+                sid = process_entry.getSid()
                 if sid[:2] == 'S-' and sid not in self.sids:
                     self.sids[sid] = sid
             
             self.lookupSids()
 
-            maxImageNameLen = max([len(i['ImageName']) for i in r])
-            maxSidLen = max([len(i['pSid']) for i in r])
+            maxImageNameLen = max([len(process_entry.getProcessInfo()['ImageNameSize'].getValue()) for process_entry in process_entry_list])
+            maxSidLen = max([len(process_entry.getSid()) for process_entry in process_entry_list])
             if options.verbose:
                 self.get_session_list()
                 self.enumerate_sessions_config()
@@ -365,35 +365,37 @@ class TSHandler:
                                                         )+'\n'
                      )
 
-                for procInfo in r:
-                    sessId = procInfo['SessionId']
+                for process_entry in process_entry_list:
+                    process_info = process_entry.getProcessInfo()
+                    sessId = process_info['SessionId']
                     fullUserName = ''
                     if len(self.sessions[sessId]['Domain']):
                         fullUserName += self.sessions[sessId]['Domain'] + '\\'
                     if len(self.sessions[sessId]['Username']):
                         fullUserName += self.sessions[sessId]['Username']
                     row = template.replace('{workingset: <12}','{workingset: >10,} K').format(
-                                          imagename   = procInfo['ImageName'],
-                                          pid         = procInfo['UniqueProcessId'],
+                                          imagename   = process_info['ImageNameSize'].getValue(),
+                                          pid         = process_info['UniqueProcessId'],
                                           sessionName = self.sessions[sessId]['SessionName'],
-                                          sessid      = procInfo['SessionId'],
+                                          sessid      = process_info['SessionId'],
                                           sessstate   = self.sessions[sessId]['state'].replace('Disconnected','Disc'),
-                                          sid         = self.sidToUser(procInfo['pSid']),
+                                          sid         = self.sidToUser(process_entry.getSid()),
                                           sessionuser = fullUserName,
-                                          workingset  = procInfo['WorkingSetSize']//1000
+                                          workingset  = process_info['WorkingSetSize']//1000
                                          )
                     print(row)
             else:
                 template = '{: <%d} {: <8} {: <11} {: <%d} {: >12}' % (maxImageNameLen, maxSidLen)
                 print(template.format('Image Name', 'PID', 'Session#', 'SID', 'Mem Usage'))
                 print(template.replace(': ',':=').format('','','','','')+'\n')
-                for procInfo in r:
+                for process_entry in process_entry_list:
+                    process_info = process_entry.getProcessInfo()
                     row = template.format(
-                                procInfo['ImageName'],
-                                procInfo['UniqueProcessId'],
-                                procInfo['SessionId'],
-                                self.sidToUser(procInfo['pSid']),
-                                '{:,} K'.format(procInfo['WorkingSetSize']//1000),
+                                process_info['ImageNameSize'].getValue(),
+                                process_info['UniqueProcessId'],
+                                process_info['SessionId'],
+                                self.sidToUser(process_entry.getSid()),
+                                '{:,} K'.format(process_info['WorkingSetSize']//1000),
                             )
                     print(row)
 
@@ -410,7 +412,8 @@ class TSHandler:
                 if not len(r):
                     LOG.error('Could not get process list')
                     return
-                pidList = [i['UniqueProcessId'] for i in r if i['ImageName'].lower() == options.name.lower()]
+                pidList = [i.getProcessInfo()['UniqueProcessId'] for i in r
+                           if i.getProcessInfo()['ImageNameSize'].getValue().lower() == options.name.lower()]
                 if not len(pidList):
                     LOG.error('Could not find %r in process list' % options.name)
                     return

--- a/examples/tstool.py
+++ b/examples/tstool.py
@@ -326,7 +326,7 @@ class TSHandler:
             
             self.lookupSids()
 
-            maxImageNameLen = max([len(process_entry.getProcessInfo()['ImageNameSize'].getValue()) for process_entry in process_entry_list])
+            maxImageNameLen = max([len(process_entry.getProcessInfo()['ImageName'].getValue()) for process_entry in process_entry_list])
             maxSidLen = max([len(process_entry.getSid()) for process_entry in process_entry_list])
             if options.verbose:
                 self.get_session_list()
@@ -374,7 +374,7 @@ class TSHandler:
                     if len(self.sessions[sessId]['Username']):
                         fullUserName += self.sessions[sessId]['Username']
                     row = template.replace('{workingset: <12}','{workingset: >10,} K').format(
-                                          imagename   = process_info['ImageNameSize'].getValue(),
+                                          imagename   = process_info['ImageName'].getValue(),
                                           pid         = process_info['UniqueProcessId'],
                                           sessionName = self.sessions[sessId]['SessionName'],
                                           sessid      = process_info['SessionId'],
@@ -391,7 +391,7 @@ class TSHandler:
                 for process_entry in process_entry_list:
                     process_info = process_entry.getProcessInfo()
                     row = template.format(
-                                process_info['ImageNameSize'].getValue(),
+                                process_info['ImageName'].getValue(),
                                 process_info['UniqueProcessId'],
                                 process_info['SessionId'],
                                 self.sidToUser(process_entry.getSid()),
@@ -413,7 +413,7 @@ class TSHandler:
                     LOG.error('Could not get process list')
                     return
                 pidList = [i.getProcessInfo()['UniqueProcessId'] for i in r
-                           if i.getProcessInfo()['ImageNameSize'].getValue().lower() == options.name.lower()]
+                           if i.getProcessInfo()['ImageName'].getValue().lower() == options.name.lower()]
                 if not len(pidList):
                     LOG.error('Could not find %r in process list' % options.name)
                     return

--- a/impacket/dcerpc/v5/tsts.py
+++ b/impacket/dcerpc/v5/tsts.py
@@ -34,7 +34,7 @@ from impacket.dcerpc.v5 import transport
 from impacket.uuid import uuidtup_to_bin, bin_to_string, string_to_bin
 from impacket.dcerpc.v5.ndr import NDR, NDRCALL, NDRSTRUCT, NDRENUM, NDRUNION, NDRUniConformantArray, \
     NDRPOINTER, NDRUniConformantVaryingArray, UNKNOWNDATA
-from impacket.dcerpc.v5.dtypes import NULL, BOOL, BOOLEAN, STR, WSTR, LPWSTR, WIDESTR, RPC_UNICODE_STRING, \
+from impacket.dcerpc.v5.dtypes import NULL, BOOL, BOOLEAN, STR, WSTR, LPWSTR, WIDESTR, \
     LONG, UINT, ULONG, PULONG, LPDWORD, LARGE_INTEGER, DWORD, NDRHYPER, USHORT, UCHAR, PCHAR, BYTE, PBYTE, \
     UUID, GUID
 from impacket import system_errors
@@ -203,6 +203,18 @@ class TS_UNICODE_STRING(NDRSTRUCT):
         ('MaximumLength', USHORT),
         ('Buffer', LPWSTR),
     )
+    def getValue(self):
+        # [MS-TSTS] 2.2.2.15.1.1 TS_UNICODE_STRING / [MS-DTYP] RPC_UNICODE_STRING:
+        # a null PWSTR means there is no string buffer to decode, so expose ''.
+        if self.fields['Buffer'].fields['ReferentID'] == 0:
+            return ''
+        rawBuffer = self.fields['Buffer'].fields['Data'].fields['Data']
+        value = rawBuffer[:self['Length']].decode('utf-16le')
+        # Some servers appear to count the terminating UTF-16 NUL inside Length
+        # even though UNICODE_STRING semantics say the logical value excludes it.
+        if value.endswith('\x00'):
+            return value[:-1]
+        return value
 
 class TS_LPCHAR(NDRPOINTER):
     referent = (
@@ -257,6 +269,7 @@ class LPUCHAR_ARRAY(NDRPOINTER):
     referent = (
         ('Data', UCHAR_ARRAY),
     )
+
 class WCHAR_ARRAY_32(WIDESTR_STRIPPED):
     length = 32
 class WCHAR_ARRAY_256(WIDESTR_STRIPPED):
@@ -1314,6 +1327,7 @@ class pResult_ENUM(NDRENUM):
 
 
 # 2.2.2.15.1 TS_SYS_PROCESS_INFORMATION
+# https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/96702c7d-6f5f-4965-8f29-5fdbea73278e
 class TS_SYS_PROCESS_INFORMATION(NDRSTRUCT):
     structure = (
          ('NextEntryOffset', ULONG),
@@ -1324,7 +1338,7 @@ class TS_SYS_PROCESS_INFORMATION(NDRSTRUCT):
          ('CreateTime', LARGE_INTEGER),
          ('UserTime', LARGE_INTEGER),
          ('KernelTime', LARGE_INTEGER),
-         ('ImageNameSize', RPC_UNICODE_STRING), 
+         ('ImageNameSize', TS_UNICODE_STRING),
          ('BasePriority', LONG),
          ('UniqueProcessId', DWORD),
          ('InheritedFromUniqueProcessId', DWORD),
@@ -1343,8 +1357,6 @@ class TS_SYS_PROCESS_INFORMATION(NDRSTRUCT):
          ('PagefileUsage', ULONG), #SIZE_T
          ('PeakPagefileUsage', ULONG), #SIZE_T
          ('PrivatePageCount', ULONG), #SIZE_T
-         ('ImageName', WSTR_STRIPPED), # THIS SHOULD NOT BE HERE
-         ('pSid', SID), # THIS SHOULD NOT BE HERE
     )
 
 
@@ -1354,15 +1366,24 @@ class PTS_SYS_PROCESS_INFORMATION(NDRPOINTER):
     )
 
 # 2.2.2.15 TS_ALL_PROCESSES_INFO
+# https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/8f5564a6-1b5e-4381-afc4-4acf7ad39d6d
 class TS_ALL_PROCESSES_INFO(NDRSTRUCT):
     structure = (
-        ('pTsProcessInfo', TS_SYS_PROCESS_INFORMATION),
+        ('pTsProcessInfo', PTS_SYS_PROCESS_INFORMATION),
         ('SizeOfSid', DWORD),
-        ('pSid', TS_CHAR),
+        ('pSid', LPUCHAR_ARRAY),
     )
+    def getProcessInfo(self):
+        return self.fields['pTsProcessInfo'].fields['Data']
+
+    def getSid(self):
+        rawSid = self.fields['pSid']['Data'] if self.fields['pSid'].fields['ReferentID'] else b''
+        if not rawSid:
+            return ''
+        return SID().known_sid(format_sid(rawSid))
  
-class TS_ALL_PROCESSES_INFO_ARRAY(NDRUniConformantVaryingArray):
-    item = TS_SYS_PROCESS_INFORMATION
+class TS_ALL_PROCESSES_INFO_ARRAY(NDRUniConformantArray):
+    item = TS_ALL_PROCESSES_INFO
 
 class PTS_ALL_PROCESSES_INFO(NDRPOINTER):
     referent = (
@@ -2717,6 +2738,7 @@ class RpcWinStationNtsdDebugResponse(NDRCALL):
         ('ErrorCode', BOOLEAN),
     )
 # 3.7.4.1.22 RpcWinStationGetAllProcesses (Opnum 43)
+# https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsts/6f43f9e4-2d80-4c5c-bc0b-7f653b1d7c02
 class RpcWinStationGetAllProcesses(NDRCALL):
     opnum = 43
     structure = (
@@ -2729,7 +2751,8 @@ class RpcWinStationGetAllProcessesResponse(NDRCALL):
     structure = (
         ('pResult', pResult_ENUM),
         ('pNumberOfProcesses', BOUNDED_ULONG),
-        ('buffer',':'),
+        ('ppTsAllProcessesInfo', PTS_ALL_PROCESSES_INFO),
+        ('ErrorCode', BOOLEAN),
     )
 # 3.7.4.1.23 RpcWinStationGetProcessSid (Opnum 44)
 class RpcWinStationGetProcessSid(NDRCALL):
@@ -3556,54 +3579,16 @@ def hRpcWinStationTerminateProcess(dce, hServer, ProcessId, ExitCode = 0):
 
 # 3.7.4.1.22 RpcWinStationGetAllProcesses (Opnum 43)
 def hRpcWinStationGetAllProcesses(dce, hServer):
-    # i'm giving up constructing legitimate structures for this method
-    # Going to parse raw response:
-    # 1. Skip ndrpointers
-    # 2. Create TS_SYS_PROCESS_INFORMATION structure one by one
-    # Tested and seems to work well on WIN11, WIN10, WIN2012R2, WIN7
     request = RpcWinStationGetAllProcesses()
     request['hServer'] = hServer
     request['Level'] = 0
     request['pNumberOfProcesses'] = 0x8000
     resp = dce.request(request, checkError=False)
-    data = resp.getData()
-    bResult = bool(data[-1])
-    if not bResult:
+    if not resp['ErrorCode']:
         raise DCERPCSessionError(error_code=resp['pResult'])
-    data = data[:-1]
-    procs = []
     if not resp['pNumberOfProcesses']:
-        return procs
-    offset = 0
-    arrayOffset = 0
-    while 1:
-        offset = data.find(b'\x02\x00')
-        if offset > 12:
-            break
-        data = data[offset+2:]
-        arrayOffset = arrayOffset + offset + 2
-    procInfo = ''
-    while len(data)>1:
-        if len(data[len(procInfo):]) < 16:
-            break
-        # I think there some alignment problems...
-        # in the structure, second DWORD is thread count, i'm looking for the second DWORD
-        # in order to align the data correctly
-        # There is no proper errors handling!
-        b,c,d,e = struct.unpack('<LLLL',data[len(procInfo):len(procInfo)+16])
-        if b:
-            data = data[len(procInfo)-4:]
-        elif c:
-            data = data[len(procInfo):]
-        elif d:
-            data = data[len(procInfo)+4:]
-        elif e:
-            data = data[len(procInfo)+8:]
-            
-        procInfo = TS_SYS_PROCESS_INFORMATION()
-        procInfo.fromString(data)
-        procs.append(procInfo)
-    return procs
+        return []
+    return resp['ppTsAllProcessesInfo']
 
 # 3.7.4.1.23 RpcWinStationGetProcessSid (Opnum 44)
 def hRpcWinStationGetProcessSid(dce, hServer, dwUniqueProcessId, ProcessStartTime):

--- a/impacket/dcerpc/v5/tsts.py
+++ b/impacket/dcerpc/v5/tsts.py
@@ -1344,7 +1344,7 @@ class TS_SYS_PROCESS_INFORMATION(NDRSTRUCT):
          ('CreateTime', LARGE_INTEGER),
          ('UserTime', LARGE_INTEGER),
          ('KernelTime', LARGE_INTEGER),
-         ('ImageNameSize', TS_UNICODE_STRING),
+         ('ImageName', TS_UNICODE_STRING),
          ('BasePriority', LONG),
          ('UniqueProcessId', DWORD),
          ('InheritedFromUniqueProcessId', DWORD),

--- a/impacket/dcerpc/v5/tsts.py
+++ b/impacket/dcerpc/v5/tsts.py
@@ -28,7 +28,6 @@
 
 import struct
 from datetime import datetime, timedelta
-from ldap3.protocol.formatters.formatters import format_sid
 
 from impacket.dcerpc.v5 import transport
 from impacket.uuid import uuidtup_to_bin, bin_to_string, string_to_bin
@@ -36,7 +35,7 @@ from impacket.dcerpc.v5.ndr import NDR, NDRCALL, NDRSTRUCT, NDRENUM, NDRUNION, N
     NDRPOINTER, NDRUniConformantVaryingArray, UNKNOWNDATA
 from impacket.dcerpc.v5.dtypes import NULL, BOOL, BOOLEAN, STR, WSTR, LPWSTR, WIDESTR, \
     LONG, UINT, ULONG, PULONG, LPDWORD, LARGE_INTEGER, DWORD, NDRHYPER, USHORT, UCHAR, PCHAR, BYTE, PBYTE, \
-    UUID, GUID
+    UUID, GUID, SID as BINARY_SID
 from impacket import system_errors
 from impacket.dcerpc.v5.enum import Enum
 from impacket.dcerpc.v5.rpcrt import DCERPCException, RPC_C_AUTHN_GSS_NEGOTIATE, RPC_C_AUTHN_LEVEL_PKT_PRIVACY
@@ -345,6 +344,12 @@ def getUnixTime(t):
 
 def enum2value(enum, key):
     return enum.enumItems._value2member_map_[key]._name_
+
+
+def binary_sid_to_string(rawSid):
+    if not rawSid:
+        return ''
+    return BINARY_SID(data=rawSid).formatCanonical()
     
 class SID(TS_CHAR):
     def known_sid(self, sid):
@@ -367,9 +372,10 @@ class SID(TS_CHAR):
         elif sid in knownSids:
             return knownSids[sid]
         return sid
+
     def __getitem__(self, key):
         if key == 'Data':
-            sid = format_sid(self.fields[key])
+            sid = binary_sid_to_string(self.fields[key])
             if not len(sid):
                 return ''
             return self.known_sid(sid)
@@ -1377,10 +1383,10 @@ class TS_ALL_PROCESSES_INFO(NDRSTRUCT):
         return self.fields['pTsProcessInfo'].fields['Data']
 
     def getSid(self):
-        rawSid = self.fields['pSid']['Data'] if self.fields['pSid'].fields['ReferentID'] else b''
+        rawSid = b''.join(self.fields['pSid']['Data']) if self.fields['pSid'].fields['ReferentID'] else b''
         if not rawSid:
             return ''
-        return SID().known_sid(format_sid(rawSid))
+        return SID().known_sid(binary_sid_to_string(rawSid))
  
 class TS_ALL_PROCESSES_INFO_ARRAY(NDRUniConformantArray):
     item = TS_ALL_PROCESSES_INFO
@@ -3604,7 +3610,7 @@ def hRpcWinStationGetProcessSid(dce, hServer, dwUniqueProcessId, ProcessStartTim
         request['dwSidSize'] = sizeNeeded
         resp = dce.request(request, checkError=False)
     if resp['ErrorCode']:
-        return format_sid(resp['pProcessUserSid'])
+        return binary_sid_to_string(resp['pProcessUserSid'])
 
 #NOT_IMPLEMENTED 3.7.4.1.24 RpcWinStationGetTermSrvCountersValue (Opnum 45)
 

--- a/tests/misc/test_tsts.py
+++ b/tests/misc/test_tsts.py
@@ -1,3 +1,17 @@
+#!/usr/bin/env python
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright Fortra, LLC and its affiliated companies
+#
+# All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+# Description:
+#   Tests for [MS-TSTS] Terminal Services Terminal Server Runtime Interface Protocol
+#
 import unittest
 
 from impacket.dcerpc.v5 import tsts

--- a/tests/misc/test_tsts.py
+++ b/tests/misc/test_tsts.py
@@ -1,0 +1,32 @@
+import unittest
+
+from impacket.dcerpc.v5 import tsts
+
+
+class TSTSTests(unittest.TestCase):
+    SYSTEM_SID = bytes([1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0])
+
+    def test_binary_sid_to_string_returns_canonical_sid(self):
+        self.assertEqual(tsts.binary_sid_to_string(self.SYSTEM_SID), 'S-1-5-18')
+
+    def test_get_all_processes_info_get_sid_with_populated_pointer(self):
+        resp = tsts.RpcWinStationGetAllProcessesResponse()
+        resp['pResult'] = 0
+        resp['pNumberOfProcesses'] = 1
+
+        entry = tsts.TS_ALL_PROCESSES_INFO()
+        entry.fields['pTsProcessInfo'].fields['Data']['UniqueProcessId'] = 123
+        entry.fields['pTsProcessInfo'].fields['Data']['SessionId'] = 1
+        entry['SizeOfSid'] = 12
+        entry.fields['pSid'].fields['Data']['Data'] = self.SYSTEM_SID
+
+        resp.fields['ppTsAllProcessesInfo'].fields['Data']['Data'] = [entry]
+        resp['ErrorCode'] = 1
+
+        parsed = tsts.RpcWinStationGetAllProcessesResponse(resp.getData())
+
+        self.assertEqual(parsed['ppTsAllProcessesInfo'][0].getSid(), 'SYSTEM')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=1)


### PR DESCRIPTION
This PR fixes #1816 by replacing the heuristic parsing of `RpcWinStationGetAllProcesses` with a proper NDR structure implementation based on the protocol spec. Since the response is now modeled according to the actual
  `TS_ALL_PROCESSES_INFO` layout, the example code was also updated to use the corrected process and SID fields.