### PR TITLE
secretsdump: Filter offline NTDS accounts by local domain SID

### DIFF
--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -175,6 +175,7 @@ class DumpSecrets:
 
     def dump(self):
         try:
+            localDomainSid = None
             # Almost like LOCAL but create (and deletes it after finishing) a Shadow Snapshot at target and download SAM, SYSTEM and SECURITY from the SS. No Code Execution.
             # If specified, NTDS will be also downloaded and parsed (no code execution needed, in contrast to vssadmin method). Use it when targeting a DC.
             # Then, parse locally
@@ -315,13 +316,19 @@ class DumpSecrets:
                 else:
                     NTDSFileName = self.__ntdsFile
 
+                if NTDSFileName is not None:
+                    try:
+                        localDomainSid = NTDSHashes.getLocalDomainSid(NTDSFileName, isRemote=self.__isRemote)
+                    except Exception as e:
+                        logging.debug('Failed to resolve local domain SID from the pekList row: %s', e)
+
                 self.__NTDSHashes = NTDSHashes(NTDSFileName, bootKey, isRemote=self.__isRemote, history=self.__history,
                                                noLMHash=self.__noLMHash, remoteOps=self.__remoteOps,
                                                useVSSMethod=self.__useVSSMethod, remoteSSMethodWMINTDS=self.__remoteSSWMINTDS, justNTLM=self.__justDCNTLM,
                                                pwdLastSet=self.__pwdLastSet, resumeSession=self.__resumeFileName,
                                                outputFileName=self.__outputFileName, justUser=self.__justUser,
                                                skipUser=self.__skipUser, ldapFilter=self.__ldapFilter,
-                                               printUserStatus=self.__printUserStatus)
+                                               printUserStatus=self.__printUserStatus, localDomainSid=localDomainSid)
                 try:
                     self.__NTDSHashes.dump()
                 except Exception as e:

--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -318,9 +318,12 @@ class DumpSecrets:
 
                 if NTDSFileName is not None:
                     try:
-                        localDomainSid = NTDSHashes.getLocalDomainSid(NTDSFileName, isRemote=self.__isRemote)
+                        if self.__isRemote is True:
+                            localDomainSid = self.__remoteOps.getDomainSid()
+                        else:
+                            localDomainSid = NTDSHashes.getLocalDomainSid(NTDSFileName)
                     except Exception as e:
-                        logging.debug('Failed to resolve local domain SID from the pekList row: %s', e)
+                        logging.debug('Failed to resolve local domain SID: %s', e)
 
                 self.__NTDSHashes = NTDSHashes(NTDSFileName, bootKey, isRemote=self.__isRemote, history=self.__history,
                                                noLMHash=self.__noLMHash, remoteOps=self.__remoteOps,

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -70,6 +70,7 @@ from impacket import system_errors
 from impacket import winregistry, ntlm
 from impacket.ldap.ldap import SimplePagedResultsControl, LDAPSearchError
 from impacket.ldap.ldapasn1 import SearchResultEntry
+from impacket.ldap.ldaptypes import LDAP_SID
 from impacket.dcerpc.v5 import transport, rrp, scmr, wkst, samr, epm, drsuapi
 from impacket.dcerpc.v5.dtypes import NULL, SID
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_LEVEL_PKT_PRIVACY, DCERPCException, RPC_C_AUTHN_GSS_NEGOTIATE
@@ -2605,7 +2606,7 @@ class NTDSHashes:
 
     def __init__(self, ntdsFile, bootKey, isRemote=False, history=False, noLMHash=True, remoteOps=None,
                  useVSSMethod=False, remoteSSMethodWMINTDS=False, justNTLM=False, pwdLastSet=False, resumeSession=None, outputFileName=None,
-                 justUser=None, skipUser=None,ldapFilter=None, printUserStatus=False,
+                 justUser=None, skipUser=None, ldapFilter=None, printUserStatus=False, localDomainSid=None,
                  perSecretCallback = lambda secretType, secret : _print_helper(secret),
                  resumeSessionMgr=ResumeSessionMgrInFile):
         self.__bootKey = bootKey
@@ -2617,6 +2618,7 @@ class NTDSHashes:
         self.__remoteOps = remoteOps
         self.__pwdLastSet = pwdLastSet
         self.__printUserStatus = printUserStatus
+        self.__localDomainSid = localDomainSid
         if self.__NTDS is not None:
             self.__ESEDB = ESENT_DB(ntdsFile, isRemote = isRemote)
             self.__cursor = self.__ESEDB.openTable('datatable')
@@ -2649,9 +2651,92 @@ class NTDSHashes:
             self.NAME_TO_INTERNAL['userAccountControl'] : 1,
             self.NAME_TO_INTERNAL['supplementalCredentials'] : 1,
             self.NAME_TO_INTERNAL['pekList'] : 1,
-            self.NAME_TO_INTERNAL['instanceType'] : 1,
 
         }
