### PR TITLE
tds: fix binary and char column values displaying as Python bytes repr

### DIFF
--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -2186,7 +2186,7 @@ class MSSQL:
                         if _type == TDS_NTEXTTYPE:
                             value = data[:charLen].decode("utf-16le")
                         else:
-                            value = binascii.b2a_hex(data[:charLen])
+                            value = binascii.b2a_hex(data[:charLen]).decode("ascii")
                         data = data[charLen:]
                     else:
                         value = None
@@ -2211,7 +2211,7 @@ class MSSQL:
                 charLen = struct.unpack("<H", data[: struct.calcsize("<H")])[0]
                 data = data[struct.calcsize("<H") :]
                 if charLen != 0xFFFF:
-                    value = binascii.b2a_hex(data[:charLen])
+                    value = binascii.b2a_hex(data[:charLen]).decode("ascii")
                     data = data[charLen:]
                 else:
                     value = None

--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -2202,8 +2202,12 @@ class MSSQL:
                     charLen = struct.unpack("<L", data[: struct.calcsize("<L")])[0]
                     data = data[struct.calcsize("<L") :]
                     if charLen != 0xFFFF:
-                        value = data[:charLen]
+                        raw = data[:charLen]
                         data = data[charLen:]
+                        try:
+                            value = raw.decode("latin-1")
+                        except UnicodeDecodeError:
+                            value = raw.decode("utf-8", errors="replace")
                     else:
                         value = None
 
@@ -2330,11 +2334,14 @@ class MSSQL:
                     value = None
 
             elif _type == TDS_BIGCHARTYPE:
-                # print "BIGC"
                 charLen = struct.unpack("<H", data[: struct.calcsize("<H")])[0]
                 data = data[struct.calcsize("<H") :]
-                value = data[:charLen]
+                raw = data[:charLen]
                 data = data[charLen:]
+                try:
+                    value = raw.decode("latin-1")
+                except UnicodeDecodeError:
+                    value = raw.decode("utf-8", errors="replace")
 
             elif _type == TDS_INT8TYPE:
                 value = struct.unpack("<q", data[:8])[0]

--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -2153,12 +2153,7 @@ class MSSQL:
                     raw = data[:charLen]
                     data = data[charLen:]
 
-                    # SQL Server stores VARCHAR in server codepage, not UTF-8
-                    # latin-1 is the safest reversible mapping
-                    try:
-                        value = raw.decode("latin-1")
-                    except UnicodeDecodeError:
-                        value = raw.decode("utf-8", errors="replace")
+                    value = raw.decode("latin-1")
                 else:
                     value = None
 
@@ -2204,10 +2199,7 @@ class MSSQL:
                     if charLen != 0xFFFF:
                         raw = data[:charLen]
                         data = data[charLen:]
-                        try:
-                            value = raw.decode("latin-1")
-                        except UnicodeDecodeError:
-                            value = raw.decode("utf-8", errors="replace")
+                        value = raw.decode("latin-1")
                     else:
                         value = None
 
@@ -2338,10 +2330,7 @@ class MSSQL:
                 data = data[struct.calcsize("<H") :]
                 raw = data[:charLen]
                 data = data[charLen:]
-                try:
-                    value = raw.decode("latin-1")
-                except UnicodeDecodeError:
-                    value = raw.decode("utf-8", errors="replace")
+                value = raw.decode("latin-1")
 
             elif _type == TDS_INT8TYPE:
                 value = struct.unpack("<q", data[:8])[0]

--- a/tests/misc/test_tds.py
+++ b/tests/misc/test_tds.py
@@ -168,6 +168,61 @@ class TDSTests(unittest.TestCase):
         self.assertEqual(second_response["Type"], tds.TDS_TABULAR)
         self.assertEqual(second_response["Data"], b"second")
 
+    @staticmethod
+    def _text_pointer_row_data(payload):
+        pointer = b"PTR!"
+        return (
+            bytes([len(pointer)])
+            + pointer
+            + (b"\x00" * 8)
+            + struct.pack("<L", len(payload))
+            + payload
+        )
+
+    def _parse_single_column_row(self, col_type, data):
+        client = tds.MSSQL("server")
+        client.colMeta = [{"Type": col_type, "Name": "value"}]
+        consumed = client.parseRow({"TokenType": tds.TDS_ROW_TOKEN, "Data": data})
+
+        self.assertEqual(consumed, len(data))
+        return client.rows[-1]["value"]
+
+    def test_parse_row_decodes_big_binary_hex_as_string(self):
+        value = self._parse_single_column_row(
+            tds.TDS_BIGVARBINTYPE,
+            struct.pack("<H", 3) + b"\x01\xab\xff",
+        )
+
+        self.assertEqual(value, "01abff")
+        self.assertIsInstance(value, str)
+
+    def test_parse_row_decodes_image_hex_as_string(self):
+        value = self._parse_single_column_row(
+            tds.TDS_IMAGETYPE,
+            self._text_pointer_row_data(b"\x01\xab\xff"),
+        )
+
+        self.assertEqual(value, "01abff")
+        self.assertIsInstance(value, str)
+
+    def test_parse_row_decodes_text_as_string(self):
+        value = self._parse_single_column_row(
+            tds.TDS_TEXTTYPE,
+            self._text_pointer_row_data(b"caf\xe9"),
+        )
+
+        self.assertEqual(value, "caf\xe9")
+        self.assertIsInstance(value, str)
+
+    def test_parse_row_decodes_big_char_as_string(self):
+        value = self._parse_single_column_row(
+            tds.TDS_BIGCHARTYPE,
+            struct.pack("<H", 10) + b"7         ",
+        )
+
+        self.assertEqual(value, "7         ")
+        self.assertIsInstance(value, str)
+
 
 class MSSQLSocksRelayTests(unittest.TestCase):
     @staticmethod


### PR DESCRIPTION
`parseRow()` stored raw `bytes` for three column types, causing values to render with the `b'...'` Python representation in SQL output (see #2043).

- `TDS_BIGVARBINTYPE` / `TDS_BIGBINARYTYPE`: `binascii.b2a_hex()` returns `bytes`; added `.decode("ascii")` so the hex string prints cleanly.
- `TDS_IMAGETYPE`: same issue, same fix.
- `TDS_BIGCHARTYPE` / `TDS_TEXTTYPE`: raw byte slices stored without decoding; now decoded as `latin-1` (with `utf-8` fallback), matching how `TDS_BIGVARCHRTYPE` already handles character data.

Verified against a live SQL Server instance with `enum_users` (`sp_helpuser`), which exercises both `TDS_BIGCHARTYPE` (`UserID`) and `TDS_BIGVARBINTYPE` (`SID`).