### PR TITLE
Fix infinite loop / duplicate rows on cyclic ESE leaf-page chain

### DIFF
--- a/impacket/ese.py
+++ b/impacket/ese.py
@@ -175,6 +175,8 @@ TABLE_CURSOR = {
     'FatherDataPageNumber': 0,
     'CurrentPageData' : b'',
     'CurrentTag' : 0,
+    'CurrentPageNumber' : 0,
+    'VisitedPages' : None,
 }
 
 class ESENT_JET_SIGNATURE(Structure):
@@ -756,6 +758,10 @@ class ESENT_DB:
             cursor['FatherDataPageNumber'] = catalogEntry['FatherDataPageNumber']
             cursor['CurrentPageData'] = page
             cursor['CurrentTag']  = page.firstDataTag - 1
+            cursor['CurrentPageNumber'] = pageNum
+            # Track the leaf pages we walk so we can bail out if the NextPageNumber
+            # chain ever loops back on itself (see getNextRow)
+            cursor['VisitedPages'] = {pageNum}
             return cursor
         else:
             return None
@@ -792,11 +798,26 @@ class ESENT_DB:
         if tag is None:
             # No more tags in this page, search for the next one on the right
             page = cursor['CurrentPageData']
-            if page.record['NextPageNumber'] == 0:
+            nextPageNumber = page.record['NextPageNumber']
+            if nextPageNumber == 0:
                 # No more pages, chau
                 return None
+            elif cursor['VisitedPages'] is not None and nextPageNumber in cursor['VisitedPages']:
+                # A healthy ESE leaf chain is acyclic and ends at NextPageNumber == 0.
+                # A back-edge to an already-visited page (e.g. a dirty-shutdown ntds.dit
+                # whose B-tree pointers were never committed) would loop forever and emit
+                # every row once per lap. Stop here: every reachable page has already been
+                # walked exactly once, so the table read is complete.
+                LOG.error('ESE leaf-page cycle detected: page %d links back to '
+                          'already-visited page %d. Stopping table walk to avoid an infinite '
+                          'loop and duplicate rows (database may be in a dirty-shutdown / '
+                          'inconsistent state).' % (cursor['CurrentPageNumber'], nextPageNumber))
+                return None
             else:
-                cursor['CurrentPageData'] = self.getPage(page.record['NextPageNumber'])
+                if cursor['VisitedPages'] is not None:
+                    cursor['VisitedPages'].add(nextPageNumber)
+                cursor['CurrentPageNumber'] = nextPageNumber
+                cursor['CurrentPageData'] = self.getPage(nextPageNumber)
                 cursor['CurrentTag'] = cursor['CurrentPageData'].firstDataTag - 1
                 return self.getNextRow(cursor, filter_tables = filter_tables)
         else:


### PR DESCRIPTION
## Summary

`ESENT_DB.getNextRow()` walks an ESE table's leaf pages by following each page's `NextPageNumber`. A healthy leaf chain is acyclic and terminates at `NextPageNumber == 0`.

However, a database in a **dirty-shutdown / inconsistent state** (e.g. an `ntds.dit` whose B-tree pointers were never committed) can contain a leaf chain whose `NextPageNumber` links **back to an already-visited page**. The current code follows that back-edge unconditionally, so it loops forever — re-emitting every row once per lap. In practice this hangs `secretsdump.py` LOCAL parsing and produces endless duplicate hashes.

## Fix

Track the set of leaf pages already visited for each cursor (`VisitedPages`, plus `CurrentPageNumber` for accurate logging). When `NextPageNumber` points to a page that has already been walked, stop the table read and log an error noting the database may be inconsistent.

Because a valid ESE leaf chain never revisits a page, this only triggers on corrupt input and is a no-op for healthy databases. At the point the cycle is detected, every reachable page has already been read exactly once, so the table walk is complete.

## Testing

- Verified against a dirty-shutdown `ntds.dit` that previously caused `secretsdump.py -ntds ... LOCAL` to loop and emit duplicate machine/user hashes — it now completes cleanly with the cycle-detection error logged.
- Healthy databases parse identically to before (no behavior change on the non-cyclic path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)