### PR TITLE
dpapi.py QoL improvements

### DIFF
--- a/examples/dpapi.py
+++ b/examples/dpapi.py
@@ -471,7 +471,11 @@ class DPAPI:
                 decrypted = blob.decrypt(key, entropy)
                 if decrypted is not None:
                     print('Successfully decrypted data')
-                    hexdump(decrypted)
+                    if self.options.outfile is not None:
+                        with open(self.options.outfile, 'wb') as f:
+                            f.write(decrypted)
+                    else:
+                        hexdump(decrypted)
                     return
             else:
                 # Just print the data
@@ -602,6 +606,7 @@ if __name__ == '__main__':
     unprotect.add_argument('-key', action='store', required=False, help='Key used for decryption')
     unprotect.add_argument('-entropy', action='store', default=None, required=False, help='String with extra entropy needed for decryption')
     unprotect.add_argument('-entropy-file', action='store', default=None, required=False, help='File with binary entropy contents (overwrites -entropy)')
+    unprotect.add_argument('-outfile', action='store', default=None, required=False, help='File to write decrypted data to (if not specified, it will be printed as hexdump)')
 
     # A CREDHIST command
     credhist = subparsers.add_parser('credhist', help='CREDHIST related functions')

--- a/examples/dpapi.py
+++ b/examples/dpapi.py
@@ -75,8 +75,8 @@ class DPAPI:
             machineKey, userKey = secret.split('\n')
             machineKey = machineKey.split(':')[1]
             userKey = userKey.split(':')[1]
-            self.dpapiSystem['MachineKey'] = unhexlify(machineKey[2:])
-            self.dpapiSystem['UserKey'] = unhexlify(userKey[2:])
+            self.dpapiSystem['MachineKey'] = unhexlify(machineKey.removeprefix("0x"))
+            self.dpapiSystem['UserKey'] = unhexlify(userKey.removeprefix("0x"))
 
     def getLSA(self):
         localOperations = LocalOperations(self.options.system)
@@ -164,7 +164,7 @@ class DPAPI:
                     print('Decrypted key: 0x%s' % hexlify(decryptedKey).decode('latin-1'))
                     return
             elif self.options.key and self.options.sid:
-                key = unhexlify(self.options.key[2:])
+                key = unhexlify(self.options.key.removeprefix("0x"))
                 key1, key2 = deriveKeysFromUserkey(self.options.sid, key)
                 decryptedKey = mk.decrypt(key1)
                 if decryptedKey:
@@ -177,7 +177,7 @@ class DPAPI:
                     print('Decrypted key: 0x%s' % hexlify(decryptedKey).decode('latin-1'))
                     return
             elif self.options.key:
-                key = unhexlify(self.options.key[2:])
+                key = unhexlify(self.options.key.removeprefix("0x"))
                 decryptedKey = mk.decrypt(key)
                 if decryptedKey:
                     print('Decrypted key with key provided')
@@ -393,7 +393,7 @@ class DPAPI:
             blob = DPAPI_BLOB(cred['Data'])
 
             if self.options.key is not None:
-                key = unhexlify(self.options.key[2:])
+                key = unhexlify(self.options.key.removeprefix("0x"))
                 decrypted = blob.decrypt(key)
                 if decrypted is not None:
                     creds = CREDENTIAL_BLOB(decrypted)
@@ -413,7 +413,7 @@ class DPAPI:
                 blob = VAULT_VCRD(data)
 
                 if self.options.key is not None:
-                    key = unhexlify(self.options.key[2:])
+                    key = unhexlify(self.options.key.removeprefix("0x"))
 
                     cleartext = None
                     for i, entry in enumerate(blob.attributesLen):
@@ -445,7 +445,7 @@ class DPAPI:
                 vpol.dump()
 
                 if self.options.key is not None:
-                    key = unhexlify(self.options.key[2:])
+                    key = unhexlify(self.options.key.removeprefix("0x"))
                     blob = vpol['Blob']
                     data = blob.decrypt(key)
                     if data is not None:
@@ -458,7 +458,7 @@ class DPAPI:
             blob = DPAPI_BLOB(data)
 
             if self.options.key is not None:
-                key = unhexlify(self.options.key[2:])
+                key = unhexlify(self.options.key.removeprefix("0x"))
                 if self.options.entropy_file is not None:
                     fp2 = open(self.options.entropy_file, 'rb')
                     entropy = fp2.read()
@@ -492,7 +492,7 @@ class DPAPI:
 
             # Handle key options
             if self.options.key:
-                key = unhexlify(self.options.key[2:])
+                key = unhexlify(self.options.key.removeprefix("0x"))
                 keys = deriveKeysFromUserkey(chf.credhist_entries_list[0].sid, key)
 
             # Only other option is using a password

--- a/examples/dpapi.py
+++ b/examples/dpapi.py
@@ -70,13 +70,16 @@ class DPAPI:
         self.dpapiSystem = {}
         pass
 
