### PR TITLE
Disable kerberos usage in dcom, print brief explanation

### DIFF
--- a/examples/dcomexec.py
+++ b/examples/dcomexec.py
@@ -604,6 +604,13 @@ if __name__ == '__main__':
         if CODEC is None:
             CODEC = 'utf-8'
 
+    if options.k or options.aesKey is not None or options.keytab is not None:
+        logging.error("Kerberos authentication is not supported by dcomexec.py's current DCOM objects "
+                      "(ShellWindows, ShellBrowserWindow, MMC20). These objects are hosted in the user context "
+                      "and do not accept HOST/<target> Kerberos tickets. Use wmiexec.py -k for Kerberos command "
+                      "execution, or use dcomexec.py with NTLM password/hash authentication.")
+        sys.exit(1)
+
     if ' '.join(options.command) == ' ' and options.nooutput is True:
         logging.error("-nooutput switch and interactive shell not supported")
         sys.exit(1)


### PR DESCRIPTION
Relates to issue #1611: Kerberos is not usable with the current `dcomexec.py` objects.

- `dcomexec.py -k` first talks to the target machine’s `DCOM/RPCSS` service.
-  This works with Kerberos because the client gets a service ticket for HOST/target.example.com (meaning that someUser is allowed to authenticate to HOST/target.example.com)
- The ticket is encrypted for the target machine account. So services running as the machine/service side of that host can validate it.
- DCOM starts the requested COM object, the objects currently supported by dcomexec.py are:
  -  MMC20
  -  ShellWindows
  -  ShellBrowserWindow

- They all are user context COM automation objects. So DCOM may start or connect to a process running as a user (e.g. mmc.exe running as `DOMAIN\someUser`)
- Now the client has to talk to that new COM object endpoint. The problem is that Impacket reuses the same ticket but the new endpoint **is not running as the machine account**. It is running as: `DOMAIN\someUser`
- That user context process cannot decrypt or validate a ticket encrypted for the machine account. So Windows rejects it, and Impacket ends up showing `invalid_checksum`

Since Kerberos is not usable with these example objects, it is better to fail fast with a brief explanation when someone uses `-k`, `-aesKey`, or `-keytab`.