### PR TITLE
fix: support 32KB page sizes in ESE parser for Windows Server 2025

### DIFF
--- a/impacket/ese.py
+++ b/impacket/ese.py
@@ -567,12 +567,26 @@ class ESENT_PAGE:
         tag = tags[-4:]
 
         if self.__DBHeader['Version'] == 0x620 and self.__DBHeader['FileFormatRevision'] >= 17 and self.__DBHeader['PageSize'] > 8192:
+            # Large page format (16KB / 32KB): page tag flags are stored in the
+            # upper 3 bits of the first 16-bit value of the entry data itself,
+            # not in the tag entry. Tag entries use full 15-bit fields.
             valueSize = unpack('<H', tag[:2])[0] & 0x7fff
             valueOffset = unpack('<H',tag[2:])[0] & 0x7fff
             tmpData = bytearray(self.data[baseOffset+valueOffset:][:valueSize])
-            pageFlags = tmpData[1] >> 5
-            tmpData[1] = tmpData[1:2][0] & 0x1f
-            tmpData = bytes(tmpData)
+            if valueSize >= 2:
+                # Extract page tag flags from the upper 3 bits of the first
+                # 16-bit little-endian value in the entry data (byte index 1
+                # holds the high byte of that 16-bit word).
+                pageFlags = tmpData[1] >> 5
+                tmpData[1] = tmpData[1] & 0x1f
+                tmpData = bytes(tmpData)
+            elif valueSize == 1:
+                pageFlags = 0
+                tmpData = bytes(tmpData)
+            else:
+                # Empty entry (e.g. leaf/branch page header with no common key)
+                pageFlags = 0
+                tmpData = b''
             tagData = tmpData
         else:
             valueSize = unpack('<H', tag[:2])[0] & 0x1fff

--- a/tests/misc/test_ese.py
+++ b/tests/misc/test_ese.py
@@ -25,7 +25,7 @@ class TestESENTLargePageTags(unittest.TestCase):
     VERSION = 0x620
     REVISION = 0x122
 
-    def _build_page(self, raw_tag_state):
+    def _build_page(self, raw_tag_state, payloads=None):
         tag_count = raw_tag_state & FIRST_AVAILABLE_PAGE_TAG_MASK
         header = ESENT_PAGE_HEADER(self.VERSION, self.REVISION, self.PAGE_SIZE)
         header['FirstAvailableDataOffset'] = tag_count * 4
@@ -37,7 +37,10 @@ class TestESENTLargePageTags(unittest.TestCase):
         page[:len(header_bytes)] = header_bytes
 
         base_offset = len(header_bytes)
-        payloads = [bytes([i, i, i, i]) for i in range(tag_count)]
+        if payloads is None:
+            payloads = [bytes([i, i, i, i]) for i in range(tag_count)]
+        self.assertEqual(len(payloads), tag_count)
+
         tags = []
         offset = 0
         for payload in payloads:
@@ -78,6 +81,16 @@ class TestESENTLargePageTags(unittest.TestCase):
 
         iterated_payloads = [page.getTag(tag_num)[1] for tag_num in page.iterDataTagNums()]
         self.assertEqual(iterated_payloads, payloads[page.firstDataTag:])
+
+    def test_large_page_tag_handles_empty_and_single_byte_values(self):
+        page, _ = self._build_page(0x1003, [
+            b'\x11\x22',
+            b'',
+            b'\xab',
+        ])
+
+        self.assertEqual(page.getTag(1), (0, b''))
+        self.assertEqual(page.getTag(2), (0, b'\xab'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Fixes #1924 — `secretsdump.py` crashes with `IndexError: bytearray index out of range` when parsing NTDS.dit files from Windows Server 2025.

## Root Cause

Windows Server 2025 uses **32KB (32768 byte) database pages** in NTDS.dit, up from the previous 8KB (8192 byte) pages. The ESE format specification (revision 0x11+) defines a different page tag format for pages larger than 8KB:

- **Tag entries** use 15-bit fields for both value size and offset (instead of 13-bit + 3-bit flags)
- **Page tag flags** are moved into the upper 3 bits of the first 16-bit value in the entry data itself

The existing code in `getTag()` correctly handles this format *except* when `valueSize` is 0 (empty entries, such as leaf/branch page headers with no common key). In that case, `tmpData` is an empty bytearray and `tmpData[1]` raises `IndexError`.

## The Fix

Added bounds checking before accessing `tmpData[1]` in the large-page code path:

| `valueSize` | Behavior |
|---|---|
| **≥ 2** | Extract flags from `tmpData[1] >> 5` (existing logic, unchanged) |
| **== 1** | Set flags to 0, return single byte as-is |
| **== 0** | Set flags to 0, return empty bytes (**was crashing**) |

The 8KB page code path (the `else` branch) is completely unchanged, preserving backward compatibility.

## References

- [libyal ESE format specification](https://github.com/libyal/libesedb/blob/main/documentation/Extensible%20Storage%20Engine%20(ESE)%20Database%20File%20(EDB)%20format.asciidoc) — documents the page tag format change for 16KB/32KB pages
- Database header from affected NTDS.dit: Version 0x620, Revision 0x122, Page Size 32768

## Testing

- Verified the fix handles all three value size cases (0, 1, ≥2)
- The 8KB page path is untouched (no regression risk for existing databases)
- Confirmed Python compilation succeeds with no syntax errors