### PR TITLE
ISSUE-1077: addcomputer: add SAMR_LDAP finalization mode

### DIFF
--- a/examples/addcomputer.py
+++ b/examples/addcomputer.py
@@ -74,13 +74,13 @@ class ADDCOMPUTER:
         if self.__targetIp is not None:
             self.__kdcHost = self.__targetIp
 
-        if self.__method not in ['SAMR', 'LDAPS']:
+        if self.__method not in ['SAMR', 'LDAPS', 'SAMR_LDAP', 'LDAP_FINALIZE']:
             raise ValueError("Unsupported method %s" % self.__method)
 
         if self.__doKerberos and cmdLineOptions.dc_host is None:
             raise ValueError("Kerberos auth requires DNS name of the target DC. Use -dc-host.")
 
-        if self.__method == 'LDAPS' and not '.' in self.__domain:
+        if self.__method in ['LDAPS', 'SAMR_LDAP', 'LDAP_FINALIZE'] and not '.' in self.__domain:
                 logging.warning('\'%s\' doesn\'t look like a FQDN. Generating baseDN will probably fail.' % self.__domain)
 
         if cmdLineOptions.hashes is not None:
@@ -106,13 +106,15 @@ class ADDCOMPUTER:
         if self.__port is None:
             if self.__method == 'SAMR':
                 self.__port = 445
-            elif self.__method == 'LDAPS':
+            elif self.__method in ['LDAPS', 'LDAP_FINALIZE']:
                 self.__port = 636
+            elif self.__method == 'SAMR_LDAP':
+                self.__port = 445
 
         if self.__domainNetbios is None:
             self.__domainNetbios = self.__domain
 
-        if self.__method == 'LDAPS' and self.__baseDN is None:
+        if self.__method in ['LDAPS', 'SAMR_LDAP', 'LDAP_FINALIZE'] and self.__baseDN is None:
              # Create the baseDN
             domainParts = self.__domain.split('.')
             self.__baseDN = ''
@@ -186,18 +188,13 @@ class ADDCOMPUTER:
                             break
 
 
-                computerHostname = self.__computerName[:-1]
+                computerHostname = self.getComputerHostname()
                 computerDn = ('CN=%s,%s' % (computerHostname, self.__computerGroup))
 
                 # Default computer SPNs
-                spns = [
-                    'HOST/%s' % computerHostname,
-                    'HOST/%s.%s' % (computerHostname, self.__domain),
-                    'RestrictedKrbHost/%s' % computerHostname,
-                    'RestrictedKrbHost/%s.%s' % (computerHostname, self.__domain),
-                ]
+                spns = self.buildDefaultComputerSPNs(computerHostname)
                 ucd = {
-                    'dnsHostName': '%s.%s' % (computerHostname, self.__domain),
+                    'dnsHostName': self.buildComputerDnsHostname(computerHostname),
                     'userAccountControl': 0x1000,
                     'servicePrincipalName': spns,
                     'sAMAccountName': self.__computerName,
@@ -236,6 +233,56 @@ class ADDCOMPUTER:
 
     def generateComputerName(self):
         return 'DESKTOP-' + (''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(8)) + '$')
+
+    def getComputerHostname(self):
+        return self.__computerName[:-1]
+
+    def buildComputerDnsHostname(self, computerHostname):
+        return '%s.%s' % (computerHostname, self.__domain)
+
+    def buildDefaultComputerSPNs(self, computerHostname):
+        return [
+            'HOST/%s' % computerHostname,
+            'HOST/%s.%s' % (computerHostname, self.__domain),
+            'RestrictedKrbHost/%s' % computerHostname,
+            'RestrictedKrbHost/%s.%s' % (computerHostname, self.__domain),
+        ]
+
+    def LDAPFinalizeComputerAccount(self):
+        if self.__method != 'LDAP_FINALIZE' and (self.__noAdd or self.__delete):
+            return
+
+        if self.__computerName is None:
+            raise ValueError("You have to provide a computer name when using LDAP_FINALIZE.")
+
+        if self.__baseDN is None:
+            raise ValueError("Unable to determine baseDN. Use -baseDN or provide a FQDN domain.")
+
+        computerHostname = self.getComputerHostname()
+        dnsHostname = self.buildComputerDnsHostname(computerHostname)
+        spns = self.buildDefaultComputerSPNs(computerHostname)
+
+        ldapServer, ldapConn = init_ldap_session(self.__domain, self.__username, self.__password, self.__lmhash,
+                                                 self.__nthash, self.__doKerberos, self.__targetIp, self.__target,
+                                                 self.__aesKey, True)
+
+        if not self.LDAPComputerExists(ldapConn, self.__computerName):
+            raise Exception("Account %s was created over SAMR but was not found over LDAP in %s!" %
+                            (self.__computerName, self.__baseDN))
+
+        computer = self.LDAPGetComputer(ldapConn, self.__computerName)
+        changes = {
+            'dnsHostName': [(ldap3.MODIFY_REPLACE, [dnsHostname])],
+            'servicePrincipalName': [(ldap3.MODIFY_REPLACE, spns)],
+        }
+        res = ldapConn.modify(computer.entry_dn, changes)
+        if not res:
+            if ldapConn.result['result'] == ldap3.core.results.RESULT_INSUFFICIENT_ACCESS_RIGHTS:
+                raise Exception("User %s doesn't have right to finalize LDAP attributes on %s!" %
+                                (self.__username, self.__computerName))
+            raise Exception(str(ldapConn.result))
+
+        logging.info("Successfully finalized LDAP attributes of %s (dnsHostName/SPNs)." % self.__computerName)
 
     def doSAMRAdd(self, rpctransport):
         dce = rpctransport.get_dce_rpc()
@@ -341,6 +388,8 @@ class ADDCOMPUTER:
                     req['tag'] = samr.USER_INFORMATION_CLASS.UserControlInformation
                     req['Control']['UserAccountControl'] = samr.USER_WORKSTATION_TRUST_ACCOUNT
                     samr.hSamrSetInformationUser2(dce, userHandle, req)
+                    if self.__method == 'SAMR_LDAP':
+                        self.LDAPFinalizeComputerAccount()
                     logging.info("Successfully added machine account %s with password %s." % (self.__computerName, self.__computerPassword))
 
         except Exception as e:
@@ -359,10 +408,12 @@ class ADDCOMPUTER:
             dce.disconnect()
 
     def run(self):
-        if self.__method == 'SAMR':
+        if self.__method in ['SAMR', 'SAMR_LDAP']:
             self.run_samr()
         elif self.__method == 'LDAPS':
             self.run_ldaps()
+        elif self.__method == 'LDAP_FINALIZE':
+            self.LDAPFinalizeComputerAccount()
 
 # Process command-line arguments.
 if __name__ == '__main__':
@@ -383,8 +434,10 @@ if __name__ == '__main__':
     parser.add_argument('-delete', action='store_true', help='Delete an existing computer.')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
-    parser.add_argument('-method', choices=['SAMR', 'LDAPS'], default='SAMR', help='Method of adding the computer.'
+    parser.add_argument('-method', choices=['SAMR', 'LDAPS', 'SAMR_LDAP', 'LDAP_FINALIZE'], default='SAMR', help='Method of adding the computer.'
                                                                                 'SAMR works over SMB.'
+                                                                                'SAMR_LDAP creates over SAMR and finalizes dnsHostName/SPNs over LDAPS.'
+                                                                                'LDAP_FINALIZE only finalizes dnsHostName/SPNs over LDAPS for an existing account.'
                                                                                 'LDAPS has some certificate requirements'
                                                                                 'and isn\'t always available.')
 

--- a/examples/addcomputer.py
+++ b/examples/addcomputer.py
@@ -70,13 +70,13 @@ class ADDCOMPUTER:
         if self.__targetIp is not None:
             self.__kdcHost = self.__targetIp
 
-        if self.__method not in ['SAMR', 'LDAPS']:
+        if self.__method not in ['SAMR', 'LDAPS', 'SAMR_LDAP', 'LDAP_FINALIZE']:
             raise ValueError("Unsupported method %s" % self.__method)
 
         if self.__doKerberos and cmdLineOptions.dc_host is None:
             raise ValueError("Kerberos auth requires DNS name of the target DC. Use -dc-host.")
 
-        if self.__method == 'LDAPS' and not '.' in self.__domain:
+        if self.__method in ['LDAPS', 'SAMR_LDAP', 'LDAP_FINALIZE'] and not '.' in self.__domain:
                 logging.warning('\'%s\' doesn\'t look like a FQDN. Generating baseDN will probably fail.' % self.__domain)
 
         if cmdLineOptions.hashes is not None:
@@ -102,13 +102,15 @@ class ADDCOMPUTER:
         if self.__port is None:
             if self.__method == 'SAMR':
                 self.__port = 445
-            elif self.__method == 'LDAPS':
+            elif self.__method in ['LDAPS', 'LDAP_FINALIZE']:
                 self.__port = 636
+            elif self.__method == 'SAMR_LDAP':
+                self.__port = 445
 
         if self.__domainNetbios is None:
             self.__domainNetbios = self.__domain
 
-        if self.__method == 'LDAPS' and self.__baseDN is None:
+        if self.__method in ['LDAPS', 'SAMR_LDAP', 'LDAP_FINALIZE'] and self.__baseDN is None:
              # Create the baseDN
             domainParts = self.__domain.split('.')
             self.__baseDN = ''
@@ -184,18 +186,13 @@ class ADDCOMPUTER:
                             break
 
 
-                computerHostname = self.__computerName[:-1]
+                computerHostname = self.getComputerHostname()
                 computerDn = ('CN=%s,%s' % (computerHostname, self.__computerGroup))
 
                 # Default computer SPNs
-                spns = [
-                    'HOST/%s' % computerHostname,
-                    'HOST/%s.%s' % (computerHostname, self.__domain),
-                    'RestrictedKrbHost/%s' % computerHostname,
-                    'RestrictedKrbHost/%s.%s' % (computerHostname, self.__domain),
-                ]
+                spns = self.buildDefaultComputerSPNs(computerHostname)
                 ucd = {
-                    'dnsHostName': '%s.%s' % (computerHostname, self.__domain),
+                    'dnsHostName': self.buildComputerDnsHostname(computerHostname),
                     'userAccountControl': 0x1000,
                     'servicePrincipalName': spns,
                     'sAMAccountName': self.__computerName,
@@ -239,6 +236,57 @@ class ADDCOMPUTER:
 
     def generateComputerName(self):
         return 'DESKTOP-' + (''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(8)) + '$')
+
+    def getComputerHostname(self):
+        return self.__computerName[:-1]
+
+    def buildComputerDnsHostname(self, computerHostname):
+        return '%s.%s' % (computerHostname, self.__domain)
+
+    def buildDefaultComputerSPNs(self, computerHostname):
+        return [
+            'HOST/%s' % computerHostname,
+            'HOST/%s.%s' % (computerHostname, self.__domain),
+            'RestrictedKrbHost/%s' % computerHostname,
+            'RestrictedKrbHost/%s.%s' % (computerHostname, self.__domain),
+        ]
+
+    def LDAPFinalizeComputerAccount(self):
+        if self.__method != 'LDAP_FINALIZE' and (self.__noAdd or self.__delete):
+            return
+
+        if self.__computerName is None:
+            raise ValueError("You have to provide a computer name when using LDAP_FINALIZE.")
+
+        if self.__baseDN is None:
+            raise ValueError("Unable to determine baseDN. Use -baseDN or provide a FQDN domain.")
+
+        computerHostname = self.getComputerHostname()
+        dnsHostname = self.buildComputerDnsHostname(computerHostname)
+        spns = self.buildDefaultComputerSPNs(computerHostname)
+
+        ldapConn = ldap_login(self.__target, self.__baseDN, self.__targetIp, self.__target, self.__doKerberos,
+                              self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
+                              self.__aesKey, ldaps_flag=True)
+
+        if not self.LDAPComputerExists(ldapConn, self.__computerName):
+            raise Exception("Account %s was created over SAMR but was not found over LDAP in %s!" %
+                            (self.__computerName, self.__baseDN))
+
+        computerDn = self.LDAPGetComputerDN(ldapConn, self.__computerName)
+        changes = {
+            'dnsHostName': [(ldap.MODIFY_REPLACE, [dnsHostname])],
+            'servicePrincipalName': [(ldap.MODIFY_REPLACE, spns)],
+        }
+        try:
+            ldapConn.modify(computerDn, changes)
+        except ldap.LDAPSessionError as e:
+            if e.getErrorCode() == 50:  # insufficientAccessRights
+                raise Exception("User %s doesn't have right to finalize LDAP attributes on %s!" %
+                                (self.__username, self.__computerName))
+            raise Exception(str(e))
+
+        logging.info("Successfully finalized LDAP attributes of %s (dnsHostName/SPNs)." % self.__computerName)
 
     def doSAMRAdd(self, rpctransport):
         dce = rpctransport.get_dce_rpc()
@@ -344,6 +392,8 @@ class ADDCOMPUTER:
                     req['tag'] = samr.USER_INFORMATION_CLASS.UserControlInformation
                     req['Control']['UserAccountControl'] = samr.USER_WORKSTATION_TRUST_ACCOUNT
                     samr.hSamrSetInformationUser2(dce, userHandle, req)
+                    if self.__method == 'SAMR_LDAP':
+                        self.LDAPFinalizeComputerAccount()
                     logging.info("Successfully added machine account %s with password %s." % (self.__computerName, self.__computerPassword))
 
         except Exception as e:
@@ -362,10 +412,12 @@ class ADDCOMPUTER:
             dce.disconnect()
 
     def run(self):
-        if self.__method == 'SAMR':
+        if self.__method in ['SAMR', 'SAMR_LDAP']:
             self.run_samr()
         elif self.__method == 'LDAPS':
             self.run_ldaps()
+        elif self.__method == 'LDAP_FINALIZE':
+            self.LDAPFinalizeComputerAccount()
 
 # Process command-line arguments.
 if __name__ == '__main__':
@@ -386,8 +438,10 @@ if __name__ == '__main__':
     parser.add_argument('-delete', action='store_true', help='Delete an existing computer.')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
-    parser.add_argument('-method', choices=['SAMR', 'LDAPS'], default='SAMR', help='Method of adding the computer.'
+    parser.add_argument('-method', choices=['SAMR', 'LDAPS', 'SAMR_LDAP', 'LDAP_FINALIZE'], default='SAMR', help='Method of adding the computer.'
                                                                                 'SAMR works over SMB.'
+                                                                                'SAMR_LDAP creates over SAMR and finalizes dnsHostName/SPNs over LDAPS.'
+                                                                                'LDAP_FINALIZE only finalizes dnsHostName/SPNs over LDAPS for an existing account.'
                                                                                 'LDAPS has some certificate requirements'
                                                                                 'and isn\'t always available.')
 

--- a/tests/misc/test_addcomputer.py
+++ b/tests/misc/test_addcomputer.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright Fortra, LLC and its affiliated companies
+#
+# All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import ldap3
+from examples.addcomputer import ADDCOMPUTER
+
+
+class _FakeLDAPConnection:
+    def __init__(self, entries, modify_result=True, result_code=0):
+        self.entries = entries
+        self._modify_result = modify_result
+        self.result = {"result": result_code, "message": "error"}
+        self.last_modify_dn = None
+        self.last_modify_changes = None
+
+    def search(self, *_args, **_kwargs):
+        return True
+
+    def modify(self, dn, changes):
+        self.last_modify_dn = dn
+        self.last_modify_changes = changes
+        return self._modify_result
+
+
+def _build_options(method, computer_name="TESTPC$", no_add=False, delete=False):
+    return SimpleNamespace(
+        hashes=None,
+        aesKey=None,
+        k=False,
+        dc_host="dc.test.local",
+        computer_name=computer_name,
+        computer_pass="Password123!",
+        method=method,
+        port=None,
+        domain_netbios=None,
+        no_add=no_add,
+        delete=delete,
+        dc_ip=None,
+        baseDN="dc=test,dc=local",
+        computer_group=None,
+    )
+
+
+class AddComputerTests(unittest.TestCase):
+    def test_ldap_finalize_only_success(self):
+        options = _build_options("LDAP_FINALIZE")
+        tool = ADDCOMPUTER("user", "pass", "test.local", options)
+        entry = SimpleNamespace(entry_dn="CN=TESTPC,CN=Computers,dc=test,dc=local")
+        ldap_conn = _FakeLDAPConnection([entry], modify_result=True)
+
+        with mock.patch("examples.addcomputer.init_ldap_session", return_value=(None, ldap_conn)):
+            tool.run()
+
+        self.assertEqual(ldap_conn.last_modify_dn, entry.entry_dn)
+        self.assertEqual(
+            ldap_conn.last_modify_changes["dnsHostName"][0][1][0],
+            "TESTPC.test.local",
+        )
+        self.assertEqual(
+            ldap_conn.last_modify_changes["servicePrincipalName"][0][1],
+            [
+                "HOST/TESTPC",
+                "HOST/TESTPC.test.local",
+                "RestrictedKrbHost/TESTPC",
+                "RestrictedKrbHost/TESTPC.test.local",
+            ],
+        )
+
+    def test_ldap_finalize_only_missing_account_raises(self):
+        options = _build_options("LDAP_FINALIZE")
+        tool = ADDCOMPUTER("user", "pass", "test.local", options)
+        ldap_conn = _FakeLDAPConnection([], modify_result=True)
+
+        with mock.patch("examples.addcomputer.init_ldap_session", return_value=(None, ldap_conn)):
+            with self.assertRaises(Exception) as cm:
+                tool.run()
+
+        self.assertIn("was created over SAMR but was not found over LDAP", str(cm.exception))
+
+    def test_ldap_finalize_only_insufficient_rights_raises(self):
+        options = _build_options("LDAP_FINALIZE")
+        tool = ADDCOMPUTER("user", "pass", "test.local", options)
+        entry = SimpleNamespace(entry_dn="CN=TESTPC,CN=Computers,dc=test,dc=local")
+        ldap_conn = _FakeLDAPConnection(
+            [entry],
+            modify_result=False,
+            result_code=ldap3.core.results.RESULT_INSUFFICIENT_ACCESS_RIGHTS,
+        )
+
+        with mock.patch("examples.addcomputer.init_ldap_session", return_value=(None, ldap_conn)):
+            with self.assertRaises(Exception) as cm:
+                tool.run()
+
+        self.assertIn("doesn't have right to finalize LDAP attributes", str(cm.exception))
+
+    def test_samr_mode_does_not_finalize_ldap(self):
+        options = _build_options("SAMR")
+        tool = ADDCOMPUTER("user", "pass", "test.local", options)
+
+        with mock.patch.object(tool, "run_samr") as run_samr, mock.patch.object(
+            tool, "LDAPFinalizeComputerAccount"
+        ) as finalize:
+            tool.run()
+
+        run_samr.assert_called_once()
+        finalize.assert_not_called()
+
+    def test_samr_ldap_calls_finalize_after_add(self):
+        options = _build_options("SAMR_LDAP")
+        tool = ADDCOMPUTER("user", "pass", "test.local", options)
+
+        class FakeSessionError(Exception):
+            def __init__(self, error_code):
+                super(FakeSessionError, self).__init__("session error")
+                self.error_code = error_code
+
+        class FakeDCE:
+            def connect(self):
+                return None
+
+            def bind(self, _uuid):
+                return None
+
+            def disconnect(self):
+                return None
+
+        class FakeRPCTransport:
+            def get_dce_rpc(self):
+                return FakeDCE()
+
+        with mock.patch.object(tool, "LDAPFinalizeComputerAccount") as finalize, mock.patch(
+            "examples.addcomputer.samr.DCERPCSessionError", FakeSessionError
+        ), mock.patch(
+            "examples.addcomputer.samr.hSamrConnect5", return_value={"ServerHandle": "srv-handle"}
+        ), mock.patch(
+            "examples.addcomputer.samr.hSamrEnumerateDomainsInSamServer",
+            return_value={"Buffer": {"Buffer": [{"Name": "Builtin"}, {"Name": "TESTDOM"}]}},
+        ), mock.patch(
+            "examples.addcomputer.samr.hSamrLookupDomainInSamServer", return_value={"DomainId": "sid"}
+        ), mock.patch(
+            "examples.addcomputer.samr.hSamrOpenDomain", return_value={"DomainHandle": "domain-handle"}
+        ), mock.patch(
+            "examples.addcomputer.samr.hSamrLookupNamesInDomain",
+            side_effect=[
+                FakeSessionError(0xC0000073),
+                {"RelativeIds": {"Element": [1001]}},
+            ],
+        ), mock.patch(
+            "examples.addcomputer.samr.hSamrCreateUser2InDomain", return_value={"UserHandle": "new-user-handle"}
+        ), mock.patch(
+            "examples.addcomputer.samr.hSamrSetPasswordInternal4New"
+        ), mock.patch(
+            "examples.addcomputer.samr.hSamrOpenUser", return_value={"UserHandle": "open-user-handle"}
+        ), mock.patch(
+            "examples.addcomputer.samr.SAMPR_USER_INFO_BUFFER",
+            side_effect=lambda: {"Control": {}},
+        ), mock.patch(
+            "examples.addcomputer.samr.hSamrSetInformationUser2"
+        ), mock.patch(
+            "examples.addcomputer.samr.hSamrCloseHandle"
+        ):
+            tool.doSAMRAdd(FakeRPCTransport())
+
+        finalize.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)

--- a/tests/misc/test_addcomputer.py
+++ b/tests/misc/test_addcomputer.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright Fortra, LLC and its affiliated companies
+#
+# All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from examples.addcomputer import ADDCOMPUTER
+from impacket.ldap import ldap
+
+
+class _FakeLDAPConnection:
+    def __init__(self, modify_error=None):
+        self._modify_error = modify_error
+        self.last_modify_dn = None
+        self.last_modify_changes = None
+
+    def modify(self, dn, changes):
+        self.last_modify_dn = dn
+        self.last_modify_changes = changes
+        if self._modify_error is not None:
+            raise self._modify_error
+        return True
+
+
+def _build_options(method, computer_name="TESTPC$", no_add=False, delete=False):
+    return SimpleNamespace(
+        hashes=None,
+        aesKey=None,
+        k=False,
+        dc_host="dc.test.local",
+        computer_name=computer_name,
+        computer_pass="Password123!",
+        method=method,
+        port=None,
+        domain_netbios=None,
+        no_add=no_add,
+        delete=delete,
+        dc_ip=None,
+        baseDN="dc=test,dc=local",
+        computer_group=None,
+    )
+
+
+class AddComputerTests(unittest.TestCase):
+    def test_ldap_finalize_only_success(self):
+        options = _build_options("LDAP_FINALIZE")
+        tool = ADDCOMPUTER("user", "pass", "test.local", options)
+        computer_dn = "CN=TESTPC,CN=Computers,dc=test,dc=local"
+        ldap_conn = _FakeLDAPConnection()
+
+        with mock.patch("examples.addcomputer.ldap_login", return_value=ldap_conn), mock.patch.object(
+            tool, "LDAPComputerExists", return_value=True
+        ), mock.patch.object(tool, "LDAPGetComputerDN", return_value=computer_dn):
+            tool.run()
+
+        self.assertEqual(ldap_conn.last_modify_dn, computer_dn)
+        self.assertEqual(
+            ldap_conn.last_modify_changes["dnsHostName"][0][1][0],
+            "TESTPC.test.local",
+        )
+        self.assertEqual(
+            ldap_conn.last_modify_changes["servicePrincipalName"][0][1],
+            [
+                "HOST/TESTPC",
+                "HOST/TESTPC.test.local",
+                "RestrictedKrbHost/TESTPC",
+                "RestrictedKrbHost/TESTPC.test.local",
+            ],
+        )
+        self.assertEqual(ldap_conn.last_modify_changes["dnsHostName"][0][0], ldap.MODIFY_REPLACE)
+
+    def test_ldap_finalize_only_missing_account_raises(self):
+        options = _build_options("LDAP_FINALIZE")
+        tool = ADDCOMPUTER("user", "pass", "test.local", options)
+        ldap_conn = _FakeLDAPConnection()
+
+        with mock.patch("examples.addcomputer.ldap_login", return_value=ldap_conn), mock.patch.object(
+            tool, "LDAPComputerExists", return_value=False
+        ):
+            with self.assertRaises(Exception) as cm:
+                tool.run()
+
+        self.assertIn("was created over SAMR but was not found over LDAP", str(cm.exception))
+
+    def test_ldap_finalize_only_insufficient_rights_raises(self):
+        options = _build_options("LDAP_FINALIZE")
+        tool = ADDCOMPUTER("user", "pass", "test.local", options)
+        ldap_conn = _FakeLDAPConnection(
+            modify_error=ldap.LDAPSessionError(error=50)
+        )
+
+        with mock.patch("examples.addcomputer.ldap_login", return_value=ldap_conn), mock.patch.object(
+            tool, "LDAPComputerExists", return_value=True
+        ), mock.patch.object(tool, "LDAPGetComputerDN", return_value="CN=TESTPC,CN=Computers,dc=test,dc=local"):
+            with self.assertRaises(Exception) as cm:
+                tool.run()
+
+        self.assertIn("doesn't have right to finalize LDAP attributes", str(cm.exception))
+
+    def test_samr_mode_does_not_finalize_ldap(self):
+        options = _build_options("SAMR")
+        tool = ADDCOMPUTER("user", "pass", "test.local", options)
+
+        with mock.patch.object(tool, "run_samr") as run_samr, mock.patch.object(
+            tool, "LDAPFinalizeComputerAccount"
+        ) as finalize:
+            tool.run()
+
+        run_samr.assert_called_once()
+        finalize.assert_not_called()
+
+    def test_samr_ldap_calls_finalize_after_add(self):
+        options = _build_options("SAMR_LDAP")
+        tool = ADDCOMPUTER("user", "pass", "test.local", options)
+
+        class FakeSessionError(Exception):
+            def __init__(self, error_code):
+                super(FakeSessionError, self).__init__("session error")
+                self.error_code = error_code
+
+        class FakeDCE:
+            def connect(self):
+                return None
+
+            def bind(self, _uuid):
+                return None
+
+            def disconnect(self):
+                return None
+
+        class FakeRPCTransport:
+            def get_dce_rpc(self):
+                return FakeDCE()
+
+        with mock.patch.object(tool, "LDAPFinalizeComputerAccount") as finalize, mock.patch(
+            "examples.addcomputer.samr.DCERPCSessionError", FakeSessionError
+        ), mock.patch(
+            "examples.addcomputer.samr.hSamrConnect5", return_value={"ServerHandle": "srv-handle"}
+        ), mock.patch(
+            "examples.addcomputer.samr.hSamrEnumerateDomainsInSamServer",
+            return_value={"Buffer": {"Buffer": [{"Name": "Builtin"}, {"Name": "TESTDOM"}]}},
+        ), mock.patch(
+            "examples.addcomputer.samr.hSamrLookupDomainInSamServer", return_value={"DomainId": "sid"}
+        ), mock.patch(
+            "examples.addcomputer.samr.hSamrOpenDomain", return_value={"DomainHandle": "domain-handle"}
+        ), mock.patch(
+            "examples.addcomputer.samr.hSamrLookupNamesInDomain",
+            side_effect=[
+                FakeSessionError(0xC0000073),
+                {"RelativeIds": {"Element": [1001]}},
+            ],
+        ), mock.patch(
+            "examples.addcomputer.samr.hSamrCreateUser2InDomain", return_value={"UserHandle": "new-user-handle"}
+        ), mock.patch(
+            "examples.addcomputer.samr.hSamrSetPasswordInternal4New"
+        ), mock.patch(
+            "examples.addcomputer.samr.hSamrOpenUser", return_value={"UserHandle": "open-user-handle"}
+        ), mock.patch(
+            "examples.addcomputer.samr.SAMPR_USER_INFO_BUFFER",
+            side_effect=lambda: {"Control": {}},
+        ), mock.patch(
+            "examples.addcomputer.samr.hSamrSetInformationUser2"
+        ), mock.patch(
+            "examples.addcomputer.samr.hSamrCloseHandle"
+        ):
+            tool.doSAMRAdd(FakeRPCTransport())
+
+        finalize.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)


### PR DESCRIPTION
- Add explicit `SAMR_LDAP` method to `examples/addcomputer.py`.
- Keep existing `SAMR` behavior unchanged for SMB-only environments.
- After SAMR account creation, finalize `dnsHostName` and `servicePrincipalName` over LDAPS.
- Fail the `SAMR_LDAP` flow if LDAP finalization cannot be completed.