+    def parseHexKey(self, key):
+        return unhexlify(key.removeprefix("0x"))
+
     def getDPAPI_SYSTEM(self,secretType, secret):
         if secret.startswith("dpapi_machinekey:"):
             machineKey, userKey = secret.split('\n')
             machineKey = machineKey.split(':')[1]
             userKey = userKey.split(':')[1]
-            self.dpapiSystem['MachineKey'] = unhexlify(machineKey.removeprefix("0x"))
-            self.dpapiSystem['UserKey'] = unhexlify(userKey.removeprefix("0x"))
+            self.dpapiSystem['MachineKey'] = self.parseHexKey(machineKey)
+            self.dpapiSystem['UserKey'] = self.parseHexKey(userKey)
 
     def getLSA(self):
         localOperations = LocalOperations(self.options.system)
@@ -164,7 +167,7 @@ class DPAPI:
                     print('Decrypted key: 0x%s' % hexlify(decryptedKey).decode('latin-1'))
                     return
             elif self.options.key and self.options.sid:
-                key = unhexlify(self.options.key.removeprefix("0x"))
+                key = self.parseHexKey(self.options.key)
                 key1, key2 = deriveKeysFromUserkey(self.options.sid, key)
                 decryptedKey = mk.decrypt(key1)
                 if decryptedKey:
@@ -177,7 +180,7 @@ class DPAPI:
                     print('Decrypted key: 0x%s' % hexlify(decryptedKey).decode('latin-1'))
                     return
             elif self.options.key:
-                key = unhexlify(self.options.key.removeprefix("0x"))
+                key = self.parseHexKey(self.options.key)
                 decryptedKey = mk.decrypt(key)
                 if decryptedKey:
                     print('Decrypted key with key provided')
@@ -393,7 +396,7 @@ class DPAPI:
             blob = DPAPI_BLOB(cred['Data'])
 
             if self.options.key is not None:
-                key = unhexlify(self.options.key.removeprefix("0x"))
+                key = self.parseHexKey(self.options.key)
                 decrypted = blob.decrypt(key)
                 if decrypted is not None:
                     creds = CREDENTIAL_BLOB(decrypted)
@@ -413,7 +416,7 @@ class DPAPI:
                 blob = VAULT_VCRD(data)
 
                 if self.options.key is not None:
-                    key = unhexlify(self.options.key.removeprefix("0x"))
+                    key = self.parseHexKey(self.options.key)
 
                     cleartext = None
                     for i, entry in enumerate(blob.attributesLen):
@@ -445,7 +448,7 @@ class DPAPI:
                 vpol.dump()
 
                 if self.options.key is not None:
-                    key = unhexlify(self.options.key.removeprefix("0x"))
+                    key = self.parseHexKey(self.options.key)
                     blob = vpol['Blob']
                     data = blob.decrypt(key)
                     if data is not None:
@@ -458,7 +461,7 @@ class DPAPI:
             blob = DPAPI_BLOB(data)
 
             if self.options.key is not None:
-                key = unhexlify(self.options.key.removeprefix("0x"))
+                key = self.parseHexKey(self.options.key)
                 if self.options.entropy_file is not None:
                     fp2 = open(self.options.entropy_file, 'rb')
                     entropy = fp2.read()
@@ -492,7 +495,7 @@ class DPAPI:
 
             # Handle key options
             if self.options.key:
-                key = unhexlify(self.options.key.removeprefix("0x"))
+                key = self.parseHexKey(self.options.key)
                 keys = deriveKeysFromUserkey(chf.credhist_entries_list[0].sid, key)
 
             # Only other option is using a password

--- a/impacket/dpapi.py
+++ b/impacket/dpapi.py
@@ -634,7 +634,12 @@ class DPAPI_BLOB(Structure):
         return derivedKey
 
     def decrypt(self, key, entropy = None):
-        keyHash = SHA1.new(key).digest()
+        if len(key) == 20:
+            # Key has already been hashed
+            keyHash = key
+        else:
+            keyHash = SHA1.new(key).digest()
+        
         sessionKey = HMAC.new(keyHash, self['Salt'], ALGORITHMS_DATA[self['HashAlgo']][1])
         if entropy is not None:
             sessionKey.update(entropy)


### PR DESCRIPTION
Three improvements:
- The `unprotect` command now auto-detects whether the supplied key is a "plaintext" key or a pre-hashed SHA1 key, rather than requiring the plaintext key. Most key-dumping tools output the SHA1 hash of relevant keys, so they can now be used directly. 
- Added an `-outfile` flag to the `unprotect` command so decrypted files can be written directly to disk, which is often much more useful than a printed hexdump. 
- All `-key` flags for all commands now handle hexstrings with and without a `0x` prefix, rather than blindly and silently discarding the first two bytes of input. 