### PR TITLE
Fix Issues with ACE type filtering and ObjectType GUID parsing in BadSuccessor.py search_ous() that causes False negatives

### DIFF
--- a/examples/badsuccessor.py
+++ b/examples/badsuccessor.py
@@ -296,7 +296,7 @@ class BADSUCCESSOR:
                                 continue
                             #Fix two: The guid conversion was wrong and one actually reads the bytes correctly and converts them to real GUIDs for processing later
                             ace_data = ace['Ace']
-                            object_type = ace_data['ObjectType']
+                            object_type = ace_data['ObjectType'] if ace['AceType'] == ldaptypes.ACCESS_ALLOWED_OBJECT_ACE.ACE_TYPE else None
                             
                             if object_type:
                                 object_guid = str(uuid.UUID(bytes_le=object_type)).lower()

--- a/examples/badsuccessor.py
+++ b/examples/badsuccessor.py
@@ -281,8 +281,12 @@ class BADSUCCESSOR:
                     dacl = sd['Dacl']
                     if dacl and hasattr(dacl, 'aces') and dacl.aces:
                         for ace in dacl.aces:
-                            # Only process ALLOW ACEs
-                            if ace['AceType'] != ldaptypes.ACCESS_ALLOWED_ACE.ACE_TYPE:
+                            #Ensure we parse and process standard ACE and Object Specific ACE
+                            allowed_types = [
+                                ldaptypes.ACCESS_ALLOWED_ACE.ACE_TYPE,
+                                ldaptypes.ACCESS_ALLOWED_OBJECT_ACE.ACE_TYPE
+                            ]
+                            if ace['AceType'] not in allowed_types:
                                 continue
                                 
                             # Check if ACE has relevant rights

--- a/examples/badsuccessor.py
+++ b/examples/badsuccessor.py
@@ -32,7 +32,7 @@ from impacket import version
 from impacket.examples import logger
 from impacket.examples.utils import parse_identity, parse_target, init_ldap_session
 from impacket.ldap import ldaptypes
-
+import uuid #needed for proper GUID conversion
 
 class BADSUCCESSOR:
     def __init__(self, username, password, domain, lmhash, nthash, cmdLineOptions):
@@ -281,7 +281,7 @@ class BADSUCCESSOR:
                     dacl = sd['Dacl']
                     if dacl and hasattr(dacl, 'aces') and dacl.aces:
                         for ace in dacl.aces:
-                            #Ensure we parse and process standard ACE and Object Specific ACE
+                            #Fix 1, Ensure we parse and process standard ACE and Object Specific ACE
                             allowed_types = [
                                 ldaptypes.ACCESS_ALLOWED_ACE.ACE_TYPE,
                                 ldaptypes.ACCESS_ALLOWED_OBJECT_ACE.ACE_TYPE
@@ -294,11 +294,13 @@ class BADSUCCESSOR:
                             has_relevant_right = any(mask & right_value for right_value in relevant_rights.values())
                             if not has_relevant_right:
                                 continue
+                            #Fix two: The guid conversion was wrong and one actually reads the bytes correctly and converts them to real GUIDs for processing later
+                            ace_data = ace['Ace']
+                            object_type = ace_data['ObjectType']
                             
-                            # Check object type (must match relevant object types)
-                            object_type = getattr(ace['Ace'], 'ObjectType', None)
                             if object_type:
-                                object_guid = str(object_type).lower()
+                                object_guid = str(uuid.UUID(bytes_le=object_type)).lower()
+                                logging.debug(object_guid)
                                 if object_guid not in relevant_object_types:
                                     continue
                                 


### PR DESCRIPTION
this pr fixes two issues in the badsuccessor.py search_ous() function which is in charge of finding actually finding/detecting the badsuccessor vuln. 

First, the ACE filtering logic was only processing standard allow ACEs and was not correctly handling object-specific allow ACEs. This meant relevant ACCESS_ALLOWED_OBJECT_ACE entries were discarded in the if block of `search_ous()`. Even tho these can cause the same vulnerability to arise and the original Akamai script successfully detects. 

Second, object-specific ACE filtering by schema object type was not working and instead it just failed silently. This causes us to pick up identifies that we don't usually want(like print and account operators). Previously, the code  attempted to read ObjectType via getattr(...) and compared the raw bytes value directly, which prevented valid schema GUIDs from being parsed and matched with what the code is actually looking for.

These issue is not present in the powershell implementation of the exploit as powershell uses .NET that handles this appropriately. 

A vendor product in my clients environment created an OU that was vulnerable and the script was not able to detect it. I only found it by chance and upon trying the powershell version, I was able to confirm the vulnerability. 

Additionally, I would like to open a separate PR to port badsuccesor and other scripts off ldap3 and to impackets ldap. I have faced in this engagement issues with tooling not working with ldap3 because of the fact that it doesn't support SASL with NTLM authentication when I want to connect to a DC with LDAP signing without a TLS cert present on LDAPS. 