### PR TITLE
Fix WINRMS relay error handling and add NTLMv2 detection

### DIFF
--- a/impacket/examples/ntlmrelayx/clients/winrmrelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/winrmrelayclient.py
@@ -58,10 +58,10 @@ class WinRMSRelayClient(ProtocolClient):
             LOG.warning('The client requested signing, relaying to WinRMS might not work!')
 
         # WinRMS relay only works with NTLMv1 (no Channel Binding support).
-        # NTLMv2 clients send CBT tokens that cannot be stripped, so relay will fail
+        # NTLMv2 clients send CBT tokens that cannot be stripped, so relay may fail
         # unless CbtHardeningLevel=None, NTLMv1 is enabled/downgraded, or MITM on WinRM.
         # See: https://sensepost.com/blog/2025/is-tls-more-secure-the-winrms-case./
-        LOG.warning('WinRMS relay requires NTLMv1. NTLMv2 clients send Channel Binding tokens that will cause relay to fail')
+        LOG.warning('WinRMS relay requires NTLMv1. NTLMv2 clients send Channel Binding tokens that may cause relay to fail')
 
         headers = {
             "Content-Length": len(self.basic_xml_data),
@@ -121,16 +121,14 @@ class WinRMSRelayClient(ProtocolClient):
         else:
             token = authenticateMessageBlob
 
-        # Detect NTLMv2 and abort: WinRMS relay only works with NTLMv1.
+        # Detect NTLM version for logging purposes only.
         # NTLMv1 NT response is exactly 24 bytes; NTLMv2 is longer.
         try:
             authMsg = NTLMAuthChallengeResponse()
             authMsg.fromString(token)
             ntlm_response_len = authMsg['ntlm_len']
             if ntlm_response_len > 24:
-                LOG.error('NTLMv2 detected (NT response %d bytes). WinRMS relay requires NTLMv1. '
-                          'Relay will fail due to Channel Binding. Aborting.' % ntlm_response_len)
-                return None, STATUS_ACCESS_DENIED
+                LOG.info('NTLMv2 detected (NT response %d bytes). WinRMS relay may fail due to Channel Binding.' % ntlm_response_len)
             else:
                 LOG.info('NTLMv1 detected (NT response %d bytes). WinRMS relay should work' % ntlm_response_len)
         except Exception:

--- a/impacket/examples/ntlmrelayx/clients/winrmrelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/winrmrelayclient.py
@@ -120,7 +120,7 @@ class WinRMSRelayClient(ProtocolClient):
         try:
             authMsg = NTLMAuthChallengeResponse()
             authMsg.fromString(token)
-            nt_response = auth_msg['ntlm']
+            nt_response = authMsg['ntlm']
             # enough min length and NTLMv2 blob
             if len(nt_response) >= 48 and nt_response[16:20] == b'\x01\x01\x00\x00':
                 LOG.debug('NTLMv2 detected (NT response %d bytes). WinRMS relay may fail due to Channel Binding.' % len(nt_response))

--- a/impacket/examples/ntlmrelayx/clients/winrmrelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/winrmrelayclient.py
@@ -11,7 +11,7 @@ from struct import unpack
 from impacket import LOG
 from impacket.examples.ntlmrelayx.clients import ProtocolClient
 from impacket.nt_errors import STATUS_SUCCESS, STATUS_ACCESS_DENIED
-from impacket.ntlm import NTLMAuthChallenge, NTLMAuthNegotiate, NTLMSSP_NEGOTIATE_SIGN, NTLMSSP_NEGOTIATE_ALWAYS_SIGN
+from impacket.ntlm import NTLMAuthChallenge, NTLMAuthNegotiate, NTLMAuthChallengeResponse, NTLMSSP_NEGOTIATE_SIGN, NTLMSSP_NEGOTIATE_ALWAYS_SIGN
 from impacket.spnego import SPNEGO_NegTokenResp
 
 PROTOCOL_CLIENT_CLASSES = ["WinRMSRelayClient"]
@@ -57,13 +57,23 @@ class WinRMSRelayClient(ProtocolClient):
         if negoMessage['flags'] & NTLMSSP_NEGOTIATE_SIGN:
             LOG.warning('The client requested signing, relaying to WinRMS might not work!')
 
+        # WinRMS relay only works with NTLMv1 (no Channel Binding support).
+        # NTLMv2 clients send CBT tokens that cannot be stripped, so relay will fail
+        # unless CbtHardeningLevel=None, NTLMv1 is enabled/downgraded, or MITM on WinRM.
+        # See: https://sensepost.com/blog/2025/is-tls-more-secure-the-winrms-case./
+        LOG.warning('WinRMS relay requires NTLMv1. NTLMv2 clients send Channel Binding tokens that will cause relay to fail')
+
         headers = {
             "Content-Length": len(self.basic_xml_data),
             "Content-Type": "application/soap+xml;charset=UTF-8"
         }
-        self.session.request("POST", self.path, headers=headers, body=self.basic_xml_data)
-        res = self.session.getresponse()
-        res.read()
+        try:
+            self.session.request("POST", self.path, headers=headers, body=self.basic_xml_data)
+            res = self.session.getresponse()
+            res.read()
+        except Exception as e:
+            LOG.error("Connection to %s:%s failed: %s" % (self.targetHost, self.targetPort, str(e)))
+            return False
 
         if res.status != 401:
             LOG.info(f"Status code returned: {res.status}. Authentication does not seem required for URL")
@@ -110,6 +120,21 @@ class WinRMSRelayClient(ProtocolClient):
             token = respToken2["ResponseToken"]
         else:
             token = authenticateMessageBlob
+
+        # Detect NTLMv2 and abort: WinRMS relay only works with NTLMv1.
+        # NTLMv1 NT response is exactly 24 bytes; NTLMv2 is longer.
+        try:
+            authMsg = NTLMAuthChallengeResponse()
+            authMsg.fromString(token)
+            ntlm_response_len = authMsg['ntlm_len']
+            if ntlm_response_len > 24:
+                LOG.error('NTLMv2 detected (NT response %d bytes). WinRMS relay requires NTLMv1. '
+                          'Relay will fail due to Channel Binding. Aborting.' % ntlm_response_len)
+                return None, STATUS_ACCESS_DENIED
+            else:
+                LOG.info('NTLMv1 detected (NT response %d bytes). WinRMS relay should work' % ntlm_response_len)
+        except Exception:
+            LOG.debug('Could not parse NTLM authenticate message to detect version, proceeding anyway')
 
         auth = base64.b64encode(token).decode("ascii")
         headers = {

--- a/impacket/examples/ntlmrelayx/clients/winrmrelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/winrmrelayclient.py
@@ -57,12 +57,6 @@ class WinRMSRelayClient(ProtocolClient):
         if negoMessage['flags'] & NTLMSSP_NEGOTIATE_SIGN:
             LOG.warning('The client requested signing, relaying to WinRMS might not work!')
 
-        # WinRMS relay only works with NTLMv1 (no Channel Binding support).
-        # NTLMv2 clients send CBT tokens that cannot be stripped, so relay may fail
-        # unless CbtHardeningLevel=None, NTLMv1 is enabled/downgraded, or MITM on WinRM.
-        # See: https://sensepost.com/blog/2025/is-tls-more-secure-the-winrms-case./
-        LOG.warning('WinRMS relay requires NTLMv1. NTLMv2 clients send Channel Binding tokens that may cause relay to fail')
-
         headers = {
             "Content-Length": len(self.basic_xml_data),
             "Content-Type": "application/soap+xml;charset=UTF-8"

--- a/impacket/examples/ntlmrelayx/clients/winrmrelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/winrmrelayclient.py
@@ -126,13 +126,12 @@ class WinRMSRelayClient(ProtocolClient):
         try:
             authMsg = NTLMAuthChallengeResponse()
             authMsg.fromString(token)
-            ntlm_response_len = authMsg['ntlm_len']
-            if ntlm_response_len > 24:
-                LOG.info('NTLMv2 detected (NT response %d bytes). WinRMS relay may fail due to Channel Binding.' % ntlm_response_len)
-            else:
-                LOG.info('NTLMv1 detected (NT response %d bytes). WinRMS relay should work' % ntlm_response_len)
+            nt_response = auth_msg['ntlm']
+            # enough min length and NTLMv2 blob
+            if len(nt_response) >= 48 and nt_response[16:20] == b'\x01\x01\x00\x00':
+                LOG.debug('NTLMv2 detected (NT response %d bytes). WinRMS relay may fail due to Channel Binding.' % len(nt_response))
         except Exception:
-            LOG.debug('Could not parse NTLM authenticate message to detect version, proceeding anyway')
+            pass
 
         auth = base64.b64encode(token).decode("ascii")
         headers = {

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -1,6 +1,6 @@
 # Impacket - Collection of Python classes for working with network protocols.
 #
-# Copyright Fortra, LLC and its affiliated companies 
+# Copyright Fortra, LLC and its affiliated companies
 #
 # All rights reserved.
 #
@@ -95,7 +95,7 @@ class SMBRelayServer(Thread):
             smbConfig.set("global", "dump_hashes", "True")
         else:
             smbConfig.set("global", "dump_hashes", "False")
-        
+
         if self.config.SMBServerChallenge is not None:
             smbConfig.set('global', 'challenge', self.config.SMBServerChallenge)
 
@@ -296,17 +296,25 @@ class SMBRelayServer(Thread):
             # Let's store it in the connection data
             connData['NEGOTIATE_MESSAGE'] = negotiateMessage
 
+            client = connData.get('SMBClient')
+            if client is None:
+                LOG.error("(SMB): No relay client initialized for target %s://%s" % (self.target.scheme, self.target.netloc))
+                respSMBCommand['SecurityBufferOffset'] = 0x48
+                respSMBCommand['SecurityBufferLength'] = 0
+                respSMBCommand['Buffer'] = b''
+                smbServer.setConnectionData(connId, connData)
+                return [respSMBCommand], None, STATUS_ACCESS_DENIED
+
             #############################################################
             # SMBRelay: Ok.. So we got a NEGOTIATE_MESSAGE from a client.
             # Let's send it to the target server and send the answer back to the client.
-            client = connData['SMBClient']
             try:
                 challengeMessage = self.do_ntlm_negotiate(client, token)
+                if not challengeMessage:
+                    raise Exception('No challenge message returned from %s://%s' % (self.target.scheme, self.target.netloc))
             except Exception as e:
-                LOG.debug("(SMB): Exception:", exc_info=True)
-                # Log this target as processed for this client
+                LOG.error("(SMB): NTLM negotiate failed: %s" % str(e))
                 self.targetprocessor.registerTarget(self.target, False, self.authUser)
-                # Raise exception again to pass it on to the SMB server
                 raise
 
              #############################################################
@@ -590,16 +598,34 @@ class SMBRelayServer(Thread):
                 # Let's store it in the connection data
                 connData['NEGOTIATE_MESSAGE'] = negotiateMessage
 
+                client = connData.get('SMBClient')
+                if client is None:
+                    packet = smb.NewSMBPacket()
+                    packet['Flags1'] = smb.SMB.FLAGS1_REPLY | smb.SMB.FLAGS1_PATHCASELESS
+                    packet['Flags2'] = smb.SMB.FLAGS2_NT_STATUS | smb.SMB.FLAGS2_EXTENDED_SECURITY
+                    packet['Command'] = recvPacket['Command']
+                    packet['Pid'] = recvPacket['Pid']
+                    packet['Tid'] = recvPacket['Tid']
+                    packet['Mid'] = recvPacket['Mid']
+                    packet['Uid'] = recvPacket['Uid']
+                    packet['Data'] = b'\x00\x00\x00'
+                    packet['ErrorCode'] = STATUS_ACCESS_DENIED >> 16
+                    packet['ErrorClass'] = STATUS_ACCESS_DENIED & 0xff
+
+                    LOG.error("(SMB): No relay client initialized for target %s://%s" % (self.target.scheme, self.target.netloc))
+                    smbServer.setConnectionData(connId, connData)
+                    return None, [packet], STATUS_ACCESS_DENIED
+
                 #############################################################
                 # SMBRelay: Ok.. So we got a NEGOTIATE_MESSAGE from a client.
                 # Let's send it to the target server and send the answer back to the client.
-                client = connData['SMBClient']
                 try:
                     challengeMessage = self.do_ntlm_negotiate(client,token)
-                except Exception:
-                    # Log this target as processed for this client
+                    if not challengeMessage:
+                        raise Exception('No challenge message returned from %s://%s' % (self.target.scheme, self.target.netloc))
+                except Exception as e:
+                    LOG.error("(SMB): NTLM negotiate failed: %s" % str(e))
                     self.targetprocessor.registerTarget(self.target, False, self.authUser)
-                    # Raise exception again to pass it on to the SMB server
                     raise
 
                 #############################################################


### PR DESCRIPTION
Hello maintainers 👋

Small PR to fix two relay-side behaviors observed during an assessment:

1. Connection failures in winrm relay negotiation were bubbling up as unhandled exceptions, resulting in noisy tracebacks.

2. A missing relay client could trigger a crash (`KeyError: 'SMBClient'`) when the target protocol client failed to initialize (for example with `winrm://`).

In addition, WinRMS relay attempts were still proceeding against NTLMv2 clients, even though CBT makes those attempts non-viable.

So I made a couple of small changes and included a reference to the article about WinRMS from @Dfte .

Regards