### PR TITLE
Fix REG_MULTI_SZ output formatting

### DIFF
--- a/examples/reg.py
+++ b/examples/reg.py
@@ -44,6 +44,7 @@ from impacket.examples import logger
 from impacket.examples.utils import parse_target
 from impacket.system_errors import ERROR_NO_MORE_ITEMS
 from impacket.structure import hexdump
+from impacket.winregistry import format_multi_sz
 from impacket.smbconnection import SMBConnection, SessionError
 from impacket.dcerpc.v5.dtypes import READ_CONTROL
 
@@ -235,11 +236,11 @@ class RegHandler:
         if self.__options.v:
             print(keyName)
             value = rrp.hBaseRegQueryValue(dce, ans2['phkResult'], self.__options.v)
-            print('\t' + self.__options.v + '\t' + self.__regValues.get(value[0], 'KEY_NOT_FOUND') + '\t', str(value[1]))
+            self.__print_query_value(self.__options.v, value[0], value[1])
         elif self.__options.ve:
             print(keyName)
             value = rrp.hBaseRegQueryValue(dce, ans2['phkResult'], '')
-            print('\t' + '(Default)' + '\t' + self.__regValues.get(value[0], 'KEY_NOT_FOUND') + '\t', str(value[1]))
+            self.__print_query_value('(Default)', value[0], value[1])
         elif self.__options.s:
             self.__print_all_subkeys_and_entries(dce, subKey + '\\', ans2['phkResult'], 0)
         else:
@@ -306,7 +307,7 @@ class RegHandler:
             if dwType == rrp.REG_MULTI_SZ:
                 vd = '\0'.join(self.__options.vd)
                 valueData = vd + 2 * '\0' # REG_MULTI_SZ ends with 2 null-bytes
