### PR TITLE
Fix large-page ESE tag-state parsing for Windows Server 2025 NTDS.dit (issue #1924)

### DIFF
--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -737,14 +737,20 @@ class RAISECHILD:
 
         if plainText:
             try:
-                userProperties = samr.USER_PROPERTIES(plainText)
+                _, propertyCount, propertiesData = samr.unpack_user_properties(plainText)
             except:
                 # On some old w2k3 there might be user properties that don't
                 # match [MS-SAMR] structure, discarding them
                 return
-            propertiesData = userProperties['UserProperties']
-            for propertyCount in range(userProperties['PropertyCount']):
-                userProperty = samr.USER_PROPERTY(propertiesData)
+            for _ in range(propertyCount):
+                try:
+                    userProperty = samr.USER_PROPERTY(propertiesData)
+                except Exception:
+                    logging.debug(
+                        'Malformed supplemental credential property, discarding the remaining data',
+                        exc_info=True,
+                    )
+                    return
                 propertiesData = propertiesData[len(userProperty):]
                 if userProperty['PropertyName'].decode('utf-16le') == 'Primary:Kerberos-Newer-Keys':
                     propertyValueBuffer = unhexlify(userProperty['PropertyValue'])

--- a/impacket/dcerpc/v5/samr.py
+++ b/impacket/dcerpc/v5/samr.py
@@ -1399,9 +1399,38 @@ class USER_PROPERTIES(Structure):
         ('Reserved3','<H=0'),
         ('Reserved4','96s=""'),
         ('PropertySignature','<H=0x50'),
-        ('PropertyCount','<H=0'),
-        ('UserProperties',':'),
     )
+
+
+def unpack_user_properties(data):
+    user_properties = USER_PROPERTIES(data)
+    property_count_offset = len(user_properties)
+    properties_end = 12 + user_properties['Length']
+
+    # MS-SAMR 3.1.1.8.11.1.1 says PropertyCount is omitted when there are zero
+    # USER_PROPERTY entries and the total structure size becomes 0x6f bytes.
+    # With the fixed 12-byte prefix and trailing Reserved5 byte, that means the
+    # length-delimited portion ends at the PropertySignature for header-only
+    # blobs, so PropertyCount must be parsed conditionally.
+    if properties_end < property_count_offset:
+        raise struct.error("USER_PROPERTIES length shorter than the fixed header")
+
+    if len(data) <= properties_end:
+        raise struct.error("USER_PROPERTIES missing Reserved5")
+
+    if properties_end == property_count_offset:
+        user_properties['PropertyCount'] = 0
+        user_properties['Reserved5'] = data[properties_end:properties_end+1]
+        return user_properties, 0, b''
+
+    if len(data) < property_count_offset + 2:
+        raise struct.error("USER_PROPERTIES missing PropertyCount")
+
+    property_count = struct.unpack('<H', data[property_count_offset:property_count_offset+2])[0]
+    user_properties['PropertyCount'] = property_count
+    user_properties['Reserved5'] = data[properties_end:properties_end+1]
+
+    return user_properties, property_count, data[property_count_offset+2:properties_end]
 
 # 2.2.10.2 USER_PROPERTY
 class USER_PROPERTY(Structure):

--- a/impacket/ese.py
+++ b/impacket/ese.py
@@ -446,10 +446,10 @@ class ESENT_PAGE:
         if data is not None:
             self.record = ESENT_PAGE_HEADER(self.__DBHeader['Version'], self.__DBHeader['FileFormatRevision'], self.__DBHeader['PageSize'], data)
             self.tagCount = self.record['FirstAvailablePageTag']
-            if self.__DBHeader['FileFormatRevision'] >= 0x11 and self.__DBHeader['PageSize'] > 8192:
-                # TODO: The upper 4 bits may encode how many leading tags are reserved on large pages.
-                    # Logical node counts should be derived from the effective reserved-tag count
-                    # instead of assuming only tag 0 is reserved, the logical node count should be tagCount - tagReserved.
+            if self.__DBHeader['Version'] == 0x620 and self.__DBHeader['FileFormatRevision'] >= 0x11 and self.__DBHeader['PageSize'] > 8192:
+                # TODO: If samples with effective tagReserved > 1 appear, logical node
+                # iteration should be derived from the reserved-tag count instead of
+                # assuming only tag 0 is reserved.
                 self.tagReserved = (self.record['FirstAvailablePageTag'] >> FIRST_AVAILABLE_PAGE_TAG_RESERVED_SHIFT) or 1
                 self.tagCount = self.record['FirstAvailablePageTag'] & FIRST_AVAILABLE_PAGE_TAG_MASK
 

