### PR TITLE
tds: return None instead of "NULL" string for SQL NULL values

### DIFF
--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -571,10 +571,10 @@ class TDS_SSVARIANT(Structure):
         Parse the sql_variant data and extract the base type, properties, and value.
 
         Returns:
-            Parsed value in its appropriate Python type, or 'NULL' if empty
+            Parsed value in its appropriate Python type, or None if empty
         """
         if self["TotalLength"] == 0:
-            return "NULL"
+            return None
 
         data = self["Data"]
 
@@ -707,7 +707,7 @@ class TDS_SSVARIANT(Structure):
                 # date: 3-byte unsigned integer (days since year 1)
                 # VARIANT_PROPBYTES = 0
                 if len(data) < 3:
-                    return "NULL"
+                    return None
                 dateValue = struct.unpack("<L", data[:3] + b"\x00")[0]
                 return datetime.date.fromordinal(dateValue)
 
@@ -744,7 +744,7 @@ class TDS_SSVARIANT(Structure):
                 timeBytes = 3 if scale <= 2 else (4 if scale <= 4 else 5)
 
                 if len(data) < timeBytes + 3:
-                    return "NULL"
+                    return None
 
                 # Parse time part
                 if timeBytes == 3:
@@ -785,7 +785,7 @@ class TDS_SSVARIANT(Structure):
                 timeBytes = 3 if scale <= 2 else (4 if scale <= 4 else 5)
 
                 if len(data) < timeBytes + 5:
-                    return "NULL"
+                    return None
 
                 # Parse time part
                 if timeBytes == 3:
@@ -835,7 +835,7 @@ class TDS_SSVARIANT(Structure):
                 scale = properties[1] if len(properties) > 1 else 0
 
                 if len(data) == 0:
-                    return "NULL"
+                    return None
 
                 # First byte is sign (1 = positive, 0 = negative)
                 sign = 1 if data[0] == 1 else -1
@@ -1660,8 +1660,9 @@ class MSSQL:
 
             col["minLenght"] = 0
             for row in self.rows:
-                if len(str(row[col["Name"]])) > col["minLenght"]:
-                    col["minLenght"] = len(str(row[col["Name"]]))
+                display = "NULL" if row[col["Name"]] is None else str(row[col["Name"]])
+                if len(display) > col["minLenght"]:
+                    col["minLenght"] = len(display)
             if col["minLenght"] < col["Length"]:
                 col["Length"] = col["minLenght"]
 
@@ -1691,8 +1692,10 @@ class MSSQL:
         self.printColumnsHeader()
         for row in self.rows:
             for col in self.colMeta:
+                value = row[col["Name"]]
+                display = "NULL" if value is None else value
                 self.__rowsPrinter.logMessage(
-                    col["Format"] % row[col["Name"]] + self.COL_SEPARATOR
+                    col["Format"] % display + self.COL_SEPARATOR
                 )
             self.__rowsPrinter.logMessage("\r")
 
@@ -1776,7 +1779,7 @@ class MSSQL:
                     value = data[:charLen].decode("utf-16le")
                     data = data[charLen:]
                 else:
-                    value = "NULL"
+                    value = None
 
             elif _type == TDS_BIGVARCHRTYPE:
                 charLen = struct.unpack("<H", data[:2])[0]
@@ -1793,7 +1796,7 @@ class MSSQL:
                     except UnicodeDecodeError:
                         value = raw.decode("utf-8", errors="replace")
                 else:
-                    value = "NULL"
+                    value = None
 
             elif _type == TDS_GUIDTYPE:
                 uuidLen = ord(data[0:1])
@@ -1803,13 +1806,13 @@ class MSSQL:
                     value = uuid.bin_to_string(uu)
                     data = data[uuidLen:]
                 else:
-                    value = "NULL"
+                    value = None
 
             elif (_type == TDS_NTEXTTYPE) | (_type == TDS_IMAGETYPE):
                 # Skip the pointer data
                 charLen = ord(data[0:1])
                 if charLen == 0:
-                    value = "NULL"
+                    value = None
                     data = data[1:]
                 else:
                     data = data[1 + charLen + 8 :]
@@ -1822,13 +1825,13 @@ class MSSQL:
                             value = binascii.b2a_hex(data[:charLen])
                         data = data[charLen:]
                     else:
-                        value = "NULL"
+                        value = None
 
             elif _type == TDS_TEXTTYPE:
                 # Skip the pointer data
                 charLen = ord(data[0:1])
                 if charLen == 0:
-                    value = "NULL"
+                    value = None
                     data = data[1:]
                 else:
                     data = data[1 + charLen + 8 :]
@@ -1838,7 +1841,7 @@ class MSSQL:
                         value = data[:charLen]
                         data = data[charLen:]
                     else:
-                        value = "NULL"
+                        value = None
 
             elif (_type == TDS_BIGVARBINTYPE) | (_type == TDS_BIGBINARYTYPE):
                 charLen = struct.unpack("<H", data[: struct.calcsize("<H")])[0]
@@ -1847,14 +1850,14 @@ class MSSQL:
                     value = binascii.b2a_hex(data[:charLen])
                     data = data[charLen:]
                 else:
-                    value = "NULL"
+                    value = None
 
             elif (
                 (_type == TDS_DATETIM4TYPE)
                 | (_type == TDS_DATETIMNTYPE)
                 | (_type == TDS_DATETIMETYPE)
             ):
-                value = ""
+                value = None
                 if _type == TDS_DATETIMNTYPE:
                     # For DATETIMNTYPE, the only valid lengths are 0x04 and 0x08, which map to smalldatetime and
                     # datetime SQL data _types respectively.
@@ -1862,8 +1865,6 @@ class MSSQL:
                         _type = TDS_DATETIM4TYPE
                     elif ord(data[0:1]) == 8:
                         _type = TDS_DATETIMETYPE
-                    else:
-                        value = "NULL"
                     data = data[1:]
                 if _type == TDS_DATETIMETYPE:
                     # datetime is represented in the following sequence:
@@ -1879,6 +1880,19 @@ class MSSQL:
                         baseDate = datetime.date(1900, 1, 1)
                     timeValue = struct.unpack("<L", data[:4])[0]
                     data = data[4:]
+                    dateValue = datetime.date.fromordinal(
+                        baseDate.toordinal() + dateValue
+                    )
+                    hours, mod = divmod(timeValue // 300, 60 * 60)
+                    minutes, second = divmod(mod, 60)
+                    value = datetime.datetime(
+                        dateValue.year,
+                        dateValue.month,
+                        dateValue.day,
+                        hours,
+                        minutes,
+                        second,
+                    )
                 elif _type == TDS_DATETIM4TYPE:
                     # Small datetime
                     # 2.2.5.5.1.8
@@ -1892,19 +1906,17 @@ class MSSQL:
                     timeValue = struct.unpack("<H", data[: struct.calcsize("<H")])[0]
                     data = data[struct.calcsize("<H") :]
                     baseDate = datetime.date(1900, 1, 1)
-                if value != "NULL":
                     dateValue = datetime.date.fromordinal(
                         baseDate.toordinal() + dateValue
                     )
-                    hours, mod = divmod(timeValue // 300, 60 * 60)
-                    minutes, second = divmod(mod, 60)
+                    hours, minutes = divmod(timeValue, 60)
                     value = datetime.datetime(
                         dateValue.year,
                         dateValue.month,
                         dateValue.day,
                         hours,
                         minutes,
-                        second,
+                        0,
                     )
 
             elif _type == TDS_INT4TYPE:
@@ -1933,7 +1945,7 @@ class MSSQL:
                     value = struct.unpack(fmt, data[:valueSize])[0]
                     data = data[valueSize:]
                 else:
-                    value = "NULL"
+                    value = None
 
             elif _type == TDS_MONEYNTYPE:
                 valueSize = ord(data[:1])
@@ -1951,7 +1963,7 @@ class MSSQL:
                     value = Decimal(raw) / Decimal(10000)
                     data = data[valueSize:]
                 else:
-                    value = "NULL"
+                    value = None
 
             elif _type == TDS_BIGCHARTYPE:
                 # print "BIGC"
@@ -1991,7 +2003,7 @@ class MSSQL:
                     value = datetime.date.fromordinal(dateValue)
                     data = data[valueSize:]
                 else:
-                    value = "NULL"
+                    value = None
 
             elif (_type == TDS_BITTYPE) | (_type == TDS_INT1TYPE):
                 # print "BITTYPE"
@@ -2003,7 +2015,7 @@ class MSSQL:
                 data = data[1:]
 
                 if valueLen == 0:
-                    value = "NULL"
+                    value = None
                 else:
                     raw = data[:valueLen]
                     data = data[valueLen:]
@@ -2032,7 +2044,7 @@ class MSSQL:
                     else:
                         value = data[:valueSize]
                 else:
-                    value = "NULL"
+                    value = None
                 data = data[valueSize:]
 
             elif _type == TDS_INTNTYPE:
@@ -2054,7 +2066,7 @@ class MSSQL:
                     value = struct.unpack(fmt, data[:valueSize])[0]
                     data = data[valueSize:]
                 else:
-                    value = "NULL"
+                    value = None
             elif _type == TDS_SSVARIANTTYPE:
                 totalLength = struct.unpack("<L", data[:4])[0]
 


### PR DESCRIPTION
parseRow() and TDS_SSVARIANT._parseValue() returned the string "NULL" for SQL NULL values.  This is semantically wrong: downstream code cannot distinguish a genuine NULL from a column that literally contains the text "NULL", and standard Python idioms like `if value is None` or `value or default` do not work.

Replace every `value = "NULL"` / `return "NULL"` with `None`. Update processColMeta() and printRows() to format None as the string "NULL" for display output, preserving the existing table rendering.