### PR TITLE
Ldap examples update phase 1

### DIFF
--- a/examples/badsuccessor.py
+++ b/examples/badsuccessor.py
@@ -26,15 +26,17 @@ import logging
 import random
 import string
 import sys
-import ldap3
 
 from impacket import version
 from impacket.examples import logger
-from impacket.examples.utils import parse_identity, parse_target, init_ldap_session
-from impacket.ldap import ldaptypes
+from impacket.examples.utils import parse_identity, parse_target, ldap_login
+from impacket.ldap import ldap, ldapasn1, ldaptypes
 import uuid #needed for proper GUID conversion
 
 class BADSUCCESSOR:
+    LDAP_SCOPE_BASE = ldap.Scope('baseObject')
+    LDAP_SCOPE_SUBTREE = ldap.Scope('wholeSubtree')
+
     def __init__(self, username, password, domain, lmhash, nthash, cmdLineOptions):
         self.__username = username
         self.__password = password
@@ -79,6 +81,68 @@ class BADSUCCESSOR:
             elif self.__method == 'LDAPS':
                 self.__port = 636
 
+    @staticmethod
+    def _entry_dn(entry):
+        return str(entry['objectName'])
+
+    @staticmethod
+    def _get_entry_values(entry, attribute_name):
+        for attribute in entry['attributes']:
+            if str(attribute['type']).lower() == attribute_name.lower():
+                return list(attribute['vals'])
+        return []
+
+    @classmethod
+    def _get_entry_value(cls, entry, attribute_name):
+        values = cls._get_entry_values(entry, attribute_name)
+        return values[0] if values else None
+
+    @staticmethod
+    def _as_bytes(value):
+        if value is None:
+            return None
+        if hasattr(value, 'asOctets'):
+            return value.asOctets()
+        if isinstance(value, bytes):
+            return value
+        return bytes(value)
+
+    @classmethod
+    def _as_string(cls, value):
+        if value is None:
+            return None
+        if isinstance(value, bytes):
+            return value.decode('utf-8')
+        if hasattr(value, 'asOctets'):
+            try:
+                return value.asOctets().decode('utf-8')
+            except UnicodeDecodeError:
+                return str(value)
+        return str(value)
+
+    @classmethod
+    def _as_sid_string(cls, value):
+        if value is None:
+            return None
+        if isinstance(value, str) and value.startswith('S-'):
+            return value
+        sid_bytes = cls._as_bytes(value)
+        if sid_bytes is None:
+            return None
+        return ldaptypes.LDAP_SID(data=sid_bytes).formatCanonical()
+
+    @classmethod
+    def _search_entries(cls, ldapConnection, search_filter, search_base=None, search_scope=None, attributes=None,
+                        search_controls=None):
+        response = ldapConnection.search(
+            searchBase=search_base,
+            searchFilter=search_filter,
+            scope=search_scope,
+            attributes=attributes,
+            searchControls=search_controls,
+        )
+        return [item for item in response if isinstance(item, ldapasn1.SearchResultEntry)]
+
     def run(self):
         # Create the baseDN if not provided
         if self.__baseDN is None:
@@ -92,28 +156,24 @@ class BADSUCCESSOR:
 
         try:
             use_ldaps = (self.__method == 'LDAPS')
-            
-            # For Kerberos authentication, ensure proper target resolution
-            if self.__doKerberos:
-                target_host = self.__target if self.__target else self.__domain
-                dc_ip = self.__kdcHost if self.__kdcHost else self.__targetIp
-            else:
-                target_host = self.__target if self.__target else self.__domain
-                dc_ip = self.__targetIp
-            
-            _, ldapConnection = init_ldap_session(
-                domain=self.__domain,
-                username=self.__username,
-                password=self.__password,
-                lmhash=self.__lmhash,
-                nthash=self.__nthash,
-                k=self.__doKerberos,
-                dc_ip=dc_ip,
-                dc_host=target_host,
-                aesKey=self.__aesKey,
-                use_ldaps=use_ldaps
+
+            target_host = self.__target if self.__target else self.__domain
+            dc_ip = self.__targetIp
+
+            ldapConnection = ldap_login(
+                target_host,
+                self.__baseDN,
+                dc_ip,
+                target_host,
+                self.__doKerberos,
+                self.__username,
+                self.__password,
+                self.__domain,
+                self.__lmhash,
+                self.__nthash,
+                self.__aesKey,
+                ldaps_flag=use_ldaps,
             )
-            
         except Exception as e:
             raise Exception('Could not connect to LDAP server: %s' % str(e))
 
@@ -134,7 +194,7 @@ class BADSUCCESSOR:
             logging.error('Unknown action: %s' % self.__action)
             result = False
 
-        ldapConnection.unbind()
+        ldapConnection.close()
         return result
 
     def delete_dmsa(self, ldapConnection):
@@ -159,10 +219,7 @@ class BADSUCCESSOR:
             logging.info("%-30s %s" % ("-" * 30, "-" * 30))
             logging.info("%-30s %s" % ("dMSA Name:", '%s$' % self.__dmsaName))
             logging.info("%-30s %s" % ("Status:", "SUCCESS" if success else "FAILED"))
-            
-            if not success and ldapConnection.result:
-                logging.error("%-30s %s" % ("Error:", ldapConnection.result))
-            
+
             return success
                 
         except Exception as e:
@@ -171,15 +228,15 @@ class BADSUCCESSOR:
     
     def check_account_exists(self, ldapConnection, dn):
         try:
-            success = ldapConnection.search(
+            entries = self._search_entries(
+                ldapConnection,
+                '(objectClass=*)',
                 search_base=dn,
-                search_filter='(objectClass=*)',
-                search_scope=ldap3.BASE,
+                search_scope=self.LDAP_SCOPE_BASE,
                 attributes=['cn']
             )
-            
-            return success and len(ldapConnection.entries) > 0
-                
+
+            return len(entries) > 0
         except Exception as e:
             logging.debug('Error checking account existence: %s' % str(e))
             # If we can't determine, assume it doesn't exist to avoid blocking operations
@@ -188,71 +245,58 @@ class BADSUCCESSOR:
     def search_ous(self, ldapConnection):
         try:
             logging.info('Searching for OUs vulnerable to BadSuccessor attack...')
-            
-            if not ldapConnection.bound:
-                logging.error('LDAP connection is not bound')
-                return False
-            
-            success = ldapConnection.search(
+
+            dc_entries = self._search_entries(
+                ldapConnection,
+                '(&(objectCategory=computer)(objectClass=computer)(userAccountControl:1.2.840.113556.1.4.803:=8192))',
                 search_base=self.__baseDN,
-                search_filter='(&(objectCategory=computer)(objectClass=computer)(userAccountControl:1.2.840.113556.1.4.803:=8192))',
-                search_scope=ldap3.SUBTREE,
+                search_scope=self.LDAP_SCOPE_SUBTREE,
                 attributes=['operatingSystem', 'operatingSystemVersion']
             )
-
-            if not success:
-                logging.error('Failed to search for Domain Controllers: %s' % ldapConnection.result)
-                return False
-
             prereq_flag = False
-            for entry in ldapConnection.entries:
-                if ('operatingSystem' and 'operatingSystemVersion') not in entry:
-                    logging.error('Could not retrieve operating system information for Domain Controller: %s' % entry.entry_dn)
-                    pass
-                else:
-                    if 'Windows Server 2025' in entry.operatingSystem.value or '26100' in entry.operatingSystemVersion.value:
-                        logging.info('Found Windows Server 2025 Domain Controller: %s' % entry.entry_dn)
-                        prereq_flag = True
-                        break
+            for entry in dc_entries:
+                operating_system = self._as_string(self._get_entry_value(entry, 'operatingSystem'))
+                operating_system_version = self._as_string(self._get_entry_value(entry, 'operatingSystemVersion'))
+                if not operating_system or not operating_system_version:
+                    logging.error('Could not retrieve operating system information for Domain Controller: %s' % self._entry_dn(entry))
+                    continue
+
+                if 'Windows Server 2025' in operating_system or '26100' in operating_system_version:
+                    logging.info('Found Windows Server 2025 Domain Controller: %s' % self._entry_dn(entry))
+                    prereq_flag = True
+                    break
             
             if not prereq_flag:
                 logging.info('No Windows Server 2025 Domain Controllers found. This script requires at least one DC running Windows Server 2025.')
                 logging.info('Resulting list of Identities/OUs will show Identities that have permissions to create objects in OUs.')
                     
-
-            success = ldapConnection.search(
+            ou_entries = self._search_entries(
+                ldapConnection,
+                '(objectClass=organizationalUnit)',
                 search_base=self.__baseDN,
-                search_filter='(objectClass=organizationalUnit)',
-                search_scope=ldap3.SUBTREE,
+                search_scope=self.LDAP_SCOPE_SUBTREE,
                 attributes=['distinguishedName', 'nTSecurityDescriptor'],
-                controls=ldap3.protocol.microsoft.security_descriptor_control(sdflags=0x5)
+                search_controls=[ldapasn1.SDFlagsControl(flags=0x5)]
             )
-
-            
-            if not success:
-                logging.error('Failed to search for organizational units: %s' % ldapConnection.result)
-                return False
-            
-            # Store the OU entries before they get overwritten by other searches
-            ou_entries = list(ldapConnection.entries)
             logging.info('Found %d organizational units' % len(ou_entries))
             
             # Get domain SID for filtering excluded accounts
+            domain_sid = None
             try:
-                success = ldapConnection.search(
+                domain_entries = self._search_entries(
+                    ldapConnection,
+                    '(objectClass=domain)',
                     search_base=self.__baseDN,
-                    search_filter='(objectClass=domain)',
-                    search_scope=ldap3.BASE,
+                    search_scope=self.LDAP_SCOPE_BASE,
                     attributes=['objectSid']
                 )
-                
-                if success and len(ldapConnection.entries) > 0:
-                    entry = ldapConnection.entries[0]
-                    if 'objectSid' in entry:
-                        domain_sid = entry.objectSid.value
+
+                if domain_entries:
+                    domain_sid = self._as_sid_string(self._get_entry_value(domain_entries[0], 'objectSid'))
             except Exception as e:
                 logging.error('Failed to retrieve domain SID: %s' % str(e))
                 return False
+
             allowed_identities = {}
             
             relevant_rights = {
@@ -269,12 +313,11 @@ class BADSUCCESSOR:
             
             for entry in ou_entries:
                 try:
-                    ou_dn = str(entry.entry_dn)
-                    
-                    if 'nTSecurityDescriptor' not in entry or not entry.nTSecurityDescriptor.value:
+                    ou_dn = self._entry_dn(entry)
+                    sd_data = self._as_bytes(self._get_entry_value(entry, 'nTSecurityDescriptor'))
+                    if not sd_data:
                         continue
-                        
-                    sd_data = entry.nTSecurityDescriptor.value
+
                     sd = ldaptypes.SR_SECURITY_DESCRIPTOR(data=sd_data)
                     
                     # Process DACL entries (ACEs)
@@ -385,17 +428,17 @@ class BADSUCCESSOR:
             if sid in well_known_sids:
                 return well_known_sids[sid]
             
-            success = ldapConnection.search(
+            entries = self._search_entries(
+                ldapConnection,
+                '(objectSid=%s)' % sid,
                 search_base=self.__baseDN,
-                search_filter='(objectSid=%s)' % sid,
-                search_scope=ldap3.SUBTREE,
+                search_scope=self.LDAP_SCOPE_SUBTREE,
                 attributes=['sAMAccountName']
             )
-            
-            if success and len(ldapConnection.entries) > 0:
-                entry = ldapConnection.entries[0]
-                if 'sAMAccountName' in entry:
-                    username = entry.sAMAccountName.value
+
+            if entries:
+                username = self._as_string(self._get_entry_value(entries[0], 'sAMAccountName'))
+                if username:
                     return '%s\\%s' % (self.__domain.upper(), username)
                     
             return sid
@@ -529,7 +572,6 @@ class BADSUCCESSOR:
                 dns_hostname = '%s.%s' % (self.__dmsaName.lower(), self.__domain)
             
             attributes = {
-                'objectClass': ['msDS-DelegatedManagedServiceAccount'],
                 'cn': self.__dmsaName,
                 'sAMAccountName': '%s$' % self.__dmsaName,
                 'dNSHostName': dns_hostname,
@@ -543,19 +585,18 @@ class BADSUCCESSOR:
             group_msa_membership = None
             try:
                 search_filter = '(&(objectClass=user)(sAMAccountName=%s))' % principals_allowed
-                success = ldapConnection.search(
+                entries = self._search_entries(
+                    ldapConnection,
+                    search_filter,
                     search_base=self.__baseDN,
-                    search_filter=search_filter,
-                    search_scope=ldap3.SUBTREE,
+                    search_scope=self.LDAP_SCOPE_SUBTREE,
                     attributes=['objectSid'])
-                if success and len(ldapConnection.entries) > 0:
-                    entry = ldapConnection.entries[0]
-                    if 'objectSid' in entry:
-                        user_sid = entry.objectSid.value
-                        if user_sid:
-                            descriptor = self.build_security_descriptor(user_sid)
-                            group_msa_membership = descriptor
-                            attributes['nTSecurityDescriptor'] = descriptor
+                if entries:
+                    user_sid = self._as_sid_string(self._get_entry_value(entries[0], 'objectSid'))
+                    if user_sid:
+                        descriptor = self.build_security_descriptor(user_sid)
+                        group_msa_membership = descriptor
+                        attributes['nTSecurityDescriptor'] = descriptor
                 
             except Exception as e:
                 logging.debug('Error building MSA membership: %s' % str(e))
@@ -565,20 +606,22 @@ class BADSUCCESSOR:
                 attributes['msDS-GroupMSAMembership'] = group_msa_membership
 
             target_dn = None
-            success = ldapConnection.search(
-                search_base=self.__baseDN, 
-                search_filter='(&(objectClass=*)(sAMAccountName=%s))' % target_account,
-                search_scope=ldap3.SUBTREE,
+            entries = self._search_entries(
+                ldapConnection,
+                '(&(objectClass=*)(sAMAccountName=%s))' % target_account,
+                search_base=self.__baseDN,
+                search_scope=self.LDAP_SCOPE_SUBTREE,
                 attributes=['distinguishedName', 'objectClass']
             )
 
-            if success and len(ldapConnection.entries) > 0:
-                for entry in ldapConnection.entries:
-                    object_classes = [str(oc).lower() for oc in entry.objectClass.values]
+            if entries:
+                for entry in entries:
+                    object_classes = [self._as_string(value).lower() for value in self._get_entry_values(entry, 'objectClass')]
                     if 'user' in object_classes or 'computer' in object_classes:
-                        target_dn = str(entry.entry_dn)
-                # Return first match if no user/computer found
-                target_dn = str(ldapConnection.entries[0].entry_dn)
+                        target_dn = self._entry_dn(entry)
+                        break
+                if target_dn is None:
+                    target_dn = self._entry_dn(entries[0])
 
                 if target_dn:
                     attributes['msDS-ManagedAccountPrecededByLink'] = target_dn
@@ -589,7 +632,7 @@ class BADSUCCESSOR:
                 logging.error('Target account not found: %s' % target_account)
                 return False
             
-            success = ldapConnection.add(dmsa_dn, attributes=attributes)
+            success = ldapConnection.add(dmsa_dn, ['msDS-DelegatedManagedServiceAccount'], attributes=attributes)
 
             if success:
                 logging.info("")
@@ -600,10 +643,6 @@ class BADSUCCESSOR:
                 logging.info("%-30s %s" % ("Principals Allowed:", principals_allowed))
                 logging.info("%-30s %s" % ("Target Account:", target_account))
                 return True
-            else:
-                if ldapConnection.result:
-                    logging.error('LDAP error: %s' % ldapConnection.result)
-                return False
                 
         except Exception as e:
             logging.error('dMSA creation failed: %s' % str(e))
@@ -618,39 +657,39 @@ class BADSUCCESSOR:
                 return False
 
             # Get current target account value
-            success = ldapConnection.search(
+            entries = self._search_entries(
+                ldapConnection,
+                '(objectClass=msDS-DelegatedManagedServiceAccount)',
                 search_base=dmsa_dn,
-                search_filter='(objectClass=msDS-DelegatedManagedServiceAccount)',
-                search_scope=ldap3.BASE,
+                search_scope=self.LDAP_SCOPE_BASE,
                 attributes=['msDS-ManagedAccountPrecededByLink']
             )
             
             current_target_dn = None
-            if success and len(ldapConnection.entries) > 0:
-                entry = ldapConnection.entries[0]
-                if hasattr(entry, 'msDS-ManagedAccountPrecededByLink'):
-                    current_target_dn = entry['msDS-ManagedAccountPrecededByLink'].value
+            if entries:
+                current_target_dn = self._as_string(self._get_entry_value(entries[0], 'msDS-ManagedAccountPrecededByLink'))
 
-            success = ldapConnection.search(
-                search_base=self.__baseDN, 
-                search_filter='(&(objectClass=*)(sAMAccountName=%s))' % self.__targetAccount,
-                search_scope=ldap3.SUBTREE,
+            entries = self._search_entries(
+                ldapConnection,
+                '(&(objectClass=*)(sAMAccountName=%s))' % self.__targetAccount,
+                search_base=self.__baseDN,
+                search_scope=self.LDAP_SCOPE_SUBTREE,
                 attributes=['distinguishedName', 'objectClass']
             )
 
-            if not (success and len(ldapConnection.entries) > 0):
+            if not entries:
                 logging.error('Target account not found: %s' % self.__targetAccount)
                 return False
 
             target_dn = None
-            for entry in ldapConnection.entries:
-                object_classes = [str(oc).lower() for oc in entry.objectClass.values]
+            for entry in entries:
+                object_classes = [self._as_string(value).lower() for value in self._get_entry_values(entry, 'objectClass')]
                 if 'user' in object_classes or 'computer' in object_classes:
-                    target_dn = str(entry.entry_dn)
+                    target_dn = self._entry_dn(entry)
                     break
             
             if not target_dn:
-                target_dn = str(ldapConnection.entries[0].entry_dn)
+                target_dn = self._entry_dn(entries[0])
 
             if current_target_dn == target_dn:
                 logging.info('Target account is already set to: %s' % target_dn)
@@ -658,7 +697,7 @@ class BADSUCCESSOR:
                 return True
 
             modifications = {
-                'msDS-ManagedAccountPrecededByLink': [(ldap3.MODIFY_REPLACE, [target_dn])]
+                'msDS-ManagedAccountPrecededByLink': [(ldap.MODIFY_REPLACE, [target_dn])]
             }
             
             success = ldapConnection.modify(dmsa_dn, modifications)
@@ -666,9 +705,6 @@ class BADSUCCESSOR:
             if success:
                 logging.info('dMSA target account modified: %s -> %s' % (current_target_dn or '(not set)', target_dn))
                 return True
-            else:
-                logging.error('Failed to modify dMSA: %s' % ldapConnection.result)
-                return False
                 
         except Exception as e:
             logging.error('Error modifying dMSA: %s' % str(e))

--- a/examples/badsuccessor.py
+++ b/examples/badsuccessor.py
@@ -30,7 +30,7 @@ import sys
 from impacket import version
 from impacket.examples import logger
 from impacket.examples.utils import (parse_identity, parse_target, ldap_login,
-                                      as_bytes, as_string, as_sid_string,
+                                      ldap_value_to_bytes, as_string, as_sid_string,
                                       search_entries)
 from impacket.ldap import ldap, ldapasn1, ldaptypes
 import uuid #needed for proper GUID conversion
@@ -255,7 +255,7 @@ class BADSUCCESSOR:
             for entry in ou_entries:
                 try:
                     ou_dn = get_entry_dn(entry)
-                    sd_data = as_bytes(get_entry_value(entry, 'nTSecurityDescriptor'))
+                    sd_data = ldap_value_to_bytes(get_entry_value(entry, 'nTSecurityDescriptor'))
                     if not sd_data:
                         continue
 

--- a/examples/badsuccessor.py
+++ b/examples/badsuccessor.py
@@ -29,9 +29,12 @@ import sys
 
 from impacket import version
 from impacket.examples import logger
-from impacket.examples.utils import parse_identity, parse_target, ldap_login
+from impacket.examples.utils import (parse_identity, parse_target, ldap_login,
+                                      as_bytes, as_string, as_sid_string,
+                                      search_entries)
 from impacket.ldap import ldap, ldapasn1, ldaptypes
 import uuid #needed for proper GUID conversion
+from impacket.ldap.ldap import get_entry_dn, get_entry_value, get_entry_values
 
 class BADSUCCESSOR:
     LDAP_SCOPE_BASE = ldap.Scope('baseObject')
@@ -80,68 +83,6 @@ class BADSUCCESSOR:
                 self.__port = 389
             elif self.__method == 'LDAPS':
                 self.__port = 636
-
-    @staticmethod
-    def _entry_dn(entry):
-        return str(entry['objectName'])
-
-    @staticmethod
-    def _get_entry_values(entry, attribute_name):
-        for attribute in entry['attributes']:
-            if str(attribute['type']).lower() == attribute_name.lower():
-                return list(attribute['vals'])
-        return []
-
-    @classmethod
-    def _get_entry_value(cls, entry, attribute_name):
-        values = cls._get_entry_values(entry, attribute_name)
-        return values[0] if values else None
-
-    @staticmethod
-    def _as_bytes(value):
-        if value is None:
-            return None
-        if hasattr(value, 'asOctets'):
-            return value.asOctets()
-        if isinstance(value, bytes):
-            return value
-        return bytes(value)
-
-    @classmethod
-    def _as_string(cls, value):
-        if value is None:
-            return None
-        if isinstance(value, bytes):
-            return value.decode('utf-8')
-        if hasattr(value, 'asOctets'):
-            try:
-                return value.asOctets().decode('utf-8')
-            except UnicodeDecodeError:
-                return str(value)
-        return str(value)
-
-    @classmethod
-    def _as_sid_string(cls, value):
-        if value is None:
-            return None
-        if isinstance(value, str) and value.startswith('S-'):
-            return value
-        sid_bytes = cls._as_bytes(value)
-        if sid_bytes is None:
-            return None
-        return ldaptypes.LDAP_SID(data=sid_bytes).formatCanonical()
-
-    @classmethod
-    def _search_entries(cls, ldapConnection, search_filter, search_base=None, search_scope=None, attributes=None,
-                        search_controls=None):
-        response = ldapConnection.search(
-            searchBase=search_base,
-            searchFilter=search_filter,
-            scope=search_scope,
-            attributes=attributes,
-            searchControls=search_controls,
-        )
-        return [item for item in response if isinstance(item, ldapasn1.SearchResultEntry)]
 
     def run(self):
         # Create the baseDN if not provided
@@ -228,10 +169,10 @@ class BADSUCCESSOR:
     
     def check_account_exists(self, ldapConnection, dn):
         try:
-            entries = self._search_entries(
+            entries = search_entries(
                 ldapConnection,
                 '(objectClass=*)',
-                search_base=dn,
+                dn,
                 search_scope=self.LDAP_SCOPE_BASE,
                 attributes=['cn']
             )
@@ -246,23 +187,23 @@ class BADSUCCESSOR:
         try:
             logging.info('Searching for OUs vulnerable to BadSuccessor attack...')
 
-            dc_entries = self._search_entries(
+            dc_entries = search_entries(
                 ldapConnection,
                 '(&(objectCategory=computer)(objectClass=computer)(userAccountControl:1.2.840.113556.1.4.803:=8192))',
-                search_base=self.__baseDN,
+                self.__baseDN,
                 search_scope=self.LDAP_SCOPE_SUBTREE,
                 attributes=['operatingSystem', 'operatingSystemVersion']
             )
             prereq_flag = False
             for entry in dc_entries:
-                operating_system = self._as_string(self._get_entry_value(entry, 'operatingSystem'))
-                operating_system_version = self._as_string(self._get_entry_value(entry, 'operatingSystemVersion'))
+                operating_system = as_string(get_entry_value(entry, 'operatingSystem'))
+                operating_system_version = as_string(get_entry_value(entry, 'operatingSystemVersion'))
                 if not operating_system or not operating_system_version:
-                    logging.error('Could not retrieve operating system information for Domain Controller: %s' % self._entry_dn(entry))
+                    logging.error('Could not retrieve operating system information for Domain Controller: %s' % get_entry_dn(entry))
                     continue
 
                 if 'Windows Server 2025' in operating_system or '26100' in operating_system_version:
-                    logging.info('Found Windows Server 2025 Domain Controller: %s' % self._entry_dn(entry))
+                    logging.info('Found Windows Server 2025 Domain Controller: %s' % get_entry_dn(entry))
                     prereq_flag = True
                     break
             
@@ -270,10 +211,10 @@ class BADSUCCESSOR:
                 logging.info('No Windows Server 2025 Domain Controllers found. This script requires at least one DC running Windows Server 2025.')
                 logging.info('Resulting list of Identities/OUs will show Identities that have permissions to create objects in OUs.')
                     
-            ou_entries = self._search_entries(
+            ou_entries = search_entries(
                 ldapConnection,
                 '(objectClass=organizationalUnit)',
-                search_base=self.__baseDN,
+                self.__baseDN,
                 search_scope=self.LDAP_SCOPE_SUBTREE,
                 attributes=['distinguishedName', 'nTSecurityDescriptor'],
                 search_controls=[ldapasn1.SDFlagsControl(flags=0x5)]
@@ -283,16 +224,16 @@ class BADSUCCESSOR:
             # Get domain SID for filtering excluded accounts
             domain_sid = None
             try:
-                domain_entries = self._search_entries(
+                domain_entries = search_entries(
                     ldapConnection,
                     '(objectClass=domain)',
-                    search_base=self.__baseDN,
+                    self.__baseDN,
                     search_scope=self.LDAP_SCOPE_BASE,
                     attributes=['objectSid']
                 )
 
                 if domain_entries:
-                    domain_sid = self._as_sid_string(self._get_entry_value(domain_entries[0], 'objectSid'))
+                    domain_sid = as_sid_string(get_entry_value(domain_entries[0], 'objectSid'))
             except Exception as e:
                 logging.error('Failed to retrieve domain SID: %s' % str(e))
                 return False
@@ -313,8 +254,8 @@ class BADSUCCESSOR:
             
             for entry in ou_entries:
                 try:
-                    ou_dn = self._entry_dn(entry)
-                    sd_data = self._as_bytes(self._get_entry_value(entry, 'nTSecurityDescriptor'))
+                    ou_dn = get_entry_dn(entry)
+                    sd_data = as_bytes(get_entry_value(entry, 'nTSecurityDescriptor'))
                     if not sd_data:
                         continue
 
@@ -428,16 +369,16 @@ class BADSUCCESSOR:
             if sid in well_known_sids:
                 return well_known_sids[sid]
             
-            entries = self._search_entries(
+            entries = search_entries(
                 ldapConnection,
                 '(objectSid=%s)' % sid,
-                search_base=self.__baseDN,
+                self.__baseDN,
                 search_scope=self.LDAP_SCOPE_SUBTREE,
                 attributes=['sAMAccountName']
             )
 
             if entries:
-                username = self._as_string(self._get_entry_value(entries[0], 'sAMAccountName'))
+                username = as_string(get_entry_value(entries[0], 'sAMAccountName'))
                 if username:
                     return '%s\\%s' % (self.__domain.upper(), username)
                     
@@ -585,14 +526,14 @@ class BADSUCCESSOR:
             group_msa_membership = None
             try:
                 search_filter = '(&(objectClass=user)(sAMAccountName=%s))' % principals_allowed
-                entries = self._search_entries(
+                entries = search_entries(
                     ldapConnection,
                     search_filter,
-                    search_base=self.__baseDN,
+                    self.__baseDN,
                     search_scope=self.LDAP_SCOPE_SUBTREE,
                     attributes=['objectSid'])
                 if entries:
-                    user_sid = self._as_sid_string(self._get_entry_value(entries[0], 'objectSid'))
+                    user_sid = as_sid_string(get_entry_value(entries[0], 'objectSid'))
                     if user_sid:
                         descriptor = self.build_security_descriptor(user_sid)
                         group_msa_membership = descriptor
@@ -606,22 +547,22 @@ class BADSUCCESSOR:
                 attributes['msDS-GroupMSAMembership'] = group_msa_membership
 
             target_dn = None
-            entries = self._search_entries(
+            entries = search_entries(
                 ldapConnection,
                 '(&(objectClass=*)(sAMAccountName=%s))' % target_account,
-                search_base=self.__baseDN,
+                self.__baseDN,
                 search_scope=self.LDAP_SCOPE_SUBTREE,
                 attributes=['distinguishedName', 'objectClass']
             )
 
             if entries:
                 for entry in entries:
-                    object_classes = [self._as_string(value).lower() for value in self._get_entry_values(entry, 'objectClass')]
+                    object_classes = [as_string(value).lower() for value in get_entry_values(entry, 'objectClass')]
                     if 'user' in object_classes or 'computer' in object_classes:
-                        target_dn = self._entry_dn(entry)
+                        target_dn = get_entry_dn(entry)
                         break
                 if target_dn is None:
-                    target_dn = self._entry_dn(entries[0])
+                    target_dn = get_entry_dn(entries[0])
 
                 if target_dn:
                     attributes['msDS-ManagedAccountPrecededByLink'] = target_dn
@@ -657,22 +598,22 @@ class BADSUCCESSOR:
                 return False
 
             # Get current target account value
-            entries = self._search_entries(
+            entries = search_entries(
                 ldapConnection,
                 '(objectClass=msDS-DelegatedManagedServiceAccount)',
-                search_base=dmsa_dn,
+                dmsa_dn,
                 search_scope=self.LDAP_SCOPE_BASE,
                 attributes=['msDS-ManagedAccountPrecededByLink']
             )
-            
+
             current_target_dn = None
             if entries:
-                current_target_dn = self._as_string(self._get_entry_value(entries[0], 'msDS-ManagedAccountPrecededByLink'))
+                current_target_dn = as_string(get_entry_value(entries[0], 'msDS-ManagedAccountPrecededByLink'))
 
-            entries = self._search_entries(
+            entries = search_entries(
                 ldapConnection,
                 '(&(objectClass=*)(sAMAccountName=%s))' % self.__targetAccount,
-                search_base=self.__baseDN,
+                self.__baseDN,
                 search_scope=self.LDAP_SCOPE_SUBTREE,
                 attributes=['distinguishedName', 'objectClass']
             )
@@ -683,13 +624,13 @@ class BADSUCCESSOR:
 
             target_dn = None
             for entry in entries:
-                object_classes = [self._as_string(value).lower() for value in self._get_entry_values(entry, 'objectClass')]
+                object_classes = [as_string(value).lower() for value in get_entry_values(entry, 'objectClass')]
                 if 'user' in object_classes or 'computer' in object_classes:
-                    target_dn = self._entry_dn(entry)
+                    target_dn = get_entry_dn(entry)
                     break
-            
+
             if not target_dn:
-                target_dn = self._entry_dn(entries[0])
+                target_dn = get_entry_dn(entries[0])
 
             if current_target_dn == target_dn:
                 logging.info('Target account is already set to: %s' % target_dn)

--- a/examples/dacledit.py
+++ b/examples/dacledit.py
@@ -28,20 +28,15 @@ import sys
 import traceback
 import datetime
 
-import ldap3
-import ldapdomaindump
 from enum import Enum
-from ldap3.protocol.formatters.formatters import format_sid
 
 from impacket import version
 from impacket.examples import logger, utils
-from impacket.ldap import ldaptypes
+from impacket.ldap import ldap, ldapasn1, ldaptypes
 from impacket.msada_guids import SCHEMA_OBJECTS, EXTENDED_RIGHTS
-from ldap3.utils.conv import escape_filter_chars
-from ldap3.protocol.microsoft import security_descriptor_control
 from impacket.uuid import string_to_bin, bin_to_string
 
-from impacket.examples.utils import init_ldap_session, parse_identity
+from impacket.examples.utils import ldap_login, parse_identity
 
 OBJECT_TYPES_GUID = {}
 OBJECT_TYPES_GUID.update(SCHEMA_OBJECTS)
@@ -222,10 +217,10 @@ class ALLOWED_OBJECT_ACE_MASK_FLAGS(Enum):
 class DACLedit(object):
     """docstring for setrbcd"""
 
-    def __init__(self, ldap_server, ldap_session, args):
+    def __init__(self, ldap_session, base_dn, args):
         super(DACLedit, self).__init__()
-        self.ldap_server = ldap_server
         self.ldap_session = ldap_session
+        self.base_dn = base_dn
 
         self.target_sAMAccountName = args.target_sAMAccountName
         self.target_SID = args.target_SID
@@ -243,10 +238,7 @@ class DACLedit(object):
         if self.inheritance:
             logging.info("NB: objects with adminCount=1 will no inherit ACEs from their parent container/OU")
 
-        logging.debug('Initializing domainDumper()')
-        cnf = ldapdomaindump.domainDumpConfig()
-        cnf.basepath = None
-        self.domain_dumper = ldapdomaindump.domainDumper(self.ldap_server, self.ldap_session, cnf)
+        self.dacl_controls = [ldapasn1.SDFlagsControl(flags=0x04)]
 
         if args.mask is not None:
             if args.mask.startswith("0x"):
@@ -267,7 +259,7 @@ class DACLedit(object):
             # Searching for target account with its security descriptor
             self.search_target_principal_security_descriptor()
             # Extract security descriptor data
-            self.principal_raw_security_descriptor = self.target_principal['nTSecurityDescriptor'].raw_values[0]
+            self.principal_raw_security_descriptor = self._as_bytes(self._get_entry_value(self.target_principal, 'nTSecurityDescriptor'))
             self.principal_security_descriptor = ldaptypes.SR_SECURITY_DESCRIPTOR(data=self.principal_raw_security_descriptor)
 
         # Searching for the principal SID if any principal argument was given and principal_SID wasn't
@@ -275,16 +267,94 @@ class DACLedit(object):
             _lookedup_principal = ""
             if self.principal_sAMAccountName is not None:
                 _lookedup_principal = self.principal_sAMAccountName
-                self.ldap_session.search(self.domain_dumper.root, '(sAMAccountName=%s)' % escape_filter_chars(_lookedup_principal), attributes=['objectSid'])
+                entries = self._search_entries('(sAMAccountName=%s)' % self.escape_filter_chars(_lookedup_principal), attributes=['objectSid'])
             elif self.principal_DN is not None:
                 _lookedup_principal = self.principal_DN
-                self.ldap_session.search(_lookedup_principal, '(distinguishedName=%s)' % _lookedup_principal, attributes=['objectSid'])
+                entries = self._search_entries('(distinguishedName=%s)' % self.escape_filter_chars(_lookedup_principal), attributes=['objectSid'])
             try:
-                self.principal_SID = format_sid(self.ldap_session.entries[0]['objectSid'].raw_values[0])
+                self.principal_SID = self._as_sid_string(self._get_entry_value(entries[0], 'objectSid'))
                 logging.debug("Found principal SID: %s" % self.principal_SID)
             except IndexError:
                 logging.error('Principal SID not found in LDAP (%s)' % _lookedup_principal)
                 exit(1)
+
+    @staticmethod
+    def escape_filter_chars(value):
+        escaped = value.replace('\\', '\\5c')
+        escaped = escaped.replace('*', '\\2a')
+        escaped = escaped.replace('(', '\\28')
+        escaped = escaped.replace(')', '\\29')
+        escaped = escaped.replace('\x00', '\\00')
+        return escaped
+
+    @staticmethod
+    def _entry_dn(entry):
+        return str(entry['objectName'])
+
+    @staticmethod
+    def _get_entry_values(entry, attribute_name):
+        for attribute in entry['attributes']:
+            if str(attribute['type']).lower() == attribute_name.lower():
+                return list(attribute['vals'])
+        return []
+
+    @classmethod
+    def _get_entry_value(cls, entry, attribute_name):
+        values = cls._get_entry_values(entry, attribute_name)
+        return values[0] if values else None
+
+    @staticmethod
+    def _as_bytes(value):
+        if value is None:
+            return None
+        if hasattr(value, 'asOctets'):
+            return value.asOctets()
+        if isinstance(value, bytes):
+            return value
+        return bytes(value)
+
+    @classmethod
+    def _as_string(cls, value):
+        if value is None:
+            return None
+        if isinstance(value, bytes):
+            return value.decode('utf-8')
+        if hasattr(value, 'asOctets'):
+            try:
+                return value.asOctets().decode('utf-8')
+            except UnicodeDecodeError:
+                return str(value)
+        return str(value)
+
+    @classmethod
+    def _as_sid_string(cls, value):
+        if value is None:
+            return None
+        if isinstance(value, str) and value.startswith('S-'):
+            return value
+        sid_bytes = cls._as_bytes(value)
+        if sid_bytes is None:
+            return None
+        return ldaptypes.LDAP_SID(data=sid_bytes).formatCanonical()
+
+    def _search_entries(self, search_filter, search_base=None, search_scope=None, attributes=None, search_controls=None):
+        response = self.ldap_session.search(
+            searchBase=search_base if search_base is not None else self.base_dn,
+            searchFilter=search_filter,
+            scope=search_scope,
+            attributes=attributes,
+            searchControls=search_controls,
+        )
+        return [item for item in response if isinstance(item, ldapasn1.SearchResultEntry)]
+
+    @staticmethod
+    def _log_ldap_error(prefix, error):
+        if error.getErrorCode() == 50:
+            logging.error('%s, the server reports insufficient rights: %s', prefix, error.getErrorString())
+        elif error.getErrorCode() == 19:
+            logging.error('%s, the server reports a constrained violation: %s', prefix, error.getErrorString())
+        else:
+            logging.error('%s: %s', prefix, error.getErrorString())
 
 
     # Main read funtion
@@ -301,19 +371,19 @@ class DACLedit(object):
         # Creates ACEs with the specified GUIDs and the SID, or FullControl if no GUID is specified
         # Append the ACEs in the DACL locally
         if self.rights == "FullControl" and self.rights_guid is None:
-            logging.debug("Appending ACE (%s --(FullControl)--> %s)" % (self.principal_SID, format_sid(self.target_SID)))
+            logging.debug("Appending ACE (%s --(FullControl)--> %s)" % (self.principal_SID, self.target_SID or self.target_sAMAccountName or self.target_DN))
             self.principal_security_descriptor['Dacl'].aces.append(self.create_ace(SIMPLE_PERMISSIONS.FullControl.value, self.principal_SID, self.ace_type))
         elif self.rights == "Custom" and self.force_mask is not None:
-            logging.debug("Appending ACE (%s --(Custom)--> %s)" % (self.principal_SID, format_sid(self.target_SID)))
+            logging.debug("Appending ACE (%s --(Custom)--> %s)" % (self.principal_SID, self.target_SID or self.target_sAMAccountName or self.target_DN))
             self.principal_security_descriptor['Dacl'].aces.append(self.create_ace(self.force_mask, self.principal_SID, self.ace_type))
         else:
             for rights_guid in self.build_guids_for_rights():
-                logging.debug("Appending ACE (%s --(%s)--> %s)" % (self.principal_SID, rights_guid, format_sid(self.target_SID)))
+                logging.debug("Appending ACE (%s --(%s)--> %s)" % (self.principal_SID, rights_guid, self.target_SID or self.target_sAMAccountName or self.target_DN))
                 self.principal_security_descriptor['Dacl'].aces.append(self.create_object_ace(rights_guid, self.principal_SID, self.ace_type, force_mask=self.force_mask))
         # Backups current DACL before add the new one
         self.backup()
         # Effectively push the DACL with the new ACE
-        self.modify_secDesc_for_dn(self.target_principal.entry_dn, self.principal_security_descriptor)
+        self.modify_secDesc_for_dn(self._entry_dn(self.target_principal), self.principal_security_descriptor)
         return
 
 
@@ -370,7 +440,7 @@ class DACLedit(object):
         if dacl_must_be_replaced:
             self.principal_security_descriptor['Dacl'].aces = new_dacl
             self.backup()
-            self.modify_secDesc_for_dn(self.target_principal.entry_dn, self.principal_security_descriptor)
+            self.modify_secDesc_for_dn(self._entry_dn(self.target_principal), self.principal_security_descriptor)
         else:
             logging.info("Nothing to remove...")
 
@@ -380,7 +450,7 @@ class DACLedit(object):
     def backup(self):
         backup = {}
         backup["sd"] = binascii.hexlify(self.principal_raw_security_descriptor).decode('utf-8')
-        backup["dn"] = self.target_principal.entry_dn
+        backup["dn"] = self._entry_dn(self.target_principal)
         if not self.filename:
             self.filename = 'dacledit-%s.bak' % datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
         else:
@@ -407,7 +477,7 @@ class DACLedit(object):
         # Searching for target account with its security descriptor
         self.search_target_principal_security_descriptor()
         # Extract security descriptor data
-        self.principal_raw_security_descriptor = self.target_principal['nTSecurityDescriptor'].raw_values[0]
+        self.principal_raw_security_descriptor = self._as_bytes(self._get_entry_value(self.target_principal, 'nTSecurityDescriptor'))
         self.principal_security_descriptor = ldaptypes.SR_SECURITY_DESCRIPTOR(data=self.principal_raw_security_descriptor)
 
         # Do a backup of the actual DACL and push the restoration
@@ -418,19 +488,17 @@ class DACLedit(object):
     # Attempts to retrieve the DACL in the Security Descriptor of the specified target
     def search_target_principal_security_descriptor(self):
         _lookedup_principal = ""
-        # Set SD flags to only query for DACL
-        controls = security_descriptor_control(sdflags=0x04)
         if self.target_sAMAccountName is not None:
             _lookedup_principal = self.target_sAMAccountName
-            self.ldap_session.search(self.domain_dumper.root, '(sAMAccountName=%s)' % escape_filter_chars(_lookedup_principal), attributes=['nTSecurityDescriptor'], controls=controls)
+            entries = self._search_entries('(sAMAccountName=%s)' % self.escape_filter_chars(_lookedup_principal), attributes=['nTSecurityDescriptor'], search_controls=self.dacl_controls)
         elif self.target_SID is not None:
             _lookedup_principal = self.target_SID
-            self.ldap_session.search(self.domain_dumper.root, '(objectSid=%s)' % _lookedup_principal, attributes=['nTSecurityDescriptor'], controls=controls)
+            entries = self._search_entries('(objectSid=%s)' % _lookedup_principal, attributes=['nTSecurityDescriptor'], search_controls=self.dacl_controls)
         elif self.target_DN is not None:
             _lookedup_principal = self.target_DN
-            self.ldap_session.search(_lookedup_principal, '(distinguishedName=%s)' % _lookedup_principal, attributes=['nTSecurityDescriptor'], controls=controls)
+            entries = self._search_entries('(distinguishedName=%s)' % self.escape_filter_chars(_lookedup_principal), attributes=['nTSecurityDescriptor'], search_controls=self.dacl_controls)
         try:
-            self.target_principal = self.ldap_session.entries[0]
+            self.target_principal = entries[0]
             logging.debug('Target principal found in LDAP (%s)' % _lookedup_principal)
         except IndexError:
             logging.error('Target principal not found in LDAP (%s)' % _lookedup_principal)
@@ -441,12 +509,12 @@ class DACLedit(object):
     # Not used for the moment
     #   - samname : a sAMAccountName
     def get_user_info(self, samname):
-        self.ldap_session.search(self.domain_dumper.root, '(sAMAccountName=%s)' % escape_filter_chars(samname), attributes=['objectSid'])
+        entries = self._search_entries('(sAMAccountName=%s)' % self.escape_filter_chars(samname), attributes=['objectSid'])
         try:
-            dn = self.ldap_session.entries[0].entry_dn
-            sid = format_sid(self.ldap_session.entries[0]['objectSid'].raw_values[0])
+            dn = self._entry_dn(entries[0])
+            sid = self._as_sid_string(self._get_entry_value(entries[0], 'objectSid'))
             return dn, sid
-        except IndexError:
+        except (IndexError, TypeError):
             logging.error('User not found in LDAP: %s' % samname)
             return False
 
@@ -459,10 +527,9 @@ class DACLedit(object):
             return WELL_KNOWN_SIDS[sid]
         # Tries to resolve the SID from the LDAP domain dump
         else:
-            self.ldap_session.search(self.domain_dumper.root, '(objectSid=%s)' % sid, attributes=['samaccountname'])
+            entries = self._search_entries('(objectSid=%s)' % sid, attributes=['samaccountname'])
             try:
-                dn = self.ldap_session.entries[0].entry_dn
-                samname = self.ldap_session.entries[0]['samaccountname']
+                samname = self._as_string(self._get_entry_value(entries[0], 'samaccountname'))
                 return samname
             except IndexError:
                 logging.debug('SID not found in LDAP: %s' % sid)
@@ -569,12 +636,12 @@ class DACLedit(object):
         if self.principal_SID is None and self.principal_sAMAccountName or self.principal_DN:
             if self.principal_sAMAccountName is not None:
                 _lookedup_principal = self.principal_sAMAccountName
-                self.ldap_session.search(self.domain_dumper.root, '(sAMAccountName=%s)' % escape_filter_chars(_lookedup_principal), attributes=['objectSid'])
+                entries = self._search_entries('(sAMAccountName=%s)' % self.escape_filter_chars(_lookedup_principal), attributes=['objectSid'])
             elif self.principal_DN is not None:
                 _lookedup_principal = self.principal_DN
-                self.ldap_session.search(_lookedup_principal, '(distinguishedName=%s)' % _lookedup_principal, attributes=['objectSid'])
+                entries = self._search_entries('(distinguishedName=%s)' % self.escape_filter_chars(_lookedup_principal), attributes=['objectSid'])
             try:
-                self.principal_SID = format_sid(self.ldap_session.entries[0]['objectSid'].raw_values[0])
+                self.principal_SID = self._as_sid_string(self._get_entry_value(entries[0], 'objectSid'))
             except IndexError:
                 logging.error('Principal not found in LDAP (%s)' % _lookedup_principal)
                 return False
@@ -628,20 +695,12 @@ class DACLedit(object):
     #   - secDesc : the Security Descriptor with the new DACL to push
     def modify_secDesc_for_dn(self, dn, secDesc):
         data = secDesc.getData()
-        controls = security_descriptor_control(sdflags=0x04)
         logging.debug('Attempts to modify the Security Descriptor.')
-        self.ldap_session.modify(dn, {'nTSecurityDescriptor': (ldap3.MODIFY_REPLACE, [data])}, controls=controls)
-        if self.ldap_session.result['result'] == 0:
+        try:
+            self.ldap_session.modify(dn, {'nTSecurityDescriptor': [(ldap.MODIFY_REPLACE, [data])]}, controls=self.dacl_controls)
             logging.info('DACL modified successfully!')
-        else:
-            if self.ldap_session.result['result'] == 50:
-                logging.error('Could not modify object, the server reports insufficient rights: %s',
-                              self.ldap_session.result['message'])
-            elif self.ldap_session.result['result'] == 19:
-                logging.error('Could not modify object, the server reports a constrained violation: %s',
-                              self.ldap_session.result['message'])
-            else:
-                logging.error('The server returned an error: %s', self.ldap_session.result['message'])
+        except ldap.LDAPSessionError as error:
+            self._log_ldap_error('Could not modify object', error)
 
 
     # Builds a standard ACE for a specified access mask (rights) and a specified SID (the principal who obtains the right)
@@ -769,8 +828,10 @@ def main():
     domain, username, password, lmhash, nthash, args.k = parse_identity(args.identity, args.hashes, args.no_pass, args.aesKey, args.k)
 
     try:
-        ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.dc_host, args.aesKey, args.use_ldaps)
-        dacledit = DACLedit(ldap_server, ldap_session, args)
+        base_dn = ','.join('dc=%s' % part for part in domain.split('.'))
+        target = args.dc_host if args.dc_host is not None else domain
+        ldap_session = ldap_login(target, base_dn, args.dc_ip, args.dc_host, args.k, username, password, domain, lmhash, nthash, args.aesKey, ldaps_flag=args.use_ldaps)
+        dacledit = DACLedit(ldap_session, base_dn, args)
         if args.action == 'read':
             dacledit.read()
         elif args.action == 'write':

--- a/examples/dacledit.py
+++ b/examples/dacledit.py
@@ -33,10 +33,13 @@ from enum import Enum
 from impacket import version
 from impacket.examples import logger, utils
 from impacket.ldap import ldap, ldapasn1, ldaptypes
+from impacket.ldap.ldap import escape_filter_chars, get_entry_dn, get_entry_value, get_entry_values
 from impacket.msada_guids import SCHEMA_OBJECTS, EXTENDED_RIGHTS
 from impacket.uuid import string_to_bin, bin_to_string
 
-from impacket.examples.utils import ldap_login, parse_identity
+from impacket.examples.utils import (ldap_login, parse_identity,
+                                      as_bytes, as_string, as_sid_string,
+                                      search_entries, log_ldap_error)
 
 OBJECT_TYPES_GUID = {}
 OBJECT_TYPES_GUID.update(SCHEMA_OBJECTS)
@@ -259,7 +262,7 @@ class DACLedit(object):
             # Searching for target account with its security descriptor
             self.search_target_principal_security_descriptor()
             # Extract security descriptor data
-            self.principal_raw_security_descriptor = self._as_bytes(self._get_entry_value(self.target_principal, 'nTSecurityDescriptor'))
+            self.principal_raw_security_descriptor = as_bytes(get_entry_value(self.target_principal, 'nTSecurityDescriptor'))
             self.principal_security_descriptor = ldaptypes.SR_SECURITY_DESCRIPTOR(data=self.principal_raw_security_descriptor)
 
         # Searching for the principal SID if any principal argument was given and principal_SID wasn't
@@ -267,94 +270,16 @@ class DACLedit(object):
             _lookedup_principal = ""
             if self.principal_sAMAccountName is not None:
                 _lookedup_principal = self.principal_sAMAccountName
-                entries = self._search_entries('(sAMAccountName=%s)' % self.escape_filter_chars(_lookedup_principal), attributes=['objectSid'])
+                entries = search_entries(self.ldap_session, '(sAMAccountName=%s)' % escape_filter_chars(_lookedup_principal), self.base_dn, attributes=['objectSid'])
             elif self.principal_DN is not None:
                 _lookedup_principal = self.principal_DN
-                entries = self._search_entries('(distinguishedName=%s)' % self.escape_filter_chars(_lookedup_principal), attributes=['objectSid'])
+                entries = search_entries(self.ldap_session, '(distinguishedName=%s)' % escape_filter_chars(_lookedup_principal), self.base_dn, attributes=['objectSid'])
             try:
-                self.principal_SID = self._as_sid_string(self._get_entry_value(entries[0], 'objectSid'))
+                self.principal_SID = as_sid_string(get_entry_value(entries[0], 'objectSid'))
                 logging.debug("Found principal SID: %s" % self.principal_SID)
             except IndexError:
                 logging.error('Principal SID not found in LDAP (%s)' % _lookedup_principal)
                 exit(1)
-
-    @staticmethod
-    def escape_filter_chars(value):
-        escaped = value.replace('\\', '\\5c')
-        escaped = escaped.replace('*', '\\2a')
-        escaped = escaped.replace('(', '\\28')
-        escaped = escaped.replace(')', '\\29')
-        escaped = escaped.replace('\x00', '\\00')
-        return escaped
-
-    @staticmethod
-    def _entry_dn(entry):
-        return str(entry['objectName'])
-
-    @staticmethod
-    def _get_entry_values(entry, attribute_name):
-        for attribute in entry['attributes']:
-            if str(attribute['type']).lower() == attribute_name.lower():
-                return list(attribute['vals'])
-        return []
-
-    @classmethod
-    def _get_entry_value(cls, entry, attribute_name):
-        values = cls._get_entry_values(entry, attribute_name)
-        return values[0] if values else None
-
-    @staticmethod
-    def _as_bytes(value):
-        if value is None:
-            return None
-        if hasattr(value, 'asOctets'):
-            return value.asOctets()
-        if isinstance(value, bytes):
-            return value
-        return bytes(value)
-
-    @classmethod
-    def _as_string(cls, value):
-        if value is None:
-            return None
-        if isinstance(value, bytes):
-            return value.decode('utf-8')
-        if hasattr(value, 'asOctets'):
-            try:
-                return value.asOctets().decode('utf-8')
-            except UnicodeDecodeError:
-                return str(value)
-        return str(value)
-
-    @classmethod
-    def _as_sid_string(cls, value):
-        if value is None:
-            return None
-        if isinstance(value, str) and value.startswith('S-'):
-            return value
-        sid_bytes = cls._as_bytes(value)
-        if sid_bytes is None:
-            return None
-        return ldaptypes.LDAP_SID(data=sid_bytes).formatCanonical()
-
-    def _search_entries(self, search_filter, search_base=None, search_scope=None, attributes=None, search_controls=None):
-        response = self.ldap_session.search(
-            searchBase=search_base if search_base is not None else self.base_dn,
-            searchFilter=search_filter,
-            scope=search_scope,
-            attributes=attributes,
-            searchControls=search_controls,
-        )
-        return [item for item in response if isinstance(item, ldapasn1.SearchResultEntry)]
-
-    @staticmethod
-    def _log_ldap_error(prefix, error):
-        if error.getErrorCode() == 50:
-            logging.error('%s, the server reports insufficient rights: %s', prefix, error.getErrorString())
-        elif error.getErrorCode() == 19:
-            logging.error('%s, the server reports a constrained violation: %s', prefix, error.getErrorString())
-        else:
-            logging.error('%s: %s', prefix, error.getErrorString())
 
 
     # Main read funtion
@@ -383,7 +308,7 @@ class DACLedit(object):
         # Backups current DACL before add the new one
         self.backup()
         # Effectively push the DACL with the new ACE
-        self.modify_secDesc_for_dn(self._entry_dn(self.target_principal), self.principal_security_descriptor)
+        self.modify_secDesc_for_dn(get_entry_dn(self.target_principal), self.principal_security_descriptor)
         return
 
 
@@ -440,7 +365,7 @@ class DACLedit(object):
         if dacl_must_be_replaced:
             self.principal_security_descriptor['Dacl'].aces = new_dacl
             self.backup()
-            self.modify_secDesc_for_dn(self._entry_dn(self.target_principal), self.principal_security_descriptor)
+            self.modify_secDesc_for_dn(get_entry_dn(self.target_principal), self.principal_security_descriptor)
         else:
             logging.info("Nothing to remove...")
 
@@ -450,7 +375,7 @@ class DACLedit(object):
     def backup(self):
         backup = {}
         backup["sd"] = binascii.hexlify(self.principal_raw_security_descriptor).decode('utf-8')
-        backup["dn"] = self._entry_dn(self.target_principal)
+        backup["dn"] = get_entry_dn(self.target_principal)
         if not self.filename:
             self.filename = 'dacledit-%s.bak' % datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
         else:
@@ -477,7 +402,7 @@ class DACLedit(object):
         # Searching for target account with its security descriptor
         self.search_target_principal_security_descriptor()
         # Extract security descriptor data
-        self.principal_raw_security_descriptor = self._as_bytes(self._get_entry_value(self.target_principal, 'nTSecurityDescriptor'))
+        self.principal_raw_security_descriptor = as_bytes(get_entry_value(self.target_principal, 'nTSecurityDescriptor'))
         self.principal_security_descriptor = ldaptypes.SR_SECURITY_DESCRIPTOR(data=self.principal_raw_security_descriptor)
 
         # Do a backup of the actual DACL and push the restoration
@@ -490,13 +415,13 @@ class DACLedit(object):
         _lookedup_principal = ""
         if self.target_sAMAccountName is not None:
             _lookedup_principal = self.target_sAMAccountName
-            entries = self._search_entries('(sAMAccountName=%s)' % self.escape_filter_chars(_lookedup_principal), attributes=['nTSecurityDescriptor'], search_controls=self.dacl_controls)
+            entries = search_entries(self.ldap_session, '(sAMAccountName=%s)' % escape_filter_chars(_lookedup_principal), self.base_dn, attributes=['nTSecurityDescriptor'], search_controls=self.dacl_controls)
         elif self.target_SID is not None:
             _lookedup_principal = self.target_SID
-            entries = self._search_entries('(objectSid=%s)' % _lookedup_principal, attributes=['nTSecurityDescriptor'], search_controls=self.dacl_controls)
+            entries = search_entries(self.ldap_session, '(objectSid=%s)' % _lookedup_principal, self.base_dn, attributes=['nTSecurityDescriptor'], search_controls=self.dacl_controls)
         elif self.target_DN is not None:
             _lookedup_principal = self.target_DN
-            entries = self._search_entries('(distinguishedName=%s)' % self.escape_filter_chars(_lookedup_principal), attributes=['nTSecurityDescriptor'], search_controls=self.dacl_controls)
+            entries = search_entries(self.ldap_session, '(distinguishedName=%s)' % escape_filter_chars(_lookedup_principal), self.base_dn, attributes=['nTSecurityDescriptor'], search_controls=self.dacl_controls)
         try:
             self.target_principal = entries[0]
             logging.debug('Target principal found in LDAP (%s)' % _lookedup_principal)
@@ -509,10 +434,10 @@ class DACLedit(object):
     # Not used for the moment
     #   - samname : a sAMAccountName
     def get_user_info(self, samname):
-        entries = self._search_entries('(sAMAccountName=%s)' % self.escape_filter_chars(samname), attributes=['objectSid'])
+        entries = search_entries(self.ldap_session, '(sAMAccountName=%s)' % escape_filter_chars(samname), self.base_dn, attributes=['objectSid'])
         try:
-            dn = self._entry_dn(entries[0])
-            sid = self._as_sid_string(self._get_entry_value(entries[0], 'objectSid'))
+            dn = get_entry_dn(entries[0])
+            sid = as_sid_string(get_entry_value(entries[0], 'objectSid'))
             return dn, sid
         except (IndexError, TypeError):
             logging.error('User not found in LDAP: %s' % samname)
@@ -527,9 +452,9 @@ class DACLedit(object):
             return WELL_KNOWN_SIDS[sid]
         # Tries to resolve the SID from the LDAP domain dump
         else:
-            entries = self._search_entries('(objectSid=%s)' % sid, attributes=['samaccountname'])
+            entries = search_entries(self.ldap_session, '(objectSid=%s)' % sid, self.base_dn, attributes=['samaccountname'])
             try:
-                samname = self._as_string(self._get_entry_value(entries[0], 'samaccountname'))
+                samname = as_string(get_entry_value(entries[0], 'samaccountname'))
                 return samname
             except IndexError:
                 logging.debug('SID not found in LDAP: %s' % sid)
@@ -636,12 +561,12 @@ class DACLedit(object):
         if self.principal_SID is None and self.principal_sAMAccountName or self.principal_DN:
             if self.principal_sAMAccountName is not None:
                 _lookedup_principal = self.principal_sAMAccountName
-                entries = self._search_entries('(sAMAccountName=%s)' % self.escape_filter_chars(_lookedup_principal), attributes=['objectSid'])
+                entries = search_entries(self.ldap_session, '(sAMAccountName=%s)' % escape_filter_chars(_lookedup_principal), self.base_dn, attributes=['objectSid'])
             elif self.principal_DN is not None:
                 _lookedup_principal = self.principal_DN
-                entries = self._search_entries('(distinguishedName=%s)' % self.escape_filter_chars(_lookedup_principal), attributes=['objectSid'])
+                entries = search_entries(self.ldap_session, '(distinguishedName=%s)' % escape_filter_chars(_lookedup_principal), self.base_dn, attributes=['objectSid'])
             try:
-                self.principal_SID = self._as_sid_string(self._get_entry_value(entries[0], 'objectSid'))
+                self.principal_SID = as_sid_string(get_entry_value(entries[0], 'objectSid'))
             except IndexError:
                 logging.error('Principal not found in LDAP (%s)' % _lookedup_principal)
                 return False
@@ -700,7 +625,7 @@ class DACLedit(object):
             self.ldap_session.modify(dn, {'nTSecurityDescriptor': [(ldap.MODIFY_REPLACE, [data])]}, controls=self.dacl_controls)
             logging.info('DACL modified successfully!')
         except ldap.LDAPSessionError as error:
-            self._log_ldap_error('Could not modify object', error)
+            log_ldap_error('Could not modify object', error)
 
 
     # Builds a standard ACE for a specified access mask (rights) and a specified SID (the principal who obtains the right)

--- a/examples/dacledit.py
+++ b/examples/dacledit.py
@@ -38,7 +38,7 @@ from impacket.msada_guids import SCHEMA_OBJECTS, EXTENDED_RIGHTS
 from impacket.uuid import string_to_bin, bin_to_string
 
 from impacket.examples.utils import (ldap_login, parse_identity,
-                                      as_bytes, as_string, as_sid_string,
+                                      ldap_value_to_bytes, as_string, as_sid_string,
                                       search_entries, log_ldap_error)
 
 OBJECT_TYPES_GUID = {}
@@ -262,7 +262,7 @@ class DACLedit(object):
             # Searching for target account with its security descriptor
             self.search_target_principal_security_descriptor()
             # Extract security descriptor data
-            self.principal_raw_security_descriptor = as_bytes(get_entry_value(self.target_principal, 'nTSecurityDescriptor'))
+            self.principal_raw_security_descriptor = ldap_value_to_bytes(get_entry_value(self.target_principal, 'nTSecurityDescriptor'))
             self.principal_security_descriptor = ldaptypes.SR_SECURITY_DESCRIPTOR(data=self.principal_raw_security_descriptor)
 
         # Searching for the principal SID if any principal argument was given and principal_SID wasn't
@@ -402,7 +402,7 @@ class DACLedit(object):
         # Searching for target account with its security descriptor
         self.search_target_principal_security_descriptor()
         # Extract security descriptor data
-        self.principal_raw_security_descriptor = as_bytes(get_entry_value(self.target_principal, 'nTSecurityDescriptor'))
+        self.principal_raw_security_descriptor = ldap_value_to_bytes(get_entry_value(self.target_principal, 'nTSecurityDescriptor'))
         self.principal_security_descriptor = ldaptypes.SR_SECURITY_DESCRIPTOR(data=self.principal_raw_security_descriptor)
 
         # Do a backup of the actual DACL and push the restoration

--- a/examples/owneredit.py
+++ b/examples/owneredit.py
@@ -23,8 +23,11 @@ import traceback
 from impacket import version
 from impacket.examples import logger, utils
 from impacket.ldap import ldap, ldapasn1, ldaptypes
+from impacket.ldap.ldap import escape_filter_chars, get_entry_dn, get_entry_value
 
-from impacket.examples.utils import ldap_login, parse_identity
+from impacket.examples.utils import (ldap_login, parse_identity,
+                                      as_bytes, as_string, as_sid_string,
+                                      search_entries, log_ldap_error)
 
 
 # Universal SIDs
@@ -125,7 +128,7 @@ class OwnerEdit(object):
             # Searching for target account with its security descriptor
             self.search_target_principal_security_descriptor()
             # Extract security descriptor data
-            self.target_principal_raw_security_descriptor = self._as_bytes(self._get_entry_value(self.target_principal, 'nTSecurityDescriptor'))
+            self.target_principal_raw_security_descriptor = as_bytes(get_entry_value(self.target_principal, 'nTSecurityDescriptor'))
             self.target_principal_security_descriptor = ldaptypes.SR_SECURITY_DESCRIPTOR(data=self.target_principal_raw_security_descriptor)
 
         # Searching for the owner SID if any owner argument was given and new_owner_SID wasn't
@@ -133,102 +136,24 @@ class OwnerEdit(object):
             _lookedup_owner = ""
             if self.new_owner_sAMAccountName is not None:
                 _lookedup_owner = self.new_owner_sAMAccountName
-                entries = self._search_entries('(sAMAccountName=%s)' % self.escape_filter_chars(_lookedup_owner), attributes=['objectSid'])
+                entries = search_entries(self.ldap_session, '(sAMAccountName=%s)' % escape_filter_chars(_lookedup_owner), self.base_dn, attributes=['objectSid'])
             elif self.new_owner_DN is not None:
                 _lookedup_owner = self.new_owner_DN
-                entries = self._search_entries('(distinguishedName=%s)' % self.escape_filter_chars(_lookedup_owner), attributes=['objectSid'])
+                entries = search_entries(self.ldap_session, '(distinguishedName=%s)' % escape_filter_chars(_lookedup_owner), self.base_dn, attributes=['objectSid'])
             try:
-                self.new_owner_SID = self._as_sid_string(self._get_entry_value(entries[0], 'objectSid'))
+                self.new_owner_SID = as_sid_string(get_entry_value(entries[0], 'objectSid'))
                 logging.debug("Found new owner SID: %s" % self.new_owner_SID)
             except IndexError:
                 logging.error('New owner SID not found in LDAP (%s)' % _lookedup_owner)
                 exit(1)
-
-    @staticmethod
-    def escape_filter_chars(value):
-        escaped = value.replace('\\', '\\5c')
-        escaped = escaped.replace('*', '\\2a')
-        escaped = escaped.replace('(', '\\28')
-        escaped = escaped.replace(')', '\\29')
-        escaped = escaped.replace('\x00', '\\00')
-        return escaped
-
-    @staticmethod
-    def _entry_dn(entry):
-        return str(entry['objectName'])
-
-    @staticmethod
-    def _get_entry_values(entry, attribute_name):
-        for attribute in entry['attributes']:
-            if str(attribute['type']).lower() == attribute_name.lower():
-                return list(attribute['vals'])
-        return []
-
-    @classmethod
-    def _get_entry_value(cls, entry, attribute_name):
-        values = cls._get_entry_values(entry, attribute_name)
-        return values[0] if values else None
-
-    @staticmethod
-    def _as_bytes(value):
-        if value is None:
-            return None
-        if hasattr(value, 'asOctets'):
-            return value.asOctets()
-        if isinstance(value, bytes):
-            return value
-        return bytes(value)
-
-    @classmethod
-    def _as_string(cls, value):
-        if value is None:
-            return None
-        if isinstance(value, bytes):
-            return value.decode('utf-8')
-        if hasattr(value, 'asOctets'):
-            try:
-                return value.asOctets().decode('utf-8')
-            except UnicodeDecodeError:
-                return str(value)
-        return str(value)
-
-    @classmethod
-    def _as_sid_string(cls, value):
-        if value is None:
-            return None
-        if isinstance(value, str) and value.startswith('S-'):
-            return value
-        sid_bytes = cls._as_bytes(value)
-        if sid_bytes is None:
-            return None
-        return ldaptypes.LDAP_SID(data=sid_bytes).formatCanonical()
-
-    def _search_entries(self, search_filter, search_base=None, search_scope=None, attributes=None, search_controls=None):
-        response = self.ldap_session.search(
-            searchBase=search_base if search_base is not None else self.base_dn,
-            searchFilter=search_filter,
-            scope=search_scope,
-            attributes=attributes,
-            searchControls=search_controls,
-        )
-        return [item for item in response if isinstance(item, ldapasn1.SearchResultEntry)]
-
-    @staticmethod
-    def _log_ldap_error(prefix, error):
-        if error.getErrorCode() == 50:
-            logging.error('%s, the server reports insufficient rights: %s', prefix, error.getErrorString())
-        elif error.getErrorCode() == 19:
-            logging.error('%s, the server reports a constrained violation: %s', prefix, error.getErrorString())
-        else:
-            logging.error('%s: %s', prefix, error.getErrorString())
 
     def read(self):
         current_owner_SID = self.target_principal_security_descriptor['OwnerSid'].formatCanonical()
         logging.info("Current owner information below")
         logging.info("- SID: %s" % current_owner_SID)
         logging.info("- sAMAccountName: %s" % self.resolveSID(current_owner_SID))
-        current_owner_entries = self._search_entries('(objectSid=%s)' % current_owner_SID, attributes=['distinguishedName'])
-        current_owner_distinguished_name = self._as_string(self._get_entry_value(current_owner_entries[0], 'distinguishedName'))
+        current_owner_entries = search_entries(self.ldap_session, '(objectSid=%s)' % current_owner_SID, self.base_dn, attributes=['distinguishedName'])
+        current_owner_distinguished_name = as_string(get_entry_value(current_owner_entries[0], 'distinguishedName'))
         logging.info("- distinguishedName: %s" % current_owner_distinguished_name)
 
     def write(self):
@@ -241,27 +166,27 @@ class OwnerEdit(object):
 
         try:
             self.ldap_session.modify(
-                self._entry_dn(self.target_principal),
+                get_entry_dn(self.target_principal),
                 {'nTSecurityDescriptor': [(ldap.MODIFY_REPLACE, [
                     self.target_principal_security_descriptor.getData()
                 ])]},
                 controls=self.owner_sd_controls)
             logging.info('OwnerSid modified successfully!')
         except ldap.LDAPSessionError as error:
-            self._log_ldap_error('Could not modify object', error)
+            log_ldap_error('Could not modify object', error)
 
     # Attempts to retrieve the Security Descriptor of the specified target
     def search_target_principal_security_descriptor(self):
         _lookedup_principal = ""
         if self.target_sAMAccountName is not None:
             _lookedup_principal = self.target_sAMAccountName
-            entries = self._search_entries('(sAMAccountName=%s)' % self.escape_filter_chars(_lookedup_principal), attributes=['nTSecurityDescriptor'], search_controls=self.owner_sd_controls)
+            entries = search_entries(self.ldap_session, '(sAMAccountName=%s)' % escape_filter_chars(_lookedup_principal), self.base_dn, attributes=['nTSecurityDescriptor'], search_controls=self.owner_sd_controls)
         elif self.target_SID is not None:
             _lookedup_principal = self.target_SID
-            entries = self._search_entries('(objectSid=%s)' % _lookedup_principal, attributes=['nTSecurityDescriptor'], search_controls=self.owner_sd_controls)
+            entries = search_entries(self.ldap_session, '(objectSid=%s)' % _lookedup_principal, self.base_dn, attributes=['nTSecurityDescriptor'], search_controls=self.owner_sd_controls)
         elif self.target_DN is not None:
             _lookedup_principal = self.target_DN
-            entries = self._search_entries('(distinguishedName=%s)' % self.escape_filter_chars(_lookedup_principal), attributes=['nTSecurityDescriptor'], search_controls=self.owner_sd_controls)
+            entries = search_entries(self.ldap_session, '(distinguishedName=%s)' % escape_filter_chars(_lookedup_principal), self.base_dn, attributes=['nTSecurityDescriptor'], search_controls=self.owner_sd_controls)
         try:
             self.target_principal = entries[0]
             logging.debug('Target principal found in LDAP (%s)' % _lookedup_principal)
@@ -276,9 +201,9 @@ class OwnerEdit(object):
             return WELL_KNOWN_SIDS[sid]
         # Tries to resolve the SID from the LDAP domain dump
         else:
-            entries = self._search_entries('(objectSid=%s)' % sid, attributes=['samaccountname'])
+            entries = search_entries(self.ldap_session, '(objectSid=%s)' % sid, self.base_dn, attributes=['samaccountname'])
             try:
-                samname = self._as_string(self._get_entry_value(entries[0], 'samaccountname'))
+                samname = as_string(get_entry_value(entries[0], 'samaccountname'))
                 return samname
             except IndexError:
                 logging.debug('SID not found in LDAP: %s' % sid)

--- a/examples/owneredit.py
+++ b/examples/owneredit.py
@@ -20,17 +20,11 @@ import logging
 import sys
 import traceback
 
-import ldap3
-import ldapdomaindump
-from ldap3.protocol.formatters.formatters import format_sid
-
 from impacket import version
 from impacket.examples import logger, utils
-from impacket.ldap import ldaptypes
-from ldap3.utils.conv import escape_filter_chars
-from ldap3.protocol.microsoft import security_descriptor_control
+from impacket.ldap import ldap, ldapasn1, ldaptypes
 
-from impacket.examples.utils import init_ldap_session, parse_identity
+from impacket.examples.utils import ldap_login, parse_identity
 
 
 # Universal SIDs
@@ -112,10 +106,10 @@ WELL_KNOWN_SIDS = {
 }
 
 class OwnerEdit(object):
-    def __init__(self, ldap_server, ldap_session, args):
+    def __init__(self, ldap_session, base_dn, args):
         super(OwnerEdit, self).__init__()
-        self.ldap_server = ldap_server
         self.ldap_session = ldap_session
+        self.base_dn = base_dn
 
         self.target_sAMAccountName = args.target_sAMAccountName
         self.target_SID = args.target_SID
@@ -125,16 +119,13 @@ class OwnerEdit(object):
         self.new_owner_SID = args.new_owner_SID
         self.new_owner_DN = args.new_owner_DN
 
-        logging.debug('Initializing domainDumper()')
-        cnf = ldapdomaindump.domainDumpConfig()
-        cnf.basepath = None
-        self.domain_dumper = ldapdomaindump.domainDumper(self.ldap_server, self.ldap_session, cnf)
+        self.owner_sd_controls = [ldapasn1.SDFlagsControl(flags=0x01)]
 
         if self.target_sAMAccountName or self.target_SID or self.target_DN:
             # Searching for target account with its security descriptor
             self.search_target_principal_security_descriptor()
             # Extract security descriptor data
-            self.target_principal_raw_security_descriptor = self.target_principal['nTSecurityDescriptor'].raw_values[0]
+            self.target_principal_raw_security_descriptor = self._as_bytes(self._get_entry_value(self.target_principal, 'nTSecurityDescriptor'))
             self.target_principal_security_descriptor = ldaptypes.SR_SECURITY_DESCRIPTOR(data=self.target_principal_raw_security_descriptor)
 
         # Searching for the owner SID if any owner argument was given and new_owner_SID wasn't
@@ -142,25 +133,103 @@ class OwnerEdit(object):
             _lookedup_owner = ""
             if self.new_owner_sAMAccountName is not None:
                 _lookedup_owner = self.new_owner_sAMAccountName
-                self.ldap_session.search(self.domain_dumper.root, '(sAMAccountName=%s)' % escape_filter_chars(_lookedup_owner), attributes=['objectSid'])
+                entries = self._search_entries('(sAMAccountName=%s)' % self.escape_filter_chars(_lookedup_owner), attributes=['objectSid'])
             elif self.new_owner_DN is not None:
                 _lookedup_owner = self.new_owner_DN
-                self.ldap_session.search(_lookedup_owner, '(distinguishedName=%s)' % _lookedup_owner, attributes=['objectSid'])
+                entries = self._search_entries('(distinguishedName=%s)' % self.escape_filter_chars(_lookedup_owner), attributes=['objectSid'])
             try:
-                self.new_owner_SID = format_sid(self.ldap_session.entries[0]['objectSid'].raw_values[0])
+                self.new_owner_SID = self._as_sid_string(self._get_entry_value(entries[0], 'objectSid'))
                 logging.debug("Found new owner SID: %s" % self.new_owner_SID)
             except IndexError:
                 logging.error('New owner SID not found in LDAP (%s)' % _lookedup_owner)
                 exit(1)
 
+    @staticmethod
+    def escape_filter_chars(value):
+        escaped = value.replace('\\', '\\5c')
+        escaped = escaped.replace('*', '\\2a')
+        escaped = escaped.replace('(', '\\28')
+        escaped = escaped.replace(')', '\\29')
+        escaped = escaped.replace('\x00', '\\00')
+        return escaped
+
+    @staticmethod
+    def _entry_dn(entry):
+        return str(entry['objectName'])
+
+    @staticmethod
+    def _get_entry_values(entry, attribute_name):
+        for attribute in entry['attributes']:
+            if str(attribute['type']).lower() == attribute_name.lower():
+                return list(attribute['vals'])
+        return []
+
+    @classmethod
+    def _get_entry_value(cls, entry, attribute_name):
+        values = cls._get_entry_values(entry, attribute_name)
+        return values[0] if values else None
+
+    @staticmethod
+    def _as_bytes(value):
+        if value is None:
+            return None
+        if hasattr(value, 'asOctets'):
+            return value.asOctets()
+        if isinstance(value, bytes):
+            return value
+        return bytes(value)
+
+    @classmethod
+    def _as_string(cls, value):
+        if value is None:
+            return None
+        if isinstance(value, bytes):
+            return value.decode('utf-8')
+        if hasattr(value, 'asOctets'):
+            try:
+                return value.asOctets().decode('utf-8')
+            except UnicodeDecodeError:
+                return str(value)
+        return str(value)
+
+    @classmethod
+    def _as_sid_string(cls, value):
+        if value is None:
+            return None
+        if isinstance(value, str) and value.startswith('S-'):
+            return value
+        sid_bytes = cls._as_bytes(value)
+        if sid_bytes is None:
+            return None
+        return ldaptypes.LDAP_SID(data=sid_bytes).formatCanonical()
+
+    def _search_entries(self, search_filter, search_base=None, search_scope=None, attributes=None, search_controls=None):
+        response = self.ldap_session.search(
+            searchBase=search_base if search_base is not None else self.base_dn,
+            searchFilter=search_filter,
+            scope=search_scope,
+            attributes=attributes,
+            searchControls=search_controls,
+        )
+        return [item for item in response if isinstance(item, ldapasn1.SearchResultEntry)]
+
+    @staticmethod
+    def _log_ldap_error(prefix, error):
+        if error.getErrorCode() == 50:
+            logging.error('%s, the server reports insufficient rights: %s', prefix, error.getErrorString())
+        elif error.getErrorCode() == 19:
+            logging.error('%s, the server reports a constrained violation: %s', prefix, error.getErrorString())
+        else:
+            logging.error('%s: %s', prefix, error.getErrorString())
+
     def read(self):
-        current_owner_SID = format_sid(self.target_principal_security_descriptor['OwnerSid']).formatCanonical()
+        current_owner_SID = self.target_principal_security_descriptor['OwnerSid'].formatCanonical()
         logging.info("Current owner information below")
         logging.info("- SID: %s" % current_owner_SID)
         logging.info("- sAMAccountName: %s" % self.resolveSID(current_owner_SID))
-        self.ldap_session.search(self.domain_dumper.root, '(objectSid=%s)' % current_owner_SID, attributes=['distinguishedName'])
-        current_owner_distinguished_name = self.ldap_session.entries[0]
-        logging.info("- distinguishedName: %s" % current_owner_distinguished_name['distinguishedName'])
+        current_owner_entries = self._search_entries('(objectSid=%s)' % current_owner_SID, attributes=['distinguishedName'])
+        current_owner_distinguished_name = self._as_string(self._get_entry_value(current_owner_entries[0], 'distinguishedName'))
+        logging.info("- distinguishedName: %s" % current_owner_distinguished_name)
 
     def write(self):
         logging.debug('Attempt to modify the OwnerSid')
@@ -170,40 +239,31 @@ class OwnerEdit(object):
         # _new_owner_SID['SubLen'] = len(_new_owner_SID['SubAuthority'])
         self.target_principal_security_descriptor['OwnerSid'] = _new_owner_SID
 
-        self.ldap_session.modify(
-            self.target_principal.entry_dn,
-            {'nTSecurityDescriptor': (ldap3.MODIFY_REPLACE, [
-                self.target_principal_security_descriptor.getData()
-            ])},
-            controls=security_descriptor_control(sdflags=0x01))
-        if self.ldap_session.result['result'] == 0:
+        try:
+            self.ldap_session.modify(
+                self._entry_dn(self.target_principal),
+                {'nTSecurityDescriptor': [(ldap.MODIFY_REPLACE, [
+                    self.target_principal_security_descriptor.getData()
+                ])]},
+                controls=self.owner_sd_controls)
             logging.info('OwnerSid modified successfully!')
-        else:
-            if self.ldap_session.result['result'] == 50:
-                logging.error('Could not modify object, the server reports insufficient rights: %s',
-                              self.ldap_session.result['message'])
-            elif self.ldap_session.result['result'] == 19:
-                logging.error('Could not modify object, the server reports a constrained violation: %s',
-                              self.ldap_session.result['message'])
-            else:
-                logging.error('The server returned an error: %s', self.ldap_session.result['message'])
+        except ldap.LDAPSessionError as error:
+            self._log_ldap_error('Could not modify object', error)
 
     # Attempts to retrieve the Security Descriptor of the specified target
     def search_target_principal_security_descriptor(self):
         _lookedup_principal = ""
-        # Set SD flags to only query for OwnerSid
-        controls = security_descriptor_control(sdflags=0x01)
         if self.target_sAMAccountName is not None:
             _lookedup_principal = self.target_sAMAccountName
-            self.ldap_session.search(self.domain_dumper.root, '(sAMAccountName=%s)' % escape_filter_chars(_lookedup_principal), attributes=['nTSecurityDescriptor'], controls=controls)
+            entries = self._search_entries('(sAMAccountName=%s)' % self.escape_filter_chars(_lookedup_principal), attributes=['nTSecurityDescriptor'], search_controls=self.owner_sd_controls)
         elif self.target_SID is not None:
             _lookedup_principal = self.target_SID
-            self.ldap_session.search(self.domain_dumper.root, '(objectSid=%s)' % _lookedup_principal, attributes=['nTSecurityDescriptor'], controls=controls)
+            entries = self._search_entries('(objectSid=%s)' % _lookedup_principal, attributes=['nTSecurityDescriptor'], search_controls=self.owner_sd_controls)
         elif self.target_DN is not None:
             _lookedup_principal = self.target_DN
-            self.ldap_session.search(_lookedup_principal, '(distinguishedName=%s)' % _lookedup_principal, attributes=['nTSecurityDescriptor'], controls=controls)
+            entries = self._search_entries('(distinguishedName=%s)' % self.escape_filter_chars(_lookedup_principal), attributes=['nTSecurityDescriptor'], search_controls=self.owner_sd_controls)
         try:
-            self.target_principal = self.ldap_session.entries[0]
+            self.target_principal = entries[0]
             logging.debug('Target principal found in LDAP (%s)' % _lookedup_principal)
         except IndexError:
             logging.error('Target principal not found in LDAP (%s)' % _lookedup_principal)
@@ -216,10 +276,9 @@ class OwnerEdit(object):
             return WELL_KNOWN_SIDS[sid]
         # Tries to resolve the SID from the LDAP domain dump
         else:
-            self.ldap_session.search(self.domain_dumper.root, '(objectSid=%s)' % sid, attributes=['samaccountname'])
+            entries = self._search_entries('(objectSid=%s)' % sid, attributes=['samaccountname'])
             try:
-                dn = self.ldap_session.entries[0].entry_dn
-                samname = self.ldap_session.entries[0]['samaccountname']
+                samname = self._as_string(self._get_entry_value(entries[0], 'samaccountname'))
                 return samname
             except IndexError:
                 logging.debug('SID not found in LDAP: %s' % sid)
@@ -278,8 +337,10 @@ def main():
     domain, username, password, lmhash, nthash, args.k = parse_identity(args.identity, args.hashes, args.no_pass, args.aesKey, args.k)
 
     try:
-        ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.dc_host, args.aesKey, args.use_ldaps)
-        owneredit = OwnerEdit(ldap_server, ldap_session, args)
+        base_dn = ','.join('dc=%s' % part for part in domain.split('.'))
+        target = args.dc_host if args.dc_host is not None else domain
+        ldap_session = ldap_login(target, base_dn, args.dc_ip, args.dc_host, args.k, username, password, domain, lmhash, nthash, args.aesKey, ldaps_flag=args.use_ldaps)
+        owneredit = OwnerEdit(ldap_session, base_dn, args)
         if args.action == 'read':
             owneredit.read()
         elif args.action == 'write':

--- a/examples/owneredit.py
+++ b/examples/owneredit.py
@@ -26,7 +26,7 @@ from impacket.ldap import ldap, ldapasn1, ldaptypes
 from impacket.ldap.ldap import escape_filter_chars, get_entry_dn, get_entry_value
 
 from impacket.examples.utils import (ldap_login, parse_identity,
-                                      as_bytes, as_string, as_sid_string,
+                                      ldap_value_to_bytes, as_string, as_sid_string,
                                       search_entries, log_ldap_error)
 
 
@@ -128,7 +128,7 @@ class OwnerEdit(object):
             # Searching for target account with its security descriptor
             self.search_target_principal_security_descriptor()
             # Extract security descriptor data
-            self.target_principal_raw_security_descriptor = as_bytes(get_entry_value(self.target_principal, 'nTSecurityDescriptor'))
+            self.target_principal_raw_security_descriptor = ldap_value_to_bytes(get_entry_value(self.target_principal, 'nTSecurityDescriptor'))
             self.target_principal_security_descriptor = ldaptypes.SR_SECURITY_DESCRIPTOR(data=self.target_principal_raw_security_descriptor)
 
         # Searching for the owner SID if any owner argument was given and new_owner_SID wasn't

--- a/examples/rbcd.py
+++ b/examples/rbcd.py
@@ -26,9 +26,12 @@ import traceback
 
 from impacket import version
 from impacket.examples import logger, utils
-from impacket.ldap import ldap, ldapasn1, ldaptypes
+from impacket.ldap import ldap, ldaptypes
+from impacket.ldap.ldap import escape_filter_chars, get_entry_dn, get_entry_value
 
-from impacket.examples.utils import ldap_login, parse_identity
+from impacket.examples.utils import (ldap_login, parse_identity,
+                                      as_bytes, as_string, as_sid_string,
+                                      search_entries, log_ldap_error)
 
 def create_empty_sd():
     sd = ldaptypes.SR_SECURITY_DESCRIPTOR()
@@ -77,85 +80,6 @@ class RBCD(object):
         self.SID_delegate_from = None
         self.DN_delegate_to = None
 
-    @staticmethod
-    def escape_filter_chars(value):
-        escaped = value.replace('\\', '\\5c')
-        escaped = escaped.replace('*', '\\2a')
-        escaped = escaped.replace('(', '\\28')
-        escaped = escaped.replace(')', '\\29')
-        escaped = escaped.replace('\x00', '\\00')
-        return escaped
-
-    @staticmethod
-    def _entry_dn(entry):
-        return str(entry['objectName'])
-
-    @staticmethod
-    def _get_entry_values(entry, attribute_name):
-        for attribute in entry['attributes']:
-            if str(attribute['type']).lower() == attribute_name.lower():
-                return list(attribute['vals'])
-        return []
-
-    @classmethod
-    def _get_entry_value(cls, entry, attribute_name):
-        values = cls._get_entry_values(entry, attribute_name)
-        return values[0] if values else None
-
-    @staticmethod
-    def _as_bytes(value):
-        if value is None:
-            return None
-        if hasattr(value, 'asOctets'):
-            return value.asOctets()
-        if isinstance(value, bytes):
-            return value
-        return bytes(value)
-
-    @classmethod
-    def _as_string(cls, value):
-        if value is None:
-            return None
-        if isinstance(value, bytes):
-            return value.decode('utf-8')
-        if hasattr(value, 'asOctets'):
-            try:
-                return value.asOctets().decode('utf-8')
-            except UnicodeDecodeError:
-                return str(value)
-        return str(value)
-
-    @classmethod
-    def _as_sid_string(cls, value):
-        if value is None:
-            return None
-        if isinstance(value, str) and value.startswith('S-'):
-            return value
-        sid_bytes = cls._as_bytes(value)
-        if sid_bytes is None:
-            return None
-        return ldaptypes.LDAP_SID(data=sid_bytes).formatCanonical()
-
-    @classmethod
-    def _search_entries(cls, ldap_session, search_filter, search_base=None, search_scope=None, attributes=None, search_controls=None):
-        response = ldap_session.search(
-            searchBase=search_base,
-            searchFilter=search_filter,
-            scope=search_scope,
-            attributes=attributes,
-            searchControls=search_controls,
-        )
-        return [item for item in response if isinstance(item, ldapasn1.SearchResultEntry)]
-
-    @staticmethod
-    def _log_ldap_error(prefix, error):
-        if error.getErrorCode() == 50:
-            logging.error('%s, the server reports insufficient rights: %s', prefix, error.getErrorString())
-        elif error.getErrorCode() == 19:
-            logging.error('%s, the server reports a constrained violation: %s', prefix, error.getErrorString())
-        else:
-            logging.error('%s: %s', prefix, error.getErrorString())
-
     def read(self):
         # Get target computer DN
         result = self.get_user_info(self.delegate_to)
@@ -194,13 +118,13 @@ class RBCD(object):
             sd['Dacl'].aces.append(create_allow_ace(self.SID_delegate_from))
             try:
                 self.ldap_session.modify(
-                    self._entry_dn(targetuser),
+                    get_entry_dn(targetuser),
                     {'msDS-AllowedToActOnBehalfOfOtherIdentity': [(ldap.MODIFY_REPLACE, [sd.getData()])]},
                 )
                 logging.info('Delegation rights modified successfully!')
                 logging.info('%s can now impersonate users on %s via S4U2Proxy', self.delegate_from, self.delegate_to)
             except ldap.LDAPSessionError as error:
-                self._log_ldap_error('Could not modify object', error)
+                log_ldap_error('Could not modify object', error)
         else:
             logging.info('%s can already impersonate users on %s via S4U2Proxy', self.delegate_from, self.delegate_to)
             logging.info('Not modifying the delegation rights.')
@@ -232,12 +156,12 @@ class RBCD(object):
         sd['Dacl'].aces = [ace for ace in sd['Dacl'].aces if self.SID_delegate_from != ace['Ace']['Sid'].formatCanonical()]
         try:
             self.ldap_session.modify(
-                self._entry_dn(targetuser),
+                get_entry_dn(targetuser),
                 {'msDS-AllowedToActOnBehalfOfOtherIdentity': [(ldap.MODIFY_REPLACE, [sd.getData()])]},
             )
             logging.info('Delegation rights modified successfully!')
         except ldap.LDAPSessionError as error:
-            self._log_ldap_error('Could not modify object', error)
+            log_ldap_error('Could not modify object', error)
         # Get list of allowed to act
         self.get_allowed_to_act()
         return
@@ -255,22 +179,22 @@ class RBCD(object):
 
         try:
             self.ldap_session.modify(
-                self._entry_dn(targetuser),
+                get_entry_dn(targetuser),
                 {'msDS-AllowedToActOnBehalfOfOtherIdentity': [(ldap.MODIFY_REPLACE, [])]},
             )
             logging.info('Delegation rights flushed successfully!')
         except ldap.LDAPSessionError as error:
-            self._log_ldap_error('Could not modify object', error)
+            log_ldap_error('Could not modify object', error)
         # Get list of allowed to act
         self.get_allowed_to_act()
         return
 
     def get_allowed_to_act(self):
         # Get target's msDS-AllowedToActOnBehalfOfOtherIdentity attribute
-        entries = self._search_entries(
+        entries = search_entries(
             self.ldap_session,
             '(objectClass=*)',
-            search_base=self.DN_delegate_to,
+            self.DN_delegate_to,
             search_scope=self.LDAP_SCOPE_BASE,
             attributes=['SAMAccountName', 'objectSid', 'msDS-AllowedToActOnBehalfOfOtherIdentity'],
         )
@@ -280,7 +204,7 @@ class RBCD(object):
             return
 
         try:
-            raw_sd = self._as_bytes(self._get_entry_value(targetuser, 'msDS-AllowedToActOnBehalfOfOtherIdentity'))
+            raw_sd = as_bytes(get_entry_value(targetuser, 'msDS-AllowedToActOnBehalfOfOtherIdentity'))
             sd = ldaptypes.SR_SECURITY_DESCRIPTOR(data=raw_sd)
             if len(sd['Dacl'].aces) > 0:
                 logging.info('Accounts allowed to act on behalf of other identity:')
@@ -299,30 +223,30 @@ class RBCD(object):
         return sd, targetuser
 
     def get_user_info(self, samname):
-        entries = self._search_entries(
+        entries = search_entries(
             self.ldap_session,
-            '(sAMAccountName=%s)' % self.escape_filter_chars(samname),
-            search_base=self.base_dn,
+            '(sAMAccountName=%s)' % escape_filter_chars(samname),
+            self.base_dn,
             attributes=['objectSid'],
         )
         try:
-            dn = self._entry_dn(entries[0])
-            sid = self._as_sid_string(self._get_entry_value(entries[0], 'objectSid'))
+            dn = get_entry_dn(entries[0])
+            sid = as_sid_string(get_entry_value(entries[0], 'objectSid'))
             return dn, sid
         except (IndexError, TypeError):
             logging.error('User not found in LDAP: %s' % samname)
             return False
 
     def get_sid_info(self, sid):
-        entries = self._search_entries(
+        entries = search_entries(
             self.ldap_session,
-            '(objectSid=%s)' % self.escape_filter_chars(sid),
-            search_base=self.base_dn,
+            '(objectSid=%s)' % escape_filter_chars(sid),
+            self.base_dn,
             attributes=['samaccountname'],
         )
         try:
-            dn = self._entry_dn(entries[0])
-            samname = self._as_string(self._get_entry_value(entries[0], 'samaccountname'))
+            dn = get_entry_dn(entries[0])
+            samname = as_string(get_entry_value(entries[0], 'samaccountname'))
             return dn, samname
         except (IndexError, TypeError):
             logging.error('SID not found in LDAP: %s' % sid)

--- a/examples/rbcd.py
+++ b/examples/rbcd.py
@@ -23,16 +23,12 @@ import argparse
 import logging
 import sys
 import traceback
-import ldap3
-import ldapdomaindump
-from ldap3.protocol.formatters.formatters import format_sid
 
 from impacket import version
 from impacket.examples import logger, utils
-from impacket.ldap import ldaptypes
-from ldap3.utils.conv import escape_filter_chars
+from impacket.ldap import ldap, ldapasn1, ldaptypes
 
-from impacket.examples.utils import init_ldap_session, parse_identity
+from impacket.examples.utils import ldap_login, parse_identity
 
 def create_empty_sd():
     sd = ldaptypes.SR_SECURITY_DESCRIPTOR()
@@ -70,18 +66,95 @@ def create_allow_ace(sid):
 class RBCD(object):
     """docstring for setrbcd"""
 
-    def __init__(self, ldap_server, ldap_session, delegate_to):
+    LDAP_SCOPE_BASE = ldap.Scope('baseObject')
+
+    def __init__(self, ldap_session, base_dn, delegate_to):
         super(RBCD, self).__init__()
-        self.ldap_server = ldap_server
         self.ldap_session = ldap_session
+        self.base_dn = base_dn
         self.delegate_from = None
         self.delegate_to = delegate_to
         self.SID_delegate_from = None
         self.DN_delegate_to = None
-        logging.debug('Initializing domainDumper()')
-        cnf = ldapdomaindump.domainDumpConfig()
-        cnf.basepath = None
-        self.domain_dumper = ldapdomaindump.domainDumper(self.ldap_server, self.ldap_session, cnf)
+
+    @staticmethod
+    def escape_filter_chars(value):
+        escaped = value.replace('\\', '\\5c')
+        escaped = escaped.replace('*', '\\2a')
+        escaped = escaped.replace('(', '\\28')
+        escaped = escaped.replace(')', '\\29')
+        escaped = escaped.replace('\x00', '\\00')
+        return escaped
+
+    @staticmethod
+    def _entry_dn(entry):
+        return str(entry['objectName'])
+
+    @staticmethod
+    def _get_entry_values(entry, attribute_name):
+        for attribute in entry['attributes']:
+            if str(attribute['type']).lower() == attribute_name.lower():
+                return list(attribute['vals'])
+        return []
+
+    @classmethod
+    def _get_entry_value(cls, entry, attribute_name):
+        values = cls._get_entry_values(entry, attribute_name)
+        return values[0] if values else None
+
+    @staticmethod
+    def _as_bytes(value):
+        if value is None:
+            return None
+        if hasattr(value, 'asOctets'):
+            return value.asOctets()
+        if isinstance(value, bytes):
+            return value
+        return bytes(value)
+
+    @classmethod
+    def _as_string(cls, value):
+        if value is None:
+            return None
+        if isinstance(value, bytes):
+            return value.decode('utf-8')
+        if hasattr(value, 'asOctets'):
+            try:
+                return value.asOctets().decode('utf-8')
+            except UnicodeDecodeError:
+                return str(value)
+        return str(value)
+
+    @classmethod
+    def _as_sid_string(cls, value):
+        if value is None:
+            return None
+        if isinstance(value, str) and value.startswith('S-'):
+            return value
+        sid_bytes = cls._as_bytes(value)
+        if sid_bytes is None:
+            return None
+        return ldaptypes.LDAP_SID(data=sid_bytes).formatCanonical()
+
+    @classmethod
+    def _search_entries(cls, ldap_session, search_filter, search_base=None, search_scope=None, attributes=None, search_controls=None):
+        response = ldap_session.search(
+            searchBase=search_base,
+            searchFilter=search_filter,
+            scope=search_scope,
+            attributes=attributes,
+            searchControls=search_controls,
+        )
+        return [item for item in response if isinstance(item, ldapasn1.SearchResultEntry)]
+
+    @staticmethod
+    def _log_ldap_error(prefix, error):
+        if error.getErrorCode() == 50:
+            logging.error('%s, the server reports insufficient rights: %s', prefix, error.getErrorString())
+        elif error.getErrorCode() == 19:
+            logging.error('%s, the server reports a constrained violation: %s', prefix, error.getErrorString())
+        else:
+            logging.error('%s: %s', prefix, error.getErrorString())
 
     def read(self):
         # Get target computer DN
@@ -119,21 +192,15 @@ class RBCD(object):
         # writing only if SID not already in list
         if self.SID_delegate_from not in [ ace['Ace']['Sid'].formatCanonical() for ace in sd['Dacl'].aces ]:
             sd['Dacl'].aces.append(create_allow_ace(self.SID_delegate_from))
-            self.ldap_session.modify(targetuser['dn'],
-                                     {'msDS-AllowedToActOnBehalfOfOtherIdentity': [ldap3.MODIFY_REPLACE,
-                                                                                   [sd.getData()]]})
-            if self.ldap_session.result['result'] == 0:
+            try:
+                self.ldap_session.modify(
+                    self._entry_dn(targetuser),
+                    {'msDS-AllowedToActOnBehalfOfOtherIdentity': [(ldap.MODIFY_REPLACE, [sd.getData()])]},
+                )
                 logging.info('Delegation rights modified successfully!')
                 logging.info('%s can now impersonate users on %s via S4U2Proxy', self.delegate_from, self.delegate_to)
-            else:
-                if self.ldap_session.result['result'] == 50:
-                    logging.error('Could not modify object, the server reports insufficient rights: %s',
-                                  self.ldap_session.result['message'])
-                elif self.ldap_session.result['result'] == 19:
-                    logging.error('Could not modify object, the server reports a constrained violation: %s',
-                                  self.ldap_session.result['message'])
-                else:
-                    logging.error('The server returned an error: %s', self.ldap_session.result['message'])
+            except ldap.LDAPSessionError as error:
+                self._log_ldap_error('Could not modify object', error)
         else:
             logging.info('%s can already impersonate users on %s via S4U2Proxy', self.delegate_from, self.delegate_to)
             logging.info('Not modifying the delegation rights.')
@@ -163,20 +230,14 @@ class RBCD(object):
 
         # Remove the entries where SID match the given -delegate-from
         sd['Dacl'].aces = [ace for ace in sd['Dacl'].aces if self.SID_delegate_from != ace['Ace']['Sid'].formatCanonical()]
-        self.ldap_session.modify(targetuser['dn'],
-                                 {'msDS-AllowedToActOnBehalfOfOtherIdentity': [ldap3.MODIFY_REPLACE, [sd.getData()]]})
-
-        if self.ldap_session.result['result'] == 0:
+        try:
+            self.ldap_session.modify(
+                self._entry_dn(targetuser),
+                {'msDS-AllowedToActOnBehalfOfOtherIdentity': [(ldap.MODIFY_REPLACE, [sd.getData()])]},
+            )
             logging.info('Delegation rights modified successfully!')
-        else:
-            if self.ldap_session.result['result'] == 50:
-                logging.error('Could not modify object, the server reports insufficient rights: %s',
-                              self.ldap_session.result['message'])
-            elif self.ldap_session.result['result'] == 19:
-                logging.error('Could not modify object, the server reports a constrained violation: %s',
-                              self.ldap_session.result['message'])
-            else:
-                logging.error('The server returned an error: %s', self.ldap_session.result['message'])
+        except ldap.LDAPSessionError as error:
+            self._log_ldap_error('Could not modify object', error)
         # Get list of allowed to act
         self.get_allowed_to_act()
         return
@@ -192,38 +253,35 @@ class RBCD(object):
         # Get list of allowed to act
         sd, targetuser = self.get_allowed_to_act()
 
-        self.ldap_session.modify(targetuser['dn'], {'msDS-AllowedToActOnBehalfOfOtherIdentity': [ldap3.MODIFY_REPLACE, []]})
-        if self.ldap_session.result['result'] == 0:
+        try:
+            self.ldap_session.modify(
+                self._entry_dn(targetuser),
+                {'msDS-AllowedToActOnBehalfOfOtherIdentity': [(ldap.MODIFY_REPLACE, [])]},
+            )
             logging.info('Delegation rights flushed successfully!')
-        else:
-            if self.ldap_session.result['result'] == 50:
-                logging.error('Could not modify object, the server reports insufficient rights: %s',
-                              self.ldap_session.result['message'])
-            elif self.ldap_session.result['result'] == 19:
-                logging.error('Could not modify object, the server reports a constrained violation: %s',
-                              self.ldap_session.result['message'])
-            else:
-                logging.error('The server returned an error: %s', self.ldap_session.result['message'])
+        except ldap.LDAPSessionError as error:
+            self._log_ldap_error('Could not modify object', error)
         # Get list of allowed to act
         self.get_allowed_to_act()
         return
 
     def get_allowed_to_act(self):
         # Get target's msDS-AllowedToActOnBehalfOfOtherIdentity attribute
-        self.ldap_session.search(self.DN_delegate_to, '(objectClass=*)', search_scope=ldap3.BASE,
-                                 attributes=['SAMAccountName', 'objectSid', 'msDS-AllowedToActOnBehalfOfOtherIdentity'])
-        targetuser = None
-        for entry in self.ldap_session.response:
-            if entry['type'] != 'searchResEntry':
-                continue
-            targetuser = entry
+        entries = self._search_entries(
+            self.ldap_session,
+            '(objectClass=*)',
+            search_base=self.DN_delegate_to,
+            search_scope=self.LDAP_SCOPE_BASE,
+            attributes=['SAMAccountName', 'objectSid', 'msDS-AllowedToActOnBehalfOfOtherIdentity'],
+        )
+        targetuser = entries[0] if entries else None
         if not targetuser:
             logging.error('Could not query target user properties')
             return
 
         try:
-            sd = ldaptypes.SR_SECURITY_DESCRIPTOR(
-                data=targetuser['raw_attributes']['msDS-AllowedToActOnBehalfOfOtherIdentity'][0])
+            raw_sd = self._as_bytes(self._get_entry_value(targetuser, 'msDS-AllowedToActOnBehalfOfOtherIdentity'))
+            sd = ldaptypes.SR_SECURITY_DESCRIPTOR(data=raw_sd)
             if len(sd['Dacl'].aces) > 0:
                 logging.info('Accounts allowed to act on behalf of other identity:')
                 for ace in sd['Dacl'].aces:
@@ -241,22 +299,32 @@ class RBCD(object):
         return sd, targetuser
 
     def get_user_info(self, samname):
-        self.ldap_session.search(self.domain_dumper.root, '(sAMAccountName=%s)' % escape_filter_chars(samname), attributes=['objectSid'])
+        entries = self._search_entries(
+            self.ldap_session,
+            '(sAMAccountName=%s)' % self.escape_filter_chars(samname),
+            search_base=self.base_dn,
+            attributes=['objectSid'],
+        )
         try:
-            dn = self.ldap_session.entries[0].entry_dn
-            sid = format_sid(self.ldap_session.entries[0]['objectSid'].raw_values[0])
+            dn = self._entry_dn(entries[0])
+            sid = self._as_sid_string(self._get_entry_value(entries[0], 'objectSid'))
             return dn, sid
-        except IndexError:
+        except (IndexError, TypeError):
             logging.error('User not found in LDAP: %s' % samname)
             return False
 
     def get_sid_info(self, sid):
-        self.ldap_session.search(self.domain_dumper.root, '(objectSid=%s)' % escape_filter_chars(sid), attributes=['samaccountname'])
+        entries = self._search_entries(
+            self.ldap_session,
+            '(objectSid=%s)' % self.escape_filter_chars(sid),
+            search_base=self.base_dn,
+            attributes=['samaccountname'],
+        )
         try:
-            dn = self.ldap_session.entries[0].entry_dn
-            samname = self.ldap_session.entries[0]['samaccountname']
+            dn = self._entry_dn(entries[0])
+            samname = self._as_string(self._get_entry_value(entries[0], 'samaccountname'))
             return dn, samname
-        except IndexError:
+        except (IndexError, TypeError):
             logging.error('SID not found in LDAP: %s' % sid)
             return False
 
@@ -314,8 +382,10 @@ def main():
     domain, username, password, lmhash, nthash, args.k = parse_identity(args.identity, args.hashes, args.no_pass, args.aesKey, args.k)
 
     try:
-        ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.dc_host, args.aesKey, args.use_ldaps)
-        rbcd = RBCD(ldap_server, ldap_session, args.delegate_to)
+        base_dn = ','.join('dc=%s' % part for part in domain.split('.'))
+        target = args.dc_host if args.dc_host is not None else domain
+        ldap_session = ldap_login(target, base_dn, args.dc_ip, args.dc_host, args.k, username, password, domain, lmhash, nthash, args.aesKey, ldaps_flag=args.use_ldaps)
+        rbcd = RBCD(ldap_session, base_dn, args.delegate_to)
         if args.action == 'read':
             rbcd.read()
         elif args.action == 'write':

--- a/examples/rbcd.py
+++ b/examples/rbcd.py
@@ -30,7 +30,7 @@ from impacket.ldap import ldap, ldaptypes
 from impacket.ldap.ldap import escape_filter_chars, get_entry_dn, get_entry_value
 
 from impacket.examples.utils import (ldap_login, parse_identity,
-                                      as_bytes, as_string, as_sid_string,
+                                      ldap_value_to_bytes, as_string, as_sid_string,
                                       search_entries, log_ldap_error)
 
 def create_empty_sd():
@@ -204,8 +204,11 @@ class RBCD(object):
             return
 
         try:
-            raw_sd = as_bytes(get_entry_value(targetuser, 'msDS-AllowedToActOnBehalfOfOtherIdentity'))
-            sd = ldaptypes.SR_SECURITY_DESCRIPTOR(data=raw_sd)
+            raw_sd = ldap_value_to_bytes(get_entry_value(targetuser, 'msDS-AllowedToActOnBehalfOfOtherIdentity'))
+            if raw_sd is None:
+                sd = create_empty_sd()
+            else:
+                sd = ldaptypes.SR_SECURITY_DESCRIPTOR(data=raw_sd)
             if len(sd['Dacl'].aces) > 0:
                 logging.info('Accounts allowed to act on behalf of other identity:')
                 for ace in sd['Dacl'].aces:

--- a/impacket/examples/utils.py
+++ b/impacket/examples/utils.py
@@ -248,8 +248,72 @@ def init_ldap_session(domain, username, password, lmhash, nthash, k, dc_ip, dc_h
 
 # ----------
 
-from impacket.ldap import ldap
+from impacket.ldap import ldap, ldapasn1
+from impacket.ldap.ldaptypes import LDAP_SID
 import logging
+
+
+def as_bytes(value):
+    """Coerce an LDAP attribute value to bytes."""
+    if value is None:
+        return None
+    if hasattr(value, 'asOctets'):
+        return value.asOctets()
+    if isinstance(value, bytes):
+        return value
+    return bytes(value)
+
+
+def as_string(value):
+    """Coerce an LDAP attribute value to a UTF-8 string."""
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value.decode('utf-8')
+    if hasattr(value, 'asOctets'):
+        raw = value.asOctets()
+        try:
+            return raw.decode('utf-8')
+        except UnicodeDecodeError:
+            return raw.decode('latin-1')
+    return str(value)
+
+
+def as_sid_string(value):
+    """Coerce an LDAP attribute value to a canonical SID string (e.g. S-1-5-...)."""
+    if value is None:
+        return None
+    if isinstance(value, str) and value.startswith('S-'):
+        return value
+    sid_bytes = as_bytes(value)
+    if sid_bytes is None:
+        return None
+    return LDAP_SID(data=sid_bytes).formatCanonical()
+
+
+def search_entries(ldap_session, search_filter, search_base, search_scope=None,
+                   attributes=None, search_controls=None):
+    """Run an LDAP search and return only SearchResultEntry items."""
+    response = ldap_session.search(
+        searchBase=search_base,
+        searchFilter=search_filter,
+        scope=search_scope,
+        attributes=attributes,
+        searchControls=search_controls,
+    )
+    return [item for item in response if isinstance(item, ldapasn1.SearchResultEntry)]
+
+
+def log_ldap_error(prefix, error):
+    """Log an LDAPSessionError with a human-readable prefix."""
+    if error.getErrorCode() == 50:
+        logging.error('%s, the server reports insufficient rights: %s', prefix, error.getErrorString())
+    elif error.getErrorCode() == 19:
+        logging.error('%s, the server reports a constrained violation: %s', prefix, error.getErrorString())
+    else:
+        logging.error('%s: %s', prefix, error.getErrorString())
+
+
 def ldap_login(target, base_dn, kdc_ip, kdc_host, do_kerberos, username, password, domain, lmhash, nthash, aeskey, ldaps_flag=False, target_domain=None, fqdn=False):
     if kdc_host is not None and (target_domain is None or domain == target_domain):
         target = kdc_host

--- a/impacket/examples/utils.py
+++ b/impacket/examples/utils.py
@@ -253,7 +253,7 @@ from impacket.ldap.ldaptypes import LDAP_SID
 import logging
 
 
-def as_bytes(value):
+def ldap_value_to_bytes(value):
     """Coerce an LDAP attribute value to bytes."""
     if value is None:
         return None
@@ -285,7 +285,7 @@ def as_sid_string(value):
         return None
     if isinstance(value, str) and value.startswith('S-'):
         return value
-    sid_bytes = as_bytes(value)
+    sid_bytes = ldap_value_to_bytes(value)
     if sid_bytes is None:
         return None
     return LDAP_SID(data=sid_bytes).formatCanonical()

--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -52,6 +52,7 @@ __all__ = [
     'LDAPConnection', 'LDAPFilterSyntaxError', 'LDAPFilterInvalidException', 'LDAPSessionError', 'LDAPSearchError',
     'Control', 'SimplePagedResultsControl', 'ResultCode', 'Scope', 'DerefAliases', 'Operation',
     'CONTROL_PAGEDRESULTS', 'KNOWN_CONTROLS', 'NOTIFICATION_DISCONNECT', 'KNOWN_NOTIFICATIONS',
+    'escape_filter_chars', 'get_entry_dn', 'get_entry_values', 'get_entry_value',
 ]
 
 # https://tools.ietf.org/search/rfc4515#section-3
@@ -73,6 +74,35 @@ MODIFY_ADD = 0
 MODIFY_DELETE = 1
 MODIFY_REPLACE = 2
 MODIFY_INCREMENT = 3
+
+
+def escape_filter_chars(value):
+    """Escape special characters in an LDAP filter value per RFC 4515."""
+    escaped = value.replace('\\', '\\5c')
+    escaped = escaped.replace('*', '\\2a')
+    escaped = escaped.replace('(', '\\28')
+    escaped = escaped.replace(')', '\\29')
+    escaped = escaped.replace('\x00', '\\00')
+    return escaped
+
+
+def get_entry_dn(entry):
+    """Return the DN of a SearchResultEntry."""
+    return str(entry['objectName'])
+
+
+def get_entry_values(entry, attribute_name):
+    """Return the list of raw values for the named attribute in a SearchResultEntry."""
+    for attribute in entry['attributes']:
+        if str(attribute['type']).lower() == attribute_name.lower():
+            return list(attribute['vals'])
+    return []
+
+
+def get_entry_value(entry, attribute_name):
+    """Return the first value for the named attribute, or None."""
+    values = get_entry_values(entry, attribute_name)
+    return values[0] if values else None
 
 class LDAPConnection:
     def __init__(self, url, baseDN='', dstIp=None, signing=True):


### PR DESCRIPTION
This PR updates several LDAP-related examples to use Impacket's LDAP implementation instead of direct `ldap3` usage.

  Changes include:
  - Migrated `addcomputer.py`, `dacledit.py`, `owneredit.py`, `rbcd.py`, and `badsuccessor.py` to shared Impacket LDAP helpers.
  - Added reusable LDAP value/search helpers in `impacket/examples/utils.py`.
  - Added LDAP entry helper functions in `impacket/ldap/ldap.py`.
  - Centralized LDAP error handling and attribute coercion helpers.
  - Fixed LDAPS handling for `addcomputer.py`.
  - Reduced duplicated LDAP parsing/search code across examples.