--- a/impacket/ese.py
+++ b/impacket/ese.py
@@ -443,15 +443,17 @@ class ESENT_PAGE:
         self.record = None
         self.tagCount = 0
         self.tagReserved = 1
+        self.firstDataTag = 1
         if data is not None:
             self.record = ESENT_PAGE_HEADER(self.__DBHeader['Version'], self.__DBHeader['FileFormatRevision'], self.__DBHeader['PageSize'], data)
             self.tagCount = self.record['FirstAvailablePageTag']
             if self.__DBHeader['Version'] == 0x620 and self.__DBHeader['FileFormatRevision'] >= 0x11 and self.__DBHeader['PageSize'] > 8192:
-                # TODO: If samples with effective tagReserved > 1 appear, logical node
-                # iteration should be derived from the reserved-tag count instead of
-                # assuming only tag 0 is reserved.
                 self.tagReserved = (self.record['FirstAvailablePageTag'] >> FIRST_AVAILABLE_PAGE_TAG_RESERVED_SHIFT) or 1
                 self.tagCount = self.record['FirstAvailablePageTag'] & FIRST_AVAILABLE_PAGE_TAG_MASK
+            self.firstDataTag = min(self.tagReserved, self.tagCount)
+
+    def iterDataTagNums(self):
+        return range(self.firstDataTag, self.tagCount)
 
     def printFlags(self):
         flags = self.record['PageFlags']
@@ -524,7 +526,7 @@ class ESENT_PAGE:
                 leafHeader.dump()
 
         # Print the leaf/branch tags
-        for tagNum in range(1,self.tagCount):
+        for tagNum in self.iterDataTagNums():
             flags, data = self.getTag(tagNum)
             if self.record['PageFlags'] & FLAGS_LEAF == 0:
                 # Branch page
@@ -672,7 +674,7 @@ class ESENT_DB:
 
     def parsePage(self, page):
         # Print the leaf/branch tags
-        for tagNum in range(1,page.tagCount):
+        for tagNum in page.iterDataTagNums():
             flags, data = page.getTag(tagNum)
             if page.record['PageFlags'] & FLAGS_LEAF > 0:
                 # Leaf page
@@ -692,7 +694,7 @@ class ESENT_DB:
         page = self.getPage(pageNum)
         self.parsePage(page)
 
-        for i in range(1, page.tagCount):
+        for i in page.iterDataTagNums():
             flags, data = page.getTag(i)
             if page.record['PageFlags'] & FLAGS_LEAF == 0:
                 # Branch page
@@ -735,10 +737,10 @@ class ESENT_DB:
             done = False
             while done is False:
                 page = self.getPage(pageNum)
-                if page.tagCount <= 1:
+                if page.tagCount <= page.firstDataTag:
                     # There are no records
                     done = True
-                for i in range(1, page.tagCount):
+                for i in page.iterDataTagNums():
                     flags, data = page.getTag(i)
                     if page.record['PageFlags'] & FLAGS_LEAF == 0:
                         # Branch page, move on to the next page
@@ -753,7 +755,7 @@ class ESENT_DB:
             cursor['TableData'] = self.__tables[tableName]
             cursor['FatherDataPageNumber'] = catalogEntry['FatherDataPageNumber']
             cursor['CurrentPageData'] = page
-            cursor['CurrentTag']  = 0
+            cursor['CurrentTag']  = page.firstDataTag - 1
             return cursor
         else:
             return None
@@ -795,7 +797,7 @@ class ESENT_DB:
                 return None
             else:
                 cursor['CurrentPageData'] = self.getPage(page.record['NextPageNumber'])
-                cursor['CurrentTag'] = 0
+                cursor['CurrentTag'] = cursor['CurrentPageData'].firstDataTag - 1
                 return self.getNextRow(cursor, filter_tables = filter_tables)
         else:
             return self.__tagToRecord(cursor, tag['EntryData'], filter_tables = filter_tables)

--- a/impacket/ese.py
+++ b/impacket/ese.py
@@ -58,6 +58,11 @@ FLAGS_LONG_VALUE   = 0x80
 FLAGS_NEW_FORMAT   = 0x2000
 FLAGS_NEW_CHECKSUM = 0x2000
 