-                valueDataToPrint = vd.replace('\0', '\n\t\t')
+                valueDataToPrint = format_multi_sz(valueData, separator='\n\t\t')
             else:
                 vd = self.__options.vd[0] if len(self.__options.vd) > 0 else ''
                 if dwType in (
@@ -471,7 +472,10 @@ class RegHandler:
                 lp_type = ans4['lpType']
                 lp_data = b''.join(ans4['lpData'])
                 print('\t' + lp_value_name + '\t' + self.__regValues.get(lp_type, 'KEY_NOT_FOUND') + '\t', end=' ')
-                self.__parse_lp_data(lp_type, lp_data)
+                separator = '\n\t%s\t%s\t ' % (
+                    ' ' * len(lp_value_name), ' ' * len(self.__regValues.get(lp_type, 'KEY_NOT_FOUND'))
+                )
+                self.__parse_lp_data(lp_type, lp_data, separator)
                 i += 1
             except rrp.DCERPCSessionError as e:
                 if e.get_error_code() == ERROR_NO_MORE_ITEMS:
@@ -502,7 +506,21 @@ class RegHandler:
                 raise
 
     @staticmethod
-    def __parse_lp_data(valueType, valueData):
+    def __format_query_value(valueType, valueData, multiSzSeparator):
+        if valueType == rrp.REG_MULTI_SZ:
+            return format_multi_sz(valueData, separator=multiSzSeparator)
+        return str(valueData)
+
+    def __print_query_value(self, valueName, valueType, valueData):
+        valueTypeName = self.__regValues.get(valueType, 'KEY_NOT_FOUND')
+        # REG_MULTI_SZ values continue on later lines. Keep the existing tabular
+        # query output by replacing the value name/type columns with spaces.
+        separator = '\n\t%s\t%s\t ' % (' ' * len(valueName), ' ' * len(valueTypeName))
+        print('\t' + valueName + '\t' + valueTypeName + '\t',
+              self.__format_query_value(valueType, valueData, separator))
+
+    @staticmethod
+    def __parse_lp_data(valueType, valueData, multiSzSeparator='\n\t\t'):
         try:
             if valueType == rrp.REG_SZ or valueType == rrp.REG_EXPAND_SZ:
                 if type(valueData) is int:
@@ -526,7 +544,7 @@ class RegHandler:
                 except:
                     print(" NULL")
             elif valueType == rrp.REG_MULTI_SZ:
-                print("%s" % (valueData.decode('utf-16le')[:-2]))
+                print("%s" % format_multi_sz(valueData, separator=multiSzSeparator))
             else:
                 print("Unknown Type 0x%x!" % valueType)
                 hexdump(valueData)

--- a/examples/registry-read.py
+++ b/examples/registry-read.py
@@ -74,7 +74,7 @@ def getValue(reg, keyValue):
         return
 
     print("Value for %s:\n    " % regValue, end=' ')
-    reg.printValue(value[0],value[1])
+    reg.printValue(value[0], value[1], multiSzSeparator='\n     ')
 
 def enumValues(reg, searchKey):
     key = reg.findKey(searchKey)

--- a/impacket/winregistry.py
+++ b/impacket/winregistry.py
@@ -47,6 +47,15 @@ REG_DWORD       = 0x04
 REG_MULTISZ     = 0x07
 REG_QWORD       = 0x0b
 
+
+def format_multi_sz(valueData, separator='\n  '):
+    if isinstance(valueData, int):
+        return 'NULL'
+    if isinstance(valueData, bytes):
+        valueData = valueData.decode('utf-16le')
+    return valueData.rstrip('\x00').replace('\x00', separator)
+
+
 # Structs
 class REG_REGF(Structure):
     structure = (
@@ -180,7 +189,7 @@ class Registry(ABC):
         pass
 
     @abstractmethod
-    def printValue(self, valueType, valueData):
+    def printValue(self, valueType, valueData, multiSzSeparator='\n  '):
         pass
 
     @abstractmethod
@@ -440,8 +449,13 @@ class saveRegistryParser(Registry):
 
         return parentKey
 
-    def printValue(self, valueType, valueData):
-        if valueType in [REG_SZ, REG_EXPAND_SZ, REG_MULTISZ]:
+    def printValue(self, valueType, valueData, multiSzSeparator='\n  '):
+        if valueType == REG_MULTISZ:
+            if isinstance(valueData, int):
+                print('NULL')
+            else:
+                print("%s" % format_multi_sz(valueData, separator=multiSzSeparator))
+        elif valueType in [REG_SZ, REG_EXPAND_SZ]:
             if isinstance(valueData, int):
                 print('NULL')
             else:
@@ -695,8 +709,13 @@ class exportRegistryParser(Registry):
         for subNode in list(node.childKeys.values()):
             self.__walkSubNodes(subNode)
 
-    def printValue(self, valueType, valueData):
-        if valueType in [REG_SZ, REG_EXPAND_SZ, REG_MULTISZ] :
+    def printValue(self, valueType, valueData, multiSzSeparator='\n  '):
+        if valueType == REG_MULTISZ:
+            if valueData == b'' or valueData == b'\x00\x00':
+                print('NULL')
+            else:
+                print("%s" % format_multi_sz(valueData, separator=multiSzSeparator))
+        elif valueType in [REG_SZ, REG_EXPAND_SZ] :
             if valueData == b'' or valueData == b'\x00\x00':
                 print('NULL')
             else:

--- a/tests/misc/test_winregistry.py
+++ b/tests/misc/test_winregistry.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright Fortra, LLC and its affiliated companies
+#
+# All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+
+from impacket.winregistry import REG_MULTISZ, exportRegistryParser, format_multi_sz, saveRegistryParser
+
+
+class WinRegistryTests(unittest.TestCase):
+
+    def test_format_multi_sz_splits_values_and_removes_trailing_terminators(self):
+        value = "first\0second\0\0".encode("utf-16le")
+
+        self.assertEqual(format_multi_sz(value, separator="\n\t\t"), "first\n\t\tsecond")
+
+    def test_format_multi_sz_accepts_unpacked_remote_registry_strings(self):
+        value = "first\0second\0\0"
+
+        self.assertEqual(format_multi_sz(value, separator="\n  "), "first\n  second")
+
+    def test_format_multi_sz_preserves_null_sentinel(self):
+        self.assertEqual(format_multi_sz(0), "NULL")
+
+    def test_save_registry_print_value_formats_reg_multi_sz(self):
+        value = "first\0second\0\0".encode("utf-16le")
+        output = StringIO()
+
+        with redirect_stdout(output):
+            saveRegistryParser.printValue(None, REG_MULTISZ, value, multiSzSeparator="\n     ")
+
+        self.assertEqual(output.getvalue(), "first\n     second\n")
+
+    def test_export_registry_print_value_formats_empty_reg_multi_sz_as_null(self):
+        output = StringIO()
+
+        with redirect_stdout(output):
+            exportRegistryParser.printValue(None, REG_MULTISZ, b"\x00\x00")
+
+        self.assertEqual(output.getvalue(), "NULL\n")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)


### PR DESCRIPTION
## Summary
- Format REG_MULTI_SZ values as separate lines in reg.py query output
- Share REG_MULTI_SZ display formatting through winregistry.format_multi_sz()
- Align multiline REG_MULTISZ output in registry-read.py get_value output

## Validation
- python -m py_compile examples/reg.py examples/registry-read.py impacket/winregistry.py
- Live validation against a standalone Windows target for:
  - examples/reg.py add/query REG_MULTI_SZ
  - examples/registry-read.py against reg export
  - examples/registry-read.py against saved hive