### PR TITLE
Adding logic for DCs with RestrictRemoteClients = 2

### DIFF
--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -495,8 +495,34 @@ class RemoteOperations:
         self.__domainName = domain
 
     def __connectDrds(self):
-        stringBinding = epm.hept_map(self.__smbConnection.getRemoteHost(), drsuapi.MSRPC_UUID_DRSUAPI,
-                                     protocol='ncacn_ip_tcp')
+        remote_host = self.__smbConnection.getRemoteHost()
+        try:
+            stringBinding = epm.hept_map(remote_host, drsuapi.MSRPC_UUID_DRSUAPI,
+                                         protocol='ncacn_ip_tcp')
+        except DCERPCException as e:
+            # RestrictRemoteClients = 2 (and similar policies): unauthenticated clients cannot
+            # talk to the TCP Endpoint Mapper (135). Resolve the DRSUAPI port via authenticated
+            # SMB to \\pipe\\epmapper, same pattern as examples/mimikatz.py.
+            if 'rpc_s_access_denied' not in str(e).lower():
+                raise
+            LOG.info('Endpoint Mapper (TCP/135) denied anonymous access; using authenticated epmapper pipe')
+            epm_rpc = transport.DCERPCTransportFactory(r'ncacn_np:445[\pipe\epmapper]')
+            epm_rpc.set_smb_connection(self.__smbConnection)
+            if hasattr(epm_rpc, 'set_credentials'):
+                epm_rpc.set_credentials(*(self.__smbConnection.getCredentials()))
+                epm_rpc.set_kerberos(self.__doKerberos, self.__kdcHost)
+            epm_rpc.setRemoteHost(self.__smbConnection.getRemoteHost())
+            epm_rpc.setRemoteName(self.__smbConnection.getRemoteName())
+            epm_dce = epm_rpc.get_dce_rpc()
+            epm_dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
+            if self.__doKerberos:
+                epm_dce.set_auth_type(RPC_C_AUTHN_GSS_NEGOTIATE)
+            epm_dce.connect()
+            try:
+                stringBinding = epm.hept_map(remote_host, drsuapi.MSRPC_UUID_DRSUAPI,
+                                             protocol='ncacn_ip_tcp', dce=epm_dce)
+            finally:
+                epm_dce.disconnect()
         rpc = transport.DCERPCTransportFactory(stringBinding)
         rpc.setRemoteHost(self.__smbConnection.getRemoteHost())
         rpc.setRemoteName(self.__smbConnection.getRemoteName())


### PR DESCRIPTION
Hi,

I figured that secretsdump fails with a `rpc_c_access_denied` error when a target DC has set the HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Rpc\RestrictRemoteClients = 2.

To resolve this, I added a fallback using the named pipe protocol sequence. 
From Microsoft docs (https://learn.microsoft.com/en-us/windows-server/security/rpc-interface-restrict): "RPC clients that use the named pipe protocol sequence (ncacn_np) are exempt from all restrictions discussed in this section. The named pipe protocol sequence can't be restricted due to significant backwards compatibility issues." 

This patch aims at resolving that. I tested it in my lab and did not see any adverse effects. (I also tried to not touch any working behavior, this is a pure fallback implementation).
A longline is printed whenever we fall back to a named pipe.

Hope this helps others as well. In case of questions let me know.