+# On 16 KiB and 32 KiB pages, the raw 16-bit tag state appears to store the total
+# tag count in the lower 12 bits. The upper 4 bits seem to represent a reserved tag count.
+FIRST_AVAILABLE_PAGE_TAG_MASK = 0x0fff
+FIRST_AVAILABLE_PAGE_TAG_RESERVED_SHIFT = 12
+
 # Tag Flags
 TAG_UNKNOWN = 0x1
 TAG_DEFUNCT = 0x2
@@ -436,8 +441,17 @@ class ESENT_PAGE:
         self.__DBHeader = db
         self.data = data
         self.record = None
+        self.tagCount = 0
+        self.tagReserved = 1
         if data is not None:
             self.record = ESENT_PAGE_HEADER(self.__DBHeader['Version'], self.__DBHeader['FileFormatRevision'], self.__DBHeader['PageSize'], data)
+            self.tagCount = self.record['FirstAvailablePageTag']
+            if self.__DBHeader['FileFormatRevision'] >= 0x11 and self.__DBHeader['PageSize'] > 8192:
+                # TODO: The upper 4 bits may encode how many leading tags are reserved on large pages.
+                    # Logical node counts should be derived from the effective reserved-tag count
+                    # instead of assuming only tag 0 is reserved, the logical node count should be tagCount - tagReserved.
+                self.tagReserved = (self.record['FirstAvailablePageTag'] >> FIRST_AVAILABLE_PAGE_TAG_RESERVED_SHIFT) or 1
+                self.tagCount = self.record['FirstAvailablePageTag'] & FIRST_AVAILABLE_PAGE_TAG_MASK
 
     def printFlags(self):
         flags = self.record['PageFlags']
@@ -465,14 +479,14 @@ class ESENT_PAGE:
     def dump(self):
         baseOffset = len(self.record)
         self.record.dump()
-        tags = self.data[-4*self.record['FirstAvailablePageTag']:]
+        tags = self.data[-4*self.tagCount:]
 
         print("FLAGS: ")
         self.printFlags()
 
         print()
 
-        for i in range(self.record['FirstAvailablePageTag']):
+        for i in range(self.tagCount):
             tag = tags[-4:]
             if self.__DBHeader['Version'] == 0x620 and self.__DBHeader['FileFormatRevision'] > 11 and self.__DBHeader['PageSize'] > 8192:
                 valueSize = unpack('<H', tag[:2])[0] & 0x7fff
@@ -510,7 +524,7 @@ class ESENT_PAGE:
                 leafHeader.dump()
 
         # Print the leaf/branch tags
-        for tagNum in range(1,self.record['FirstAvailablePageTag']):
+        for tagNum in range(1,self.tagCount):
             flags, data = self.getTag(tagNum)
             if self.record['PageFlags'] & FLAGS_LEAF == 0:
                 # Branch page
@@ -540,10 +554,10 @@ class ESENT_PAGE:
                     hexdump(leafEntry['EntryData'])
 
     def getTag(self, tagNum):
-        if self.record['FirstAvailablePageTag'] < tagNum:
+        if self.tagCount <= tagNum:
             raise Exception('Trying to grab an unknown tag 0x%x' % tagNum)
 
-        tags = self.data[-4*self.record['FirstAvailablePageTag']:]
+        tags = self.data[-4*self.tagCount:]
         baseOffset = len(self.record)
         for i in range(tagNum):
             tags = tags[:-4]
@@ -658,7 +672,7 @@ class ESENT_DB:
 
     def parsePage(self, page):
         # Print the leaf/branch tags
-        for tagNum in range(1,page.record['FirstAvailablePageTag']):
+        for tagNum in range(1,page.tagCount):
             flags, data = page.getTag(tagNum)
             if page.record['PageFlags'] & FLAGS_LEAF > 0:
                 # Leaf page
@@ -678,7 +692,7 @@ class ESENT_DB:
         page = self.getPage(pageNum)
         self.parsePage(page)
 
-        for i in range(1, page.record['FirstAvailablePageTag']):
+        for i in range(1, page.tagCount):
             flags, data = page.getTag(i)
             if page.record['PageFlags'] & FLAGS_LEAF == 0:
                 # Branch page
@@ -721,10 +735,10 @@ class ESENT_DB:
             done = False
             while done is False:
                 page = self.getPage(pageNum)
-                if page.record['FirstAvailablePageTag'] <= 1:
+                if page.tagCount <= 1:
                     # There are no records
                     done = True
-                for i in range(1, page.record['FirstAvailablePageTag']):
+                for i in range(1, page.tagCount):
                     flags, data = page.getTag(i)
                     if page.record['PageFlags'] & FLAGS_LEAF == 0:
                         # Branch page, move on to the next page
@@ -747,7 +761,7 @@ class ESENT_DB:
     def __getNextTag(self, cursor):
         page = cursor['CurrentPageData']
 
-        if cursor['CurrentTag'] >= page.record['FirstAvailablePageTag']:
+        if cursor['CurrentTag'] >= page.tagCount:
             # No more data in this page, chau
             return None
 

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -2811,14 +2811,21 @@ class NTDSHashes:
 
         if haveInfo is True:
             try:
-                userProperties = samr.USER_PROPERTIES(plainText)
+                _, propertyCount, propertiesData = samr.unpack_user_properties(plainText)
             except:
                 # On some old w2k3 there might be user properties that don't
                 # match [MS-SAMR] structure, discarding them
                 return
-            propertiesData = userProperties['UserProperties']
-            for propertyCount in range(userProperties['PropertyCount']):
-                userProperty = samr.USER_PROPERTY(propertiesData)
+            for _ in range(propertyCount):
+                try:
+                    userProperty = samr.USER_PROPERTY(propertiesData)
+                except Exception:
+                    LOG.debug(
+                        'Malformed supplemental credential property for %s, discarding the remaining data',
+                        userName,
+                        exc_info=True,
+                    )
+                    return
                 propertiesData = propertiesData[len(userProperty):]
                 # For now, we will only process Newer Kerberos Keys and CLEARTEXT
                 if userProperty['PropertyName'].decode('utf-16le') == 'Primary:Kerberos-Newer-Keys':

--- a/tests/SMB_RPC/test_secretsdump.py
+++ b/tests/SMB_RPC/test_secretsdump.py
@@ -10,10 +10,12 @@
 #
 import os
 import logging
+import struct
 import pytest
 import unittest
 from tests import RemoteTestCase
 
+from impacket.dcerpc.v5 import samr
 from impacket.examples.secretsdump import LocalOperations, RemoteOperations, SAMHashes, LSASecrets, NTDSHashes
 from impacket.smbconnection import SMBConnection
 
@@ -257,6 +259,124 @@ class Options(object):
     target_ip=''
     use_vss=False
     user_status=False
+
+
+class NTDSHashesUnitTests(unittest.TestCase):
+
+    def test_header_only_supplemental_credentials_are_ignored(self):
+        header_only_properties = (
+            b'\x00\x00\x00\x00'
+            b'\x62\x00\x00\x00'
+            b'\x00\x00'
+            b'\x00\x00'
+            + (b'\x20\x00' * 48)
+            + b'\x50\x00\x00\x01'
+        )
+
+        user_properties, property_count, properties_data = samr.unpack_user_properties(header_only_properties)
+
+        self.assertEqual(98, user_properties['Length'])
+        self.assertEqual(0, property_count)
+        self.assertEqual(b'', properties_data)
+        self.assertEqual(b'\x00', user_properties['Reserved5'])
+
+        ntds = object.__new__(NTDSHashes)
+        ntds._NTDSHashes__useVSSMethod = True
+        ntds._NTDSHashes__remoteSSMethodWMINTDS = False
+        ntds._NTDSHashes__kerberosKeys = {}
+        ntds._NTDSHashes__clearTextPwds = {}
+        ntds._NTDSHashes__perSecretCallback = lambda *args, **kwargs: None
+        ntds._NTDSHashes__removeRC4Layer = lambda cipherText: header_only_properties
+
+        record = {
+            NTDSHashes.NAME_TO_INTERNAL['supplementalCredentials']: b'00' * 32,
+            NTDSHashes.NAME_TO_INTERNAL['userPrincipalName']: None,
+            NTDSHashes.NAME_TO_INTERNAL['sAMAccountName']: 'Administrator',
+        }
+
+        ntds._NTDSHashes__decryptSupplementalInfo(record)
+
+        self.assertEqual({}, ntds._NTDSHashes__kerberosKeys)
+        self.assertEqual({}, ntds._NTDSHashes__clearTextPwds)
+
+    def test_unpack_user_properties_excludes_reserved5_and_padding(self):
+        property_data = (
+            b'\x04\x00'
+            b'\x02\x00'
+            b'\x00\x00'
+            b'A\x00B\x00'
+            b'ff'
+        )
+        user_properties_blob = (
+            b'\x00\x00\x00\x00'
+            + (100 + len(property_data)).to_bytes(4, 'little')
+            + b'\x00\x00'
+            + b'\x00\x00'
+            + (b'\x20\x00' * 48)
+            + b'\x50\x00'
+            + b'\x01\x00'
+            + property_data
+            + b'\x00'
+            + b'\x03\x03\x03'
+        )
+
+        user_properties, property_count, properties_data = samr.unpack_user_properties(user_properties_blob)
+        user_property = samr.USER_PROPERTY(properties_data)
+
+        self.assertEqual(1, property_count)
+        self.assertEqual(112, user_properties['Length'])
+        self.assertEqual(b'\x00', user_properties['Reserved5'])
+        self.assertEqual(property_data, properties_data)
+        self.assertEqual('AB', user_property['PropertyName'].decode('utf-16le'))
+        self.assertEqual(b'ff', user_property['PropertyValue'])
+
+    def test_unpack_user_properties_requires_reserved5_for_header_only_blob(self):
+        header_only_properties = (
+            b'\x00\x00\x00\x00'
+            b'\x62\x00\x00\x00'
+            b'\x00\x00'
+            b'\x00\x00'
+            + (b'\x20\x00' * 48)
+            + b'\x50\x00'
+        )
+
+        with self.assertRaisesRegex(struct.error, 'missing Reserved5'):
+            samr.unpack_user_properties(header_only_properties)
+
+    def test_unpack_user_properties_requires_reserved5_for_property_blob(self):
+        property_data = (
+            b'\x04\x00'
+            b'\x02\x00'
+            b'\x00\x00'
+            b'A\x00B\x00'
+            b'ff'
+        )
+        user_properties_blob = (
+            b'\x00\x00\x00\x00'
+            + (100 + len(property_data)).to_bytes(4, 'little')
+            + b'\x00\x00'
+            + b'\x00\x00'
+            + (b'\x20\x00' * 48)
+            + b'\x50\x00'
+            + b'\x01\x00'
+            + property_data
+        )
+
+        with self.assertRaisesRegex(struct.error, 'missing Reserved5'):
+            samr.unpack_user_properties(user_properties_blob)
+
+    def test_unpack_user_properties_rejects_length_shorter_than_fixed_header(self):
+        invalid_header = (
+            b'\x00\x00\x00\x00'
+            b'\x61\x00\x00\x00'
+            b'\x00\x00'
+            b'\x00\x00'
+            + (b'\x20\x00' * 48)
+            + b'\x50\x00\x00'
+        )
+
+        with self.assertRaisesRegex(struct.error, 'length shorter than the fixed header'):
+            samr.unpack_user_properties(invalid_header)
 
 
 class SecretsDumpTests(RemoteTestCase):

--- a/tests/misc/test_ese.py
+++ b/tests/misc/test_ese.py
@@ -69,6 +69,16 @@ class TestESENTLargePageTags(unittest.TestCase):
         with self.assertRaisesRegex(Exception, r'unknown tag'):
             page.getTag(page.tagCount)
 
+    def test_iter_data_tags_skips_all_reserved_large_page_tags(self):
+        page, payloads = self._build_page(0x200c)
+
+        self.assertEqual(page.tagReserved, 2)
+        self.assertEqual(page.firstDataTag, 2)
+        self.assertEqual(list(page.iterDataTagNums()), list(range(2, page.tagCount)))
+
+        iterated_payloads = [page.getTag(tag_num)[1] for tag_num in page.iterDataTagNums()]
+        self.assertEqual(iterated_payloads, payloads[page.firstDataTag:])
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=1)

--- a/tests/misc/test_ese.py
+++ b/tests/misc/test_ese.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright Fortra, LLC and its affiliated companies
+#
+# All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+import struct
+import unittest
+
+from impacket.ese import (
+    ESENT_PAGE,
+    ESENT_PAGE_HEADER,
+    FIRST_AVAILABLE_PAGE_TAG_MASK,
+    FIRST_AVAILABLE_PAGE_TAG_RESERVED_SHIFT,
+)
+
+
+class TestESENTLargePageTags(unittest.TestCase):
+    PAGE_SIZE = 32768
+    VERSION = 0x620
+    REVISION = 0x122
+
+    def _build_page(self, raw_tag_state):
+        tag_count = raw_tag_state & FIRST_AVAILABLE_PAGE_TAG_MASK
+        header = ESENT_PAGE_HEADER(self.VERSION, self.REVISION, self.PAGE_SIZE)
+        header['FirstAvailableDataOffset'] = tag_count * 4
+        header['FirstAvailablePageTag'] = raw_tag_state
+        header['PageFlags'] = 0x2001
+
+        header_bytes = header.getData()
+        page = bytearray(self.PAGE_SIZE)
+        page[:len(header_bytes)] = header_bytes
+
+        base_offset = len(header_bytes)
+        payloads = [bytes([i, i, i, i]) for i in range(tag_count)]
+        tags = []
+        offset = 0
+        for payload in payloads:
+            page[base_offset + offset:base_offset + offset + len(payload)] = payload
+            tags.append(struct.pack('<HH', len(payload), offset))
+            offset += len(payload)
+
+        page[-4 * tag_count:] = b''.join(reversed(tags))
+
+        return ESENT_PAGE({
+            'Version': self.VERSION,
+            'FileFormatRevision': self.REVISION,
+            'PageSize': self.PAGE_SIZE,
+        }, bytes(page)), payloads
+
+    def test_splits_large_page_tag_state(self):
+        page, _ = self._build_page(0x100c)
+
+        self.assertEqual(page.record['FirstAvailablePageTag'], 0x100c)
+        self.assertEqual(page.tagReserved, (0x100c >> FIRST_AVAILABLE_PAGE_TAG_RESERVED_SHIFT) or 1)
+        self.assertEqual(page.tagCount, 0x100c & FIRST_AVAILABLE_PAGE_TAG_MASK)
+
+    def test_iterates_large_page_tags_with_high_bits_set(self):
+        page, payloads = self._build_page(0x100c)
+
+        for tag_num in range(1, page.tagCount):
+            self.assertEqual(page.getTag(tag_num), (0, payloads[tag_num]))
+
+        with self.assertRaisesRegex(Exception, r'unknown tag'):
+            page.getTag(page.tagCount)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=1)


### PR DESCRIPTION
 This PR fixes the ESE page-header parsing bug behind issue #1924, where `secretsdump.py` failed to parse Windows Server 2025 `NTDS.dit` files using 32 KB ESE pages.

  Root cause:
-  `FirstAvailablePageTag` was treated as a plain 16-bit tag count.
-  On large page databases, the low 12 bits contain the tag count, while the upper 4 bits appear to encode reserved tag state.
-  This resulted in values such as `0x100c` to be interpreted as `4108` tag count instead of just `12`, causing Impacket to walk past the last valid tag and crash with IndexError.

Fix:

- `FirstAvailablePageTag` is now split into 2 values:
  - Upper 4 bits are stored as `tagReserved`, there's not much information about this, dissect.esedb treats it as a counter for reserved tags which is then used to calculate the actual logical node count. I did not implement this because i could not manage to create a dump which had tagReserved > 1
  - Remaining 12 bits are used for the tag count (instead of the 16 that were used previously)
- These changes are in line with [what dissect.esedb does](https://github.com/fox-it/dissect.esedb/blob/ea5efb8a8fc2902e5e4d43f035b7461ffb9ef734/dissect/esedb/page.py#L44-L48)

Additional Fix:

- `secretsdump` and `raiseChild` assumed `USER_PROPERTIES` structure always contains `PropertyCount` and `UserProperties`. Those fields are optional, and i obtained a dump in which a user had a valid zero-property `supplementalCredentials` blob, where SAMR omits `PropertyCount`. Because we modeled `PropertyCount` as unconditional, the parser consumed later bytes as the count and then failed while decoding a non-existent `USER_PROPERTY`, producing an Error while processing that user.

- This was fixed by parsing only the fixed `USER_PROPERTIES` header in samr.py and handle the optional tail manually based on Length. When the blob is the zero-property form, we now return `PropertyCount` = 0 and empty property data; otherwise we parse `PropertyCount`, the property buffer, and `Reserved5` explicitly. secretsdump.py and raiseChild.py were updated to use that helper, and both now discard malformed trailing property data safely instead of crashing the whole row.
