### PR TITLE
tds: demote "Changed database context" messages to debug level

### DIFF
--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -1719,8 +1719,7 @@ class MSSQL:
                         key["LineNumber"],
                         msg_text,
                     )
-                    # Context-switch messages are protocol noise, log at debug
-                    if msg_text.startswith("Changed database context to"):
+                    if key["Number"] == 5701:
                         debug_logger(log_msg)
                     else:
                         info_logger(log_msg)

--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -1696,7 +1696,9 @@ class MSSQL:
                 )
             self.__rowsPrinter.logMessage("\r")
 
-    def printReplies(self, error_logger=LOG.error, info_logger=LOG.info):
+    def printReplies(
+        self, error_logger=LOG.error, info_logger=LOG.info, debug_logger=LOG.debug
+    ):
         for keys in list(self.replies.keys()):
             for i, key in enumerate(self.replies[keys]):
                 if key["TokenType"] == TDS_ERROR_TOKEN:
@@ -1711,14 +1713,17 @@ class MSSQL:
                     error_logger(self.lastError)
 
                 elif key["TokenType"] == TDS_INFO_TOKEN:
-                    info_logger(
-                        "INFO(%s): Line %d: %s"
-                        % (
-                            key["ServerName"].decode("utf-16le"),
-                            key["LineNumber"],
-                            key["MsgText"].decode("utf-16le"),
-                        )
+                    msg_text = key["MsgText"].decode("utf-16le")
+                    log_msg = "INFO(%s): Line %d: %s" % (
+                        key["ServerName"].decode("utf-16le"),
+                        key["LineNumber"],
+                        msg_text,
                     )
+                    # Context-switch messages are protocol noise, log at debug
+                    if msg_text.startswith("Changed database context to"):
+                        debug_logger(log_msg)
+                    else:
+                        info_logger(log_msg)
 
                 elif key["TokenType"] == TDS_LOGINACK_TOKEN:
                     info_logger(


### PR DESCRIPTION
The "Changed database context to ..." INFO messages are emitted on every USE statement and add noise to output in tools that switch databases frequently. Route them through a new debug_logger parameter instead, keeping all other INFO tokens at info level.