### PR TITLE
Added new Documentation section and installation guide link reference to the Setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Documentation
 
 Setup
 =====
+> :link: For full installation instructions including using docker, virtual environments, dependency details, upgrading impacket, and troubleshooting, see the [Installation Guide](https://mintlify.wiki/fortra/impacket/installation).
 
 ### Quick start
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Table of Contents
 =================
 
 * [Getting Impacket](#getting-impacket)
+* [Documentation](#documentation)
 * [Setup](#setup)
 * [Testing](#testing)
 * [Licensing](#licensing)
@@ -64,6 +65,11 @@ Getting Impacket
 
   [![Python versions](https://img.shields.io/badge/python-3.9%20|%203.10%20|%203.11%20|%203.12%20|%203.13-blue.svg)](https://github.com/fortra/impacket/tree/master)
 
+Documentation
+=============
+
+* [Introduction & Overview](https://mintlify.wiki/fortra/impacket/introduction) — Covers Impacket's architecture, supported protocols, authentication mechanisms, and examples/tools and advanced topics
+* [API Reference](https://mintlify.wiki/fortra/impacket/api/smb) — Full class and method documentation for core modules, DCE/RPC, Kerberos authentication handling, LDAP and utilities.
 
 Setup
 =====


### PR DESCRIPTION
Hi there, I noticed on #1566 and in other online channels such as on discord etc people don't appear to know there's documentation for impacket and that there's a API reference present. 

Additionally the setup section in the readme could be better placed to have a reference to the fuller installation guide that includes a lot more details such as supported python versions, troubleshooting, how to set up virtual environments, and upgrading the lib.  

This PR creates a new section, `Documentation`, and added a link to reference the installation guide in the `setup` section.

Happy to change the order or anything but I think this is simple, clean and offers a proper way for people to find the impacket documentation to make the project more accessible. 