### PR TITLE
structure: descriptive error when 'z' field has no NUL terminator (#2099)

### DIFF
--- a/impacket/structure.py
+++ b/impacket/structure.py
@@ -537,7 +537,10 @@ class Structure:
 
         # asciiz specifier
         if format[:1] == 'z':
-            return data.index(self.b('\x00'))+1
+            try:
+                return data.index(self.b('\x00'))+1
+            except ValueError:
+                raise ValueError("'z' field is not NUL terminated: %r" % data)
 
         # asciiz specifier
         if format[:1] == 'u':

--- a/tests/misc/test_structure.py
+++ b/tests/misc/test_structure.py
@@ -213,6 +213,23 @@ class Test_UnpackCode(_StructureTest, unittest.TestCase):
     hexData = '18000000 736f7920 756e206c 6f636f21 71756520 68616365 73206669 657261'
 
 
+class Test_AsciiZ_calcUnpackSize_missing_terminator(unittest.TestCase):
+    # Regression test for impacket #2099. When a Structure containing a 'z'
+    # (asciiz) field is unpacked from data that has no NUL byte at all,
+    # calcUnpackSize used to surface a bare 'ValueError: subsection not found'
+    # from str.index(), which is opaque for callers (e.g. SMBConnection.login
+    # parsing a truncated session response). Should raise a descriptive
+    # ValueError naming the field type.
+    class theClass(Structure):
+        structure = (
+            ('z1', 'z'),
+        )
+
+    def test_missing_nul_terminator(self):
+        with six.assertRaisesRegex(self, ValueError, r"'z' field is not NUL terminated"):
+            self.theClass(b'no terminator here')
+
+
 class Test_AAA(_StructureTest, unittest.TestCase):
     class theClass(Structure):
         commonHdr = ()


### PR DESCRIPTION
Closes #2099.

When a `Structure` contains an asciiz (`'z'`) field and is unpacked from data that
has no NUL byte at all, `calcUnpackSize` calls `data.index(b'\x00')` which raises
the bare `ValueError: subsection not found`. That message is opaque from a caller's
perspective — the issue reporter hit it during `SMBConnection.login` against a
device that closed the session early, and the trace just bottomed out in the
generic `str.index()` exception with no hint about which field or why.

This wraps the lookup and re-raises a `ValueError` whose message tells you the
field type and shows the data, mirroring how the parallel `'u'` (UTF-16) specifier
already raises a descriptive `ValueError` (and how `unpack` already raises a
descriptive `Exception` for the same `'z'` case at line 378). Same exception type,
no behavior change for code that catches `ValueError`.

Includes a regression test in `tests/misc/test_structure.py`.