+
+    @classmethod
+    def __getOfflineDatatableSidComponents(cls, objectSid, minimumSubAuthorityCount, context):
+        try:
+            sid = LDAP_SID(data=unhexlify(objectSid))
+            canonicalSid = sid.formatCanonical().split('-')
+        except Exception as e:
+            LOG.debug('Failed to parse %s while normalizing an offline datatable SID: %s', context, e)
+            return None
+
+        # TODO: Offline datatable objectSid values in our samples only reconcile the
+        # domain root/pekList row with account rows when the final subauthority is
+        # interpreted as big-endian. Keep this mixed decoding limited to offline
+        # datatable SID normalization for NTDS row filtering until the on-disk
+        # encoding/parsing mismatch is better understood.
+        if sid['SubAuthorityCount'] < minimumSubAuthorityCount:
+            LOG.debug('Ignoring unexpected %s without the expected domain SID shape: %s', context,
+                      sid.formatCanonical())
+            return None
+
+        subAuthorities = sid['SubAuthority']
+        canonicalSid[-1] = str(unpack('>L', subAuthorities[-4:])[0])
+        return canonicalSid
+
+    @classmethod
+    def __getAccountDomainSid(cls, objectSid):
+        sidComponents = cls.__getOfflineDatatableSidComponents(objectSid, 5, 'account objectSid')
+        if sidComponents is None:
+            return None
+        return '-'.join(sidComponents[:-1])
+
+    @classmethod
+    def __getPekListDomainSid(cls, objectSid):
+        sidComponents = cls.__getOfflineDatatableSidComponents(objectSid, 4, 'pekList objectSid')
+        if sidComponents is None:
+            return None
+        return '-'.join(sidComponents)
+
+    @classmethod
+    def getLocalDomainSid(cls, ntdsFile, isRemote=False):
+        if ntdsFile is None:
+            return None
+
+        eseDB = ESENT_DB(ntdsFile, isRemote=isRemote)
+        try:
+            cursor = eseDB.openTable('datatable')
+            filter_tables = {
+                cls.NAME_TO_INTERNAL['objectSid']: 1,
+                cls.NAME_TO_INTERNAL['pekList']: 1,
+            }
+
+            while True:
+                try:
+                    record = eseDB.getNextRow(cursor, filter_tables=filter_tables)
+                except Exception:
+                    LOG.error('Error while calling getNextRow() for local domain SID resolution, trying the next one')
+                    continue
+
+                if record is None:
+                    return None
+
+                if record[cls.NAME_TO_INTERNAL['pekList']] is None:
+                    continue
+
+                objectSid = record[cls.NAME_TO_INTERNAL['objectSid']]
+                if objectSid is None:
+                    return None
+
+                return cls.__getPekListDomainSid(objectSid)
+        finally:
+            eseDB.close()
+
+    def __isLocalDomainAccount(self, record):
+        if record[self.NAME_TO_INTERNAL['sAMAccountType']] not in self.ACCOUNT_TYPES:
+            return False
+
+        if self.__localDomainSid is None:
+            return True
+
+        objectSid = record[self.NAME_TO_INTERNAL['objectSid']]
+        if objectSid is None:
+            return False
+
+        return self.__getAccountDomainSid(objectSid) == self.__localDomainSid
 
     def getResumeSessionFile(self):
         return self.__resumeSession.getFileName()
@@ -2671,7 +2756,7 @@ class NTDSHashes:
             elif record[self.NAME_TO_INTERNAL['pekList']] is not None:
                 peklist =  unhexlify(record[self.NAME_TO_INTERNAL['pekList']])
                 break
-            elif record[self.NAME_TO_INTERNAL['sAMAccountType']] in self.ACCOUNT_TYPES and record[self.NAME_TO_INTERNAL['instanceType']] & 4:    # "The object is writable on this directory":
+            elif self.__isLocalDomainAccount(record):
                 # Okey.. we found some users, but we're not yet ready to process them.
                 # Let's just store them in a temp list
                 self.__tmpUsers.append(record)
@@ -3198,7 +3283,7 @@ class NTDSHashes:
                         if record is None:
                             break
                         try:
-                            if record[self.NAME_TO_INTERNAL['sAMAccountType']] in self.ACCOUNT_TYPES and record[self.NAME_TO_INTERNAL['instanceType']] & 4:    # "The object is writable on this directory"
+                            if self.__isLocalDomainAccount(record):
                                 self.__decryptHash(record, outputFile=hashesOutputFile)
                                 if self.__justNTLM is False:
                                     self.__decryptSupplementalInfo(record, None, keysOutputFile, clearTextOutputFile)
@@ -3440,14 +3525,17 @@ class LocalOperations:
     def __init__(self, systemHive):
         self.__systemHive = systemHive
 
+    def __getCurrentControlSet(self, winreg):
+        currentControlSet = winreg.getValue('\\Select\\Current')[1]
+        return "ControlSet%03d" % currentControlSet
+
     def getBootKey(self):
         # Local Version whenever we are given the files directly
         bootKey = b''
         tmpKey = b''
         winreg = winregistry.get_registry_parser(self.__systemHive, False)
         # We gotta find out the Current Control Set
-        currentControlSet = winreg.getValue('\\Select\\Current')[1]
-        currentControlSet = "ControlSet%03d" % currentControlSet
+        currentControlSet = self.__getCurrentControlSet(winreg)
         for key in ['JD', 'Skew1', 'GBG', 'Data']:
             LOG.debug('Retrieving class info for %s' % key)
             ans = winreg.getClass('\\%s\\Control\\Lsa\\%s' % (currentControlSet, key))
@@ -3470,8 +3558,7 @@ class LocalOperations:
         LOG.debug('Checking NoLMHash Policy')
         winreg = winregistry.get_registry_parser(self.__systemHive, False)
         # We gotta find out the Current Control Set
-        currentControlSet = winreg.getValue('\\Select\\Current')[1]
-        currentControlSet = "ControlSet%03d" % currentControlSet
+        currentControlSet = self.__getCurrentControlSet(winreg)
 
         # noLmHash = winreg.getValue('\\%s\\Control\\Lsa\\NoLmHash' % currentControlSet)[1]
         noLmHash = winreg.getValue('\\%s\\Control\\Lsa\\NoLmHash' % currentControlSet)
@@ -3485,7 +3572,6 @@ class LocalOperations:
             return False
         LOG.debug('LMHashes are NOT being stored')
         return True
-
 
 class KeyListSecrets:
     def __init__(self, domainName, kdc, kvno, rodcKey, remoteOps=None):

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -2485,6 +2485,9 @@ class ResumeSessionMgrInFile(object):
 
 
 class NTDSHashes:
+    class MissingPekIndex(Exception):
+        pass
+
     class SECRET_TYPE:
         NTDS = 0
         NTDS_CLEARTEXT = 1
@@ -2808,14 +2811,22 @@ class NTDSHashes:
     def __removeRC4Layer(self, cryptedHash):
         md5 = hashlib.new('md5')
         # PEK index can be found on header of each ciphered blob (pos 8-10)
-        pekIndex = hexlify(cryptedHash['Header'])
-        md5.update(self.__PEK[int(pekIndex[8:10])])
+        md5.update(self.__getPekFromHeader(cryptedHash['Header']))
         md5.update(cryptedHash['KeyMaterial'])
         tmpKey = md5.digest()
         rc4 = ARC4.new(tmpKey)
         plainText = rc4.encrypt(cryptedHash['EncryptedHash'])
 
         return plainText
+
+    def __getPekFromHeader(self, header):
+        # PEK index can be found on header of each ciphered blob (pos 8-10).
+        pekIndex = int(hexlify(header)[8:10], 16)
+        if pekIndex >= len(self.__PEK):
+            raise self.MissingPekIndex('Encrypted secret references PEK index %d, but only %d PEK entries are available' %
+                                       (pekIndex, len(self.__PEK)))
+
+        return self.__PEK[pekIndex]
 
     def __removeDESLayer(self, cryptedHash, rid):
         Key1,Key2 = self.__cryptoCommon.deriveKey(int(rid))
@@ -2853,8 +2864,7 @@ class NTDSHashes:
 
                     if cipherText['Header'][:4] == b'\x13\x00\x00\x00':
                         # Win2016 TP4 decryption is different
-                        pekIndex = hexlify(cipherText['Header'])
-                        plainText = self.__cryptoCommon.decryptAES(self.__PEK[int(pekIndex[8:10])],
+                        plainText = self.__cryptoCommon.decryptAES(self.__getPekFromHeader(cipherText['Header']),
                                                                    cipherText['EncryptedHash'][4:],
                                                                    cipherText['KeyMaterial'])
                         haveInfo = True
@@ -2968,8 +2978,7 @@ class NTDSHashes:
                 if encryptedLMHash['Header'][:4] == b'\x13\x00\x00\x00':
                     # Win2016 TP4 decryption is different
                     encryptedLMHash = self.CRYPTED_HASHW16(unhexlify(record[self.NAME_TO_INTERNAL['dBCSPwd']]))
-                    pekIndex = hexlify(encryptedLMHash['Header'])
-                    tmpLMHash = self.__cryptoCommon.decryptAES(self.__PEK[int(pekIndex[8:10])],
+                    tmpLMHash = self.__cryptoCommon.decryptAES(self.__getPekFromHeader(encryptedLMHash['Header']),
                                                                encryptedLMHash['EncryptedHash'][:16],
                                                                encryptedLMHash['KeyMaterial'])
                 else:
@@ -2983,8 +2992,7 @@ class NTDSHashes:
                 if encryptedNTHash['Header'][:4] == b'\x13\x00\x00\x00':
                     # Win2016 TP4 decryption is different
                     encryptedNTHash = self.CRYPTED_HASHW16(unhexlify(record[self.NAME_TO_INTERNAL['unicodePwd']]))
-                    pekIndex = hexlify(encryptedNTHash['Header'])
-                    tmpNTHash = self.__cryptoCommon.decryptAES(self.__PEK[int(pekIndex[8:10])],
+                    tmpNTHash = self.__cryptoCommon.decryptAES(self.__getPekFromHeader(encryptedNTHash['Header']),
                                                                encryptedNTHash['EncryptedHash'][:16],
                                                                encryptedNTHash['KeyMaterial'])
                 else:
@@ -3042,8 +3050,7 @@ class NTDSHashes:
                         # Win2016 TP4 decryption is different
                         encryptedNTHistory = self.CRYPTED_HASHW16(
                             unhexlify(record[self.NAME_TO_INTERNAL['ntPwdHistory']]))
-                        pekIndex = hexlify(encryptedNTHistory['Header'])
-                        tmpNTHistory = self.__cryptoCommon.decryptAES(self.__PEK[int(pekIndex[8:10])],
+                        tmpNTHistory = self.__cryptoCommon.decryptAES(self.__getPekFromHeader(encryptedNTHistory['Header']),
                                                                       encryptedNTHistory['EncryptedHash'],
                                                                       encryptedNTHistory['KeyMaterial'])
                     else:
@@ -3261,6 +3268,13 @@ class NTDSHashes:
                             if self.__justNTLM is False:
                                 self.__decryptSupplementalInfo(record, None, keysOutputFile, clearTextOutputFile)
                         except Exception as e:
+                            if isinstance(e, self.MissingPekIndex):
+                                try:
+                                    LOG.warning("Skipping row for user %s: %s" %
+                                                (record[self.NAME_TO_INTERNAL['name']], e))
+                                except:
+                                    LOG.warning("Skipping row: %s" % e)
+                                continue
                             LOG.debug('Exception', exc_info=True)
                             try:
                                 LOG.error(
@@ -3288,6 +3302,13 @@ class NTDSHashes:
                                 if self.__justNTLM is False:
                                     self.__decryptSupplementalInfo(record, None, keysOutputFile, clearTextOutputFile)
                         except Exception as e:
+                            if isinstance(e, self.MissingPekIndex):
+                                try:
+                                    LOG.warning("Skipping row for user %s: %s" %
+                                                (record[self.NAME_TO_INTERNAL['name']], e))
+                                except:
+                                    LOG.warning("Skipping row: %s" % e)
+                                continue
                             LOG.debug('Exception', exc_info=True)
                             try:
                                 LOG.error(

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -872,7 +872,7 @@ class SMBConnection:
         """
 
         # Verify we're under SMB2+ session
-        if self.getDialect() not in [SMB2_DIALECT_002, SMB2_DIALECT_21, SMB2_DIALECT_30]:
+        if self.getDialect() not in [SMB2_DIALECT_002, SMB2_DIALECT_21, SMB2_DIALECT_30, SMB2_DIALECT_311]:
             raise SessionError(error = nt_errors.STATUS_NOT_SUPPORTED)
 
         fid = self.openFile(tid, path, FILE_READ_DATA | FILE_READ_EA | FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE,


### PR DESCRIPTION
Previously, when parsing NTDS databases offline, secretsdump relied on checking instanceType & 4 (the object is writable) to identify and filter local domain accounts (#1759) . However, this approach can be imprecise and does not reliably isolate accounts strictly belonging to the target domain, which causes failures when extracting hashes from Read-Only Domain Controllers (RODCs) or multi-domain forest environments (#2105).

This PR improves the accuracy of account filtering during offline NTDS extraction by explicitly checking the account's Domain SID. By extracting the local domain SID from the pekList row and comparing it against the objectSid of each account, we ensure that only the relevant local domain accounts are processed and dumped.