### PR TITLE
smbserver: add SMB 3.1.1 dialect support

### DIFF
--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -5139,7 +5139,12 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
                         respPacket['CreditCharge'] = packet['CreditCharge']
                         # respPacket['CreditCharge'] = 0
                         respPacket['Reserved'] = packet['Reserved']
-                        respPacket['SessionID'] = connData['Uid']
+                        # MS-SMB2 §3.3.4.1: for SESSION_SETUP the server assigns a new SessionId;
+                        # for all other commands it MUST echo the request's SessionId.
+                        if packet['Command'] == smb2.SMB2_SESSION_SETUP:
+                            respPacket['SessionID'] = connData['Uid']
+                        else:
+                            respPacket['SessionID'] = packet['SessionID']
                         respPacket['MessageID'] = packet['MessageID']
                         respPacket['TreeID'] = packet['TreeID']
                         if hasattr(respCommand, 'getData'):

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -81,9 +81,8 @@ _PREAUTH_HASH_ZERO = b'\x00' * 64
 def _preauth_hash_update(current: bytes, data: bytes) -> bytes:
     """SHA-512(current || data), one step of the SMB 3.1.1 pre-auth integrity hash chain.
 
-    MS-SMB2 §3.3.5.4 (negotiate) and §3.3.5.5.3 (session setup) describe how the server
-    iteratively hashes request and response bytes into the connection/session pre-auth value:
-    https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/b39f253e-4963-40df-8dff-2f9040ebbeb1
+    The server iteratively hashes each request and response into the connection/session
+    pre-auth value during negotiate and session setup.
     """
     h = SHA512.new()
     h.update(current)
@@ -92,11 +91,7 @@ def _preauth_hash_update(current: bytes, data: bytes) -> bytes:
 
 
 def _build_smb311_preauth_context() -> bytes:
-    """Build a serialised SMB2_PREAUTH_INTEGRITY_CAPABILITIES negotiate context (SHA-512, no salt).
-
-    MS-SMB2 §2.2.3.1.1, SMB2_PREAUTH_INTEGRITY_CAPABILITIES structure definition:
-    https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/5a07bd66-4734-4af8-abcf-5a44ff7ee0e5
-    """
+    """Build a serialised SMB2_PREAUTH_INTEGRITY_CAPABILITIES negotiate context (SHA-512, no salt)."""
     preauth = smb2.SMB2PreAuthIntegrityCapabilities()
     preauth['HashAlgorithmCount'] = 1
     preauth['SaltLength'] = 0
@@ -112,11 +107,7 @@ def _build_smb311_preauth_context() -> bytes:
 
 
 def _parse_negotiate_contexts(data: bytes) -> dict:
-    """Parse a raw NegotiateContextList, returning {ContextType: data_bytes}.
-
-    MS-SMB2 §2.2.3.1, SMB2_NEGOTIATE_CONTEXT:
-    https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/15332256-522e-4a53-8a7d-2a87be5f8470
-    """
+    """Parse a raw NegotiateContextList, returning {ContextType: data_bytes}."""
     contexts = {}
     offset = 0
     while offset + 4 <= len(data):
@@ -131,11 +122,7 @@ def _parse_negotiate_contexts(data: bytes) -> dict:
 
 
 def _build_smb311_encrypt_context(cipher_id: int) -> bytes:
-    """Build a serialised SMB2_ENCRYPTION_CAPABILITIES negotiate context for the given cipher.
-
-    MS-SMB2 §2.2.3.1.2, SMB2_ENCRYPTION_CAPABILITIES:
-    https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/16693be7-2b27-4d3b-804b-f605bde5bcdd
-    """
+    """Build a serialised SMB2_ENCRYPTION_CAPABILITIES negotiate context for the given cipher."""
     enc = smb2.SMB2EncryptionCapabilities()
     enc['CipherCount'] = 1
     enc['Ciphers'] = struct.pack('<H', cipher_id)
@@ -2985,9 +2972,6 @@ class SMB2Commands:
         Parses the client's NegotiateContextList to discover offered ciphers, selects AES-128-GCM
         when available (falling back to AES-128-CCM), and advertises it in the response alongside
         the mandatory pre-authentication integrity context.
-
-        MS-SMB2 §3.3.5.4, Receiving an SMB2 NEGOTIATE Request:
-        https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/b39f253e-4963-40df-8dff-2f9040ebbeb1
         """
         connData['PreauthIntegrityHashValue'] = _preauth_hash_update(
             _PREAUTH_HASH_ZERO, recvPacket.rawData)
@@ -2997,7 +2981,7 @@ class SMB2Commands:
         # is always empty after structure parsing. Read the offset from the raw body instead.
         # In SMB 3.1.1, bytes 28-31 of the negotiate body are NegotiateContextOffset (the
         # first 4 bytes of the ClientStartTime union), which is the offset from the SMB2 header.
-        # MS-SMB2 §3.3.5.4 step 4: if SMB2_ENCRYPTION_CAPABILITIES is present, select a cipher.
+        # If the client advertises encryption support, pick the first mutually supported cipher.
         raw_body = bytes(recvPacket['Data'])
         neg_ctx_offset = struct.unpack_from('<L', raw_body, 28)[0]
         client_contexts = _parse_negotiate_contexts(raw_body[neg_ctx_offset - 64:]) if neg_ctx_offset else {}
@@ -3109,7 +3093,7 @@ class SMB2Commands:
             respSMBCommand['Buffer'] = acceptBytes
 
             connData['SignatureEnabled'] = True
-            connData['SigningSessionKey'] = encryption_key.contents[:16] # MS-SMB2 3.2.5.3.1
+            connData['SigningSessionKey'] = encryption_key.contents[:16]
             connData['SignSequenceNumber'] = 1
 
             return respSMBCommand, STATUS_SUCCESS
@@ -3398,10 +3382,8 @@ class SMB2Commands:
         is_311 = (connData.get('Dialect') == smb2.SMB2_DIALECT_311)
 
         if is_311:
-            # MS-SMB2 §3.3.5.5.3, Handling GSS-API Authentication:
-            # the session pre-auth hash is forked from the connection hash at the first
+            # The session pre-auth hash is forked from the connection hash at the first
             # SESSION_SETUP round and updated with each request/response pair.
-            # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/5ed93f06-a1d2-4837-8954-fa8b833c2654
             is_ntlm_round1 = (token[:8] == b'NTLMSSP\x00' and len(token) >= 12
                               and struct.unpack('<L', token[8:12])[0] == 0x01)
             if is_ntlm_round1 or 'SessionPreauthIntegrityHashValue' not in connData:
@@ -3433,10 +3415,6 @@ class SMB2Commands:
                     connData['SessionPreauthIntegrityHashValue'], resp_bytes + b'\x00' * pad)
             elif errorCode == STATUS_SUCCESS:
                 # Derive SMB 3.1.1 session keys via SP 800-108 counter-mode KBKDF.
-                # MS-SMB2 §3.1.4.2, Generating Cryptographic Keys:
-                # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/da4e579e-02ce-4e27-bbce-3fc816a3ff92
-                # NIST SP 800-108r1, KDF in Counter Mode (referenced from §3.1.4.2 as [SP800-108]):
-                # https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-108r1.pdf
                 session_key = connData.get('SigningSessionKey', b'')
                 if session_key:
                     preauth_hash = connData['SessionPreauthIntegrityHashValue']
@@ -3444,7 +3422,6 @@ class SMB2Commands:
                         session_key, b'SMBSigningKey\x00', preauth_hash, 128)
                     if connData.get('CipherId', 0):
                         # Derive server-to-client and client-to-server encryption keys.
-                        # Labels from MS-SMB2 §3.1.4.2, table "Label" column.
                         connData['SessionEncryptionKey'] = crypto.KDF_CounterMode(
                             session_key, b'SMBS2CCipherKey\x00', preauth_hash, 128)
                         connData['SessionDecryptionKey'] = crypto.KDF_CounterMode(
@@ -4864,11 +4841,7 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
         packet['Signature'] = signature[:16]
 
     def signSMBv3(self, packet, signingKey, padLength=0):
-        """Sign an SMB 3.x packet with AES-CMAC using the derived signing key.
-
-        MS-SMB2 §3.1.4.1, Signing an Outgoing Message (SMB 3.x uses AES-CMAC per RFC 4493):
-        https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/a3e9ea1e-53c8-4cff-94bd-d98fb20417c0
-        """
+        """Sign an SMB 3.x packet with AES-CMAC using the derived signing key."""
         packet['Signature'] = b'\x00' * 16
         packet['Flags'] |= smb2.SMB2_FLAGS_SIGNED
         packetData = packet.getData() + b'\x00' * padLength
@@ -4876,12 +4849,9 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
         packet['Signature'] = signature[:16]
 
     def _decryptSMB3(self, connId, data: bytes) -> bytes:
-        """Decrypt an SMB2_TRANSFORM_HEADER-wrapped message (MS-SMB2 §3.3.5.2.1).
+        """Decrypt an SMB2_TRANSFORM_HEADER-wrapped message.
 
         Supports AES-128-GCM and AES-128-CCM depending on the negotiated cipher.
-
-        MS-SMB2 §3.1.4.4, Decrypting the Message:
-        https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/d1c2b61f-6ad4-4eaa-a5fb-c6df3e32a1e5
         """
         conn_data = self.getConnectionData(connId, False)
         key = conn_data.get('SessionDecryptionKey', b'')
@@ -4898,11 +4868,7 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
         return cipher.decrypt(ciphertext)
 
     def _encryptSMB3(self, connId, plain_data: bytes) -> bytes:
-        """Wrap plain SMB2 bytes in an SMB2_TRANSFORM_HEADER encrypted with AES (MS-SMB2 §3.1.4.3).
-
-        MS-SMB2 §3.1.4.3, Encrypting the Message:
-        https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/0c6a2a95-c1e0-4a52-af59-3b6c6de4bcf6
-        """
+        """Wrap plain SMB2 bytes in an SMB2_TRANSFORM_HEADER encrypted with AES."""
         conn_data = self.getConnectionData(connId, False)
         key = conn_data.get('SessionEncryptionKey', b'')
         cipher_id = conn_data.get('CipherId', smb2.SMB2_ENCRYPTION_AES128_CCM)
@@ -4930,8 +4896,6 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
 
         # Decrypt SMB2_TRANSFORM_HEADER-wrapped packets before any parsing.
         # Must happen here, before the SMB1/SMB2 detection try/except below.
-        # MS-SMB2 §3.3.5.2.1:
-        # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/d1c2b61f-6ad4-4eaa-a5fb-c6df3e32a1e5
         if data[:4] == b'\xfdSMB':
             data = self._decryptSMB3(connId, data)
 
@@ -5139,8 +5103,8 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
                         respPacket['CreditCharge'] = packet['CreditCharge']
                         # respPacket['CreditCharge'] = 0
                         respPacket['Reserved'] = packet['Reserved']
-                        # MS-SMB2 §3.3.4.1: for SESSION_SETUP the server assigns a new SessionId;
-                        # for all other commands it MUST echo the request's SessionId.
+                        # SESSION_SETUP assigns a new SessionId; all other commands echo the
+                        # request's SessionId so the client can match the response to its session.
                         if packet['Command'] == smb2.SMB2_SESSION_SETUP:
                             respPacket['SessionID'] = connData['Uid']
                         else:
@@ -5167,10 +5131,8 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
                     packet['NextCommand'] = len(packet) + padLen
 
                 # Encrypt all post-session-setup packets when the session requires it.
-                # SESSION_SETUP responses are signed (not encrypted) even for encrypted sessions,
-                # so the client can read the SMB2_SESSION_FLAG_ENCRYPT_DATA flag.
-                # MS-SMB2 §3.3.5.5.3 step 12 and §3.1.4.3:
-                # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/0c6a2a95-c1e0-4a52-af59-3b6c6de4bcf6
+                # SESSION_SETUP responses are signed but not encrypted, so the client can
+                # read SMB2_SESSION_FLAG_ENCRYPT_DATA before switching to encryption.
                 if connData.get('EncryptData') and packet['Command'] != smb2.SMB2_SESSION_SETUP:
                     plain = packet.getData() if hasattr(packet, 'getData') else packet
                     finalData.append(self._encryptSMB3(connId, plain + padLen * b'\x00'))

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -50,8 +50,10 @@ from six import b, ensure_str
 from six.moves import configparser, socketserver
 from pyasn1.codec.der import encoder, decoder
 
-# For signing
-from impacket import smb, nmb, ntlm, uuid
+# For signing and session encryption
+from Cryptodome.Cipher import AES
+from Cryptodome.Hash import SHA512
+from impacket import smb, nmb, ntlm, uuid, crypto
 from impacket import smb3structs as smb2
 from impacket.spnego import SPNEGO_NegTokenInit, TypesMech, MechTypes, SPNEGO_NegTokenResp, ASN1_AID, \
     ASN1_SUPPORTED_MECH
@@ -71,6 +73,79 @@ LOG = logging.getLogger(__name__)
 # These ones not defined in nt_errors
 STATUS_SMB_BAD_UID = 0x005B0002
 STATUS_SMB_BAD_TID = 0x00050002
+
+_SUPPORTED_DIALECTS = (smb2.SMB2_DIALECT_311, smb2.SMB2_DIALECT_21, smb2.SMB2_DIALECT_002)
+_PREAUTH_HASH_ZERO = b'\x00' * 64
+
+
+def _preauth_hash_update(current: bytes, data: bytes) -> bytes:
+    """SHA-512(current || data), one step of the SMB 3.1.1 pre-auth integrity hash chain.
+
+    MS-SMB2 §3.3.5.4 (negotiate) and §3.3.5.5.3 (session setup) describe how the server
+    iteratively hashes request and response bytes into the connection/session pre-auth value:
+    https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/b39f253e-4963-40df-8dff-2f9040ebbeb1
+    """
+    h = SHA512.new()
+    h.update(current)
+    h.update(data)
+    return h.digest()
+
+
+def _build_smb311_preauth_context() -> bytes:
+    """Build a serialised SMB2_PREAUTH_INTEGRITY_CAPABILITIES negotiate context (SHA-512, no salt).
+
+    MS-SMB2 §2.2.3.1.1, SMB2_PREAUTH_INTEGRITY_CAPABILITIES structure definition:
+    https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/5a07bd66-4734-4af8-abcf-5a44ff7ee0e5
+    """
+    preauth = smb2.SMB2PreAuthIntegrityCapabilities()
+    preauth['HashAlgorithmCount'] = 1
+    preauth['SaltLength'] = 0
+    preauth['HashAlgorithms'] = struct.pack('<H', 0x0001)
+    preauth['Salt'] = b''
+    ctx = smb2.SMB2NegotiateContext()
+    ctx['ContextType'] = smb2.SMB2_PREAUTH_INTEGRITY_CAPABILITIES
+    ctx_data = preauth.getData()
+    ctx['DataLength'] = len(ctx_data)
+    ctx['Reserved'] = 0
+    ctx['Data'] = ctx_data
+    return ctx.getData()
+
+
+def _parse_negotiate_contexts(data: bytes) -> dict:
+    """Parse a raw NegotiateContextList, returning {ContextType: data_bytes}.
+
+    MS-SMB2 §2.2.3.1, SMB2_NEGOTIATE_CONTEXT:
+    https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/15332256-522e-4a53-8a7d-2a87be5f8470
+    """
+    contexts = {}
+    offset = 0
+    while offset + 4 <= len(data):
+        ctx_type = struct.unpack_from('<H', data, offset)[0]
+        data_len = struct.unpack_from('<H', data, offset + 2)[0]
+        if offset + 8 + data_len > len(data):
+            break
+        contexts[ctx_type] = data[offset + 8: offset + 8 + data_len]
+        total = 8 + data_len
+        offset += (total + 7) & ~7
+    return contexts
+
+
+def _build_smb311_encrypt_context(cipher_id: int) -> bytes:
+    """Build a serialised SMB2_ENCRYPTION_CAPABILITIES negotiate context for the given cipher.
+
+    MS-SMB2 §2.2.3.1.2, SMB2_ENCRYPTION_CAPABILITIES:
+    https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/16693be7-2b27-4d3b-804b-f605bde5bcdd
+    """
+    enc = smb2.SMB2EncryptionCapabilities()
+    enc['CipherCount'] = 1
+    enc['Ciphers'] = struct.pack('<H', cipher_id)
+    ctx = smb2.SMB2NegotiateContext()
+    ctx['ContextType'] = smb2.SMB2_ENCRYPTION_CAPABILITIES
+    ctx_data = enc.getData()
+    ctx['DataLength'] = len(ctx_data)
+    ctx['Reserved'] = 0
+    ctx['Data'] = ctx_data
+    return ctx.getData()
 
 
 # Utility functions
@@ -2834,7 +2909,7 @@ class SMBCommands:
 
 class SMB2Commands:
     @staticmethod
-    def smb2Negotiate(connId, smbServer, recvPacket, isSMB1=False):
+    def smbNegotiate(connId, smbServer, recvPacket, isSMB1=False):
         connData = smbServer.getConnectionData(connId, checkStatus=False)
 
         respPacket = smb2.SMB2Packet()
@@ -2857,13 +2932,21 @@ class SMB2Commands:
             SMBCommand = smb.SMBCommand(recvPacket['Data'][0])
 
             dialects = SMBCommand['Data'].split(b'\x02')
-            if b'SMB 2.002\x00' in dialects or b'SMB 2.???\x00' in dialects:
+            if b'SMB 2.???\x00' in dialects:
+                respSMBCommand['DialectRevision'] = smb2.SMB2_DIALECT_WILDCARD
+                connData['Dialect'] = smb2.SMB2_DIALECT_WILDCARD
+            elif b'SMB 2.002\x00' in dialects:
                 respSMBCommand['DialectRevision'] = smb2.SMB2_DIALECT_002
+                connData['Dialect'] = smb2.SMB2_DIALECT_002
             else:
-                # Client does not support SMB2 fallbacking
                 raise Exception('SMB2 not supported, fallbacking')
         else:
-            respSMBCommand['DialectRevision'] = smb2.SMB2_DIALECT_002
+            negRequest = smb2.SMB2Negotiate(recvPacket['Data'])
+            offered = set(negRequest['Dialects'])
+            selected = next((d for d in _SUPPORTED_DIALECTS if d in offered), smb2.SMB2_DIALECT_002)
+            respSMBCommand['DialectRevision'] = selected
+            connData['Dialect'] = selected
+
         respSMBCommand['ServerGuid'] = b'A' * 16
         respSMBCommand['Capabilities'] = 0
         respSMBCommand['MaxTransactSize'] = 65536
@@ -2886,11 +2969,75 @@ class SMB2Commands:
         respSMBCommand['Buffer'] = blob.getData()
         respSMBCommand['SecurityBufferLength'] = len(respSMBCommand['Buffer'])
 
-        respPacket['Data'] = respSMBCommand
+        if connData.get('Dialect') == smb2.SMB2_DIALECT_311:
+            SMB2Commands._smb311_negotiate(connData, recvPacket, respSMBCommand, respPacket)
+        else:
+            respPacket['Data'] = respSMBCommand
 
         smbServer.setConnectionData(connId, connData)
 
         return None, [respPacket], STATUS_SUCCESS
+
+    @staticmethod
+    def _smb311_negotiate(connData: dict, recvPacket, respSMBCommand, respPacket) -> None:
+        """Handle SMB 3.1.1 negotiate: initialise pre-auth hash chain, respond with negotiate contexts.
+
+        Parses the client's NegotiateContextList to discover offered ciphers, selects AES-128-GCM
+        when available (falling back to AES-128-CCM), and advertises it in the response alongside
+        the mandatory pre-authentication integrity context.
+
+        MS-SMB2 §3.3.5.4, Receiving an SMB2 NEGOTIATE Request:
+        https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/b39f253e-4963-40df-8dff-2f9040ebbeb1
+        """
+        connData['PreauthIntegrityHashValue'] = _preauth_hash_update(
+            _PREAUTH_HASH_ZERO, recvPacket.rawData)
+
+        # Parse the client's NegotiateContextList to check for encryption support.
+        # SMB2Negotiate.Dialects ('*<H') consumes all remaining bytes, so NegotiateContextList
+        # is always empty after structure parsing. Read the offset from the raw body instead.
+        # In SMB 3.1.1, bytes 28-31 of the negotiate body are NegotiateContextOffset (the
+        # first 4 bytes of the ClientStartTime union), which is the offset from the SMB2 header.
+        # MS-SMB2 §3.3.5.4 step 4: if SMB2_ENCRYPTION_CAPABILITIES is present, select a cipher.
+        raw_body = bytes(recvPacket['Data'])
+        neg_ctx_offset = struct.unpack_from('<L', raw_body, 28)[0]
+        client_contexts = _parse_negotiate_contexts(raw_body[neg_ctx_offset - 64:]) if neg_ctx_offset else {}
+        cipher_id = 0
+        if smb2.SMB2_ENCRYPTION_CAPABILITIES in client_contexts:
+            enc_data = client_contexts[smb2.SMB2_ENCRYPTION_CAPABILITIES]
+            count = struct.unpack_from('<H', enc_data, 0)[0]
+            offered = [struct.unpack_from('<H', enc_data, 2 + i * 2)[0] for i in range(count)]
+            # Prefer AES-128-GCM (faster on modern hardware); fall back to AES-128-CCM.
+            if smb2.SMB2_ENCRYPTION_AES128_GCM in offered:
+                cipher_id = smb2.SMB2_ENCRYPTION_AES128_GCM
+            elif smb2.SMB2_ENCRYPTION_AES128_CCM in offered:
+                cipher_id = smb2.SMB2_ENCRYPTION_AES128_CCM
+        connData['CipherId'] = cipher_id
+
+        preauth_ctx = _build_smb311_preauth_context()
+        sec_buf_len = len(respSMBCommand['Buffer'])
+        ctx_pad = (8 - sec_buf_len % 8) % 8
+        respSMBCommand['NegotiateContextOffset'] = 0x80 + sec_buf_len + ctx_pad
+        respSMBCommand['Padding'] = b'\x00' * ctx_pad
+
+        if cipher_id:
+            # Pad preauth context to 8-byte boundary before appending encryption context.
+            preauth_pad = (8 - len(preauth_ctx) % 8) % 8
+            ctx_list = preauth_ctx + b'\x00' * preauth_pad + _build_smb311_encrypt_context(cipher_id)
+            respSMBCommand['NegotiateContextCount'] = 2
+            respSMBCommand['Capabilities'] |= smb2.SMB2_GLOBAL_CAP_ENCRYPTION
+        else:
+            ctx_list = preauth_ctx
+            respSMBCommand['NegotiateContextCount'] = 1
+
+        respSMBCommand['NegotiateContextList'] = ctx_list
+        respPacket['Data'] = respSMBCommand
+
+        # Include the 8-byte alignment padding that processRequest appends when sending,
+        # so the hash matches what the client receives and hashes on its side.
+        resp_bytes = respPacket.getData()
+        pad = (-len(resp_bytes)) % 8
+        connData['PreauthIntegrityHashValue'] = _preauth_hash_update(
+            connData['PreauthIntegrityHashValue'], resp_bytes + b'\x00' * pad)
 
     @staticmethod
     def _kerberos_auth(token, connData, smbServer):
@@ -3247,11 +3394,64 @@ class SMB2Commands:
         else:
             smbServer.log("Unknown or unsupported security blob type", logging.ERROR, connData=connData)
             return [SMB2Commands.generic_negTokenResp()], None, STATUS_MORE_PROCESSING_REQUIRED
-        
+
+        is_311 = (connData.get('Dialect') == smb2.SMB2_DIALECT_311)
+
+        if is_311:
+            # MS-SMB2 §3.3.5.5.3, Handling GSS-API Authentication:
+            # the session pre-auth hash is forked from the connection hash at the first
+            # SESSION_SETUP round and updated with each request/response pair.
+            # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/5ed93f06-a1d2-4837-8954-fa8b833c2654
+            is_ntlm_round1 = (token[:8] == b'NTLMSSP\x00' and len(token) >= 12
+                              and struct.unpack('<L', token[8:12])[0] == 0x01)
+            if is_ntlm_round1 or 'SessionPreauthIntegrityHashValue' not in connData:
+                connData['SessionPreauthIntegrityHashValue'] = connData.get('PreauthIntegrityHashValue', _PREAUTH_HASH_ZERO)
+            connData['SessionPreauthIntegrityHashValue'] = _preauth_hash_update(
+                connData['SessionPreauthIntegrityHashValue'], recvPacket.rawData)
+
         if authType in [TypesMech['MS KRB5 - Microsoft Kerberos 5'], TypesMech['KRB5 - Kerberos 5'], TypesMech['KRB5 - Kerberos 5 - User to User']]:
             respSMBCommand, errorCode = SMB2Commands._kerberos_auth(token, connData, smbServer)
         elif authType == TypesMech['NTLMSSP - Microsoft NTLM Security Support Provider']:
             respSMBCommand, errorCode = SMB2Commands._ntlm_auth(token, connData, smbServer, rawNTLM)
+
+        if is_311:
+            if errorCode == STATUS_MORE_PROCESSING_REQUIRED:
+                resp_pkt = smb2.SMB2Packet()
+                resp_pkt['Flags'] = smb2.SMB2_FLAGS_SERVER_TO_REDIR
+                resp_pkt['Status'] = errorCode
+                resp_pkt['CreditRequestResponse'] = recvPacket['CreditRequestResponse']
+                resp_pkt['Command'] = recvPacket['Command']
+                resp_pkt['CreditCharge'] = recvPacket['CreditCharge']
+                resp_pkt['Reserved'] = recvPacket['Reserved']
+                resp_pkt['SessionID'] = connData['Uid']
+                resp_pkt['MessageID'] = recvPacket['MessageID']
+                resp_pkt['TreeID'] = recvPacket['TreeID']
+                resp_pkt['Data'] = respSMBCommand.getData()
+                resp_bytes = resp_pkt.getData()
+                pad = (-len(resp_bytes)) % 8
+                connData['SessionPreauthIntegrityHashValue'] = _preauth_hash_update(
+                    connData['SessionPreauthIntegrityHashValue'], resp_bytes + b'\x00' * pad)
+            elif errorCode == STATUS_SUCCESS:
+                # Derive SMB 3.1.1 session keys via SP 800-108 counter-mode KBKDF.
+                # MS-SMB2 §3.1.4.2, Generating Cryptographic Keys:
+                # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/da4e579e-02ce-4e27-bbce-3fc816a3ff92
+                # NIST SP 800-108r1, KDF in Counter Mode (referenced from §3.1.4.2 as [SP800-108]):
+                # https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-108r1.pdf
+                session_key = connData.get('SigningSessionKey', b'')
+                if session_key:
+                    preauth_hash = connData['SessionPreauthIntegrityHashValue']
+                    connData['SigningSessionKey'] = crypto.KDF_CounterMode(
+                        session_key, b'SMBSigningKey\x00', preauth_hash, 128)
+                    if connData.get('CipherId', 0):
+                        # Derive server-to-client and client-to-server encryption keys.
+                        # Labels from MS-SMB2 §3.1.4.2, table "Label" column.
+                        connData['SessionEncryptionKey'] = crypto.KDF_CounterMode(
+                            session_key, b'SMBS2CCipherKey\x00', preauth_hash, 128)
+                        connData['SessionDecryptionKey'] = crypto.KDF_CounterMode(
+                            session_key, b'SMBC2SCipherKey\x00', preauth_hash, 128)
+                        connData['EncryptData'] = True
+                        existing_flags = respSMBCommand.fields.get('SessionFlags', 0)
+                        respSMBCommand['SessionFlags'] = existing_flags | smb2.SMB2_SESSION_FLAG_ENCRYPT_DATA
 
         # From now on, the client can ask for other commands
         connData['Authenticated'] = True
@@ -3324,7 +3524,10 @@ class SMB2Commands:
 
         # Sign the packet if needed
         if connData['SignatureEnabled']:
-            smbServer.signSMBv2(respPacket, connData['SigningSessionKey'])
+            if connData.get('Dialect', smb2.SMB2_DIALECT_002) >= smb2.SMB2_DIALECT_30:
+                smbServer.signSMBv3(respPacket, connData['SigningSessionKey'])
+            else:
+                smbServer.signSMBv2(respPacket, connData['SigningSessionKey'])
         smbServer.setConnectionData(connId, connData)
 
         return None, [respPacket], errorCode
@@ -4143,7 +4346,7 @@ class Ioctls:
         validateNegotiateInfoResponse['Capabilities'] = 0
         validateNegotiateInfoResponse['Guid'] = b'A' * 16
         validateNegotiateInfoResponse['SecurityMode'] = 1
-        validateNegotiateInfoResponse['Dialect'] = smb2.SMB2_DIALECT_002
+        validateNegotiateInfoResponse['Dialect'] = connData.get('Dialect', smb2.SMB2_DIALECT_002)
 
         smbServer.setConnectionData(connId, connData)
         return validateNegotiateInfoResponse.getData(), errorCode
@@ -4350,7 +4553,7 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
         }
 
         self.__smb2Commands = {
-            smb2.SMB2_NEGOTIATE: self.__smb2CommandsHandler.smb2Negotiate,
+            smb2.SMB2_NEGOTIATE: self.__smb2CommandsHandler.smbNegotiate,
             smb2.SMB2_SESSION_SETUP: self.__smb2CommandsHandler.smb2SessionSetup,
             smb2.SMB2_LOGOFF: self.__smb2CommandsHandler.smb2Logoff,
             smb2.SMB2_TREE_CONNECT: self.__smb2CommandsHandler.smb2TreeConnect,
@@ -4659,9 +4862,78 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
         packetData = packet.getData() + b'\x00' * padLength
         signature = hmac.new(signingSessionKey, packetData, hashlib.sha256).digest()
         packet['Signature'] = signature[:16]
-        # print "%s" % packet['Signature'].encode('hex')
+
+    def signSMBv3(self, packet, signingKey, padLength=0):
+        """Sign an SMB 3.x packet with AES-CMAC using the derived signing key.
+
+        MS-SMB2 §3.1.4.1, Signing an Outgoing Message (SMB 3.x uses AES-CMAC per RFC 4493):
+        https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/a3e9ea1e-53c8-4cff-94bd-d98fb20417c0
+        """
+        packet['Signature'] = b'\x00' * 16
+        packet['Flags'] |= smb2.SMB2_FLAGS_SIGNED
+        packetData = packet.getData() + b'\x00' * padLength
+        signature = crypto.AES_CMAC(signingKey, packetData, len(packetData))
+        packet['Signature'] = signature[:16]
+
+    def _decryptSMB3(self, connId, data: bytes) -> bytes:
+        """Decrypt an SMB2_TRANSFORM_HEADER-wrapped message (MS-SMB2 §3.3.5.2.1).
+
+        Supports AES-128-GCM and AES-128-CCM depending on the negotiated cipher.
+
+        MS-SMB2 §3.1.4.4, Decrypting the Message:
+        https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/d1c2b61f-6ad4-4eaa-a5fb-c6df3e32a1e5
+        """
+        conn_data = self.getConnectionData(connId, False)
+        key = conn_data.get('SessionDecryptionKey', b'')
+        cipher_id = struct.unpack_from('<H', data, 42)[0]
+        nonce = data[20:36]
+        # AAD: all transform header fields except ProtocolId and Signature (bytes 20..52).
+        aad = data[20:52]
+        ciphertext = data[52:]
+        if cipher_id == smb2.SMB2_ENCRYPTION_AES128_GCM:
+            cipher = AES.new(key, AES.MODE_GCM, nonce=nonce[:12])
+        else:
+            cipher = AES.new(key, AES.MODE_CCM, nonce=nonce[:11])
+        cipher.update(aad)
+        return cipher.decrypt(ciphertext)
+
+    def _encryptSMB3(self, connId, plain_data: bytes) -> bytes:
+        """Wrap plain SMB2 bytes in an SMB2_TRANSFORM_HEADER encrypted with AES (MS-SMB2 §3.1.4.3).
+
+        MS-SMB2 §3.1.4.3, Encrypting the Message:
+        https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/0c6a2a95-c1e0-4a52-af59-3b6c6de4bcf6
+        """
+        conn_data = self.getConnectionData(connId, False)
+        key = conn_data.get('SessionEncryptionKey', b'')
+        cipher_id = conn_data.get('CipherId', smb2.SMB2_ENCRYPTION_AES128_CCM)
+        transform = smb2.SMB2_TRANSFORM_HEADER()
+        if cipher_id == smb2.SMB2_ENCRYPTION_AES128_GCM:
+            nonce = os.urandom(12) + b'\x00' * 4
+        else:
+            nonce = os.urandom(11) + b'\x00' * 5
+        transform['Nonce'] = nonce
+        transform['OriginalMessageSize'] = len(plain_data)
+        transform['EncryptionAlgorithm'] = cipher_id
+        transform['SessionID'] = conn_data.get('Uid', 0)
+        # AAD: transform header bytes starting after ProtocolId and Signature (offset 20).
+        aad = transform.getData()[20:]
+        if cipher_id == smb2.SMB2_ENCRYPTION_AES128_GCM:
+            cipher = AES.new(key, AES.MODE_GCM, nonce=nonce[:12])
+        else:
+            cipher = AES.new(key, AES.MODE_CCM, nonce=nonce[:11])
+        cipher.update(aad)
+        ciphertext = cipher.encrypt(plain_data)
+        transform['Signature'] = cipher.digest()
+        return transform.getData() + ciphertext
 
     def processRequest(self, connId, data):
+
+        # Decrypt SMB2_TRANSFORM_HEADER-wrapped packets before any parsing.
+        # Must happen here, before the SMB1/SMB2 detection try/except below.
+        # MS-SMB2 §3.3.5.2.1:
+        # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/d1c2b61f-6ad4-4eaa-a5fb-c6df3e32a1e5
+        if data[:4] == b'\xfdSMB':
+            data = self._decryptSMB3(connId, data)
 
         # TODO: Process batched commands.
         isSMB2 = False
@@ -4881,7 +5153,7 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
                 packetsToSend = respPackets
 
         if isSMB2 is True:
-            # Let's build a compound answer and sign it
+            # Let's build a compound answer, sign or encrypt each packet.
             finalData = []
             totalPackets = len(packetsToSend)
             for idx, packet in enumerate(packetsToSend):
@@ -4889,13 +5161,24 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
                 if idx + 1 < totalPackets:
                     packet['NextCommand'] = len(packet) + padLen
 
-                if connData['SignatureEnabled']:
-                    self.signSMBv2(packet, connData['SigningSessionKey'], padLength=padLen)
-
-                if hasattr(packet, 'getData'):
-                    finalData.append(packet.getData() + padLen * b'\x00')
+                # Encrypt all post-session-setup packets when the session requires it.
+                # SESSION_SETUP responses are signed (not encrypted) even for encrypted sessions,
+                # so the client can read the SMB2_SESSION_FLAG_ENCRYPT_DATA flag.
+                # MS-SMB2 §3.3.5.5.3 step 12 and §3.1.4.3:
+                # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/0c6a2a95-c1e0-4a52-af59-3b6c6de4bcf6
+                if connData.get('EncryptData') and packet['Command'] != smb2.SMB2_SESSION_SETUP:
+                    plain = packet.getData() if hasattr(packet, 'getData') else packet
+                    finalData.append(self._encryptSMB3(connId, plain + padLen * b'\x00'))
                 else:
-                    finalData.append(packet + padLen * b'\x00')
+                    if connData['SignatureEnabled']:
+                        if connData.get('Dialect', smb2.SMB2_DIALECT_002) >= smb2.SMB2_DIALECT_30:
+                            self.signSMBv3(packet, connData['SigningSessionKey'], padLength=padLen)
+                        else:
+                            self.signSMBv2(packet, connData['SigningSessionKey'], padLength=padLen)
+                    if hasattr(packet, 'getData'):
+                        finalData.append(packet.getData() + padLen * b'\x00')
+                    else:
+                        finalData.append(packet + padLen * b'\x00')
 
             packetsToSend = [b"".join(finalData)]
 

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -4894,7 +4894,7 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
             raise ValueError('Invalid SMB2 transform original message size')
         return plain_data
 
-    def _encryptSMB3(self, connId, plain_data: bytes) -> bytes:
+    def _encryptSMB3(self, connId, plain_data: bytes, session_id: int) -> bytes:
         """Wrap plain SMB2 bytes in an SMB2_TRANSFORM_HEADER encrypted with AES."""
         conn_data = self.getConnectionData(connId, False)
         key = conn_data.get('SessionEncryptionKey', b'')
@@ -4912,7 +4912,7 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
         # but for SMB 3.1.1 it is the Flags field and MUST contain 0x0001. The cipher
         # itself is selected from the negotiated connection state.
         transform['EncryptionAlgorithm'] = 0x0001
-        transform['SessionID'] = conn_data.get('Uid', 0)
+        transform['SessionID'] = session_id
         # AAD: transform header bytes starting after ProtocolId and Signature (offset 20).
         aad = transform.getData()[20:]
         if cipher_id == smb2.SMB2_ENCRYPTION_AES128_GCM:
@@ -4947,6 +4947,10 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
             isSMB2 = True
 
         connData = self.getConnectionData(connId, False)
+        # Captured now: a command in this request (e.g. LOGOFF) may clear connData['Uid']
+        # before the compound response is encrypted below, and the transform header must
+        # still carry the session the request was authenticated under.
+        sessionId = connData.get('Uid', 0)
 
         # We might have compound requests
         compoundedPacketsResponse = []
@@ -5182,7 +5186,7 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
 
             finalData = b"".join(finalData)
             if encryptResponse:
-                finalData = self._encryptSMB3(connId, finalData)
+                finalData = self._encryptSMB3(connId, finalData, sessionId)
             packetsToSend = [finalData]
 
         # We clear the compound requests

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -5130,32 +5130,34 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
                 packetsToSend = respPackets
 
         if isSMB2 is True:
-            # Let's build a compound answer, sign or encrypt each packet.
+            # Build the complete compound answer before encrypting. A single transform
+            # header wraps the whole compound chain, per MS-SMB2 3.1.4.3.
             finalData = []
             totalPackets = len(packetsToSend)
+            # SESSION_SETUP responses are signed but not encrypted, so the client can
+            # read SMB2_SESSION_FLAG_ENCRYPT_DATA before switching to encryption.
+            encryptResponse = connData.get('EncryptData') and all(
+                packet['Command'] != smb2.SMB2_SESSION_SETUP for packet in packetsToSend)
             for idx, packet in enumerate(packetsToSend):
                 padLen = -len(packet) % 8
                 if idx + 1 < totalPackets:
                     packet['NextCommand'] = len(packet) + padLen
 
-                # Encrypt all post-session-setup packets when the session requires it.
-                # SESSION_SETUP responses are signed but not encrypted, so the client can
-                # read SMB2_SESSION_FLAG_ENCRYPT_DATA before switching to encryption.
-                if connData.get('EncryptData') and packet['Command'] != smb2.SMB2_SESSION_SETUP:
-                    plain = packet.getData() if hasattr(packet, 'getData') else packet
-                    finalData.append(self._encryptSMB3(connId, plain + padLen * b'\x00'))
-                else:
+                if not encryptResponse:
                     if connData['SignatureEnabled']:
                         if connData.get('Dialect', smb2.SMB2_DIALECT_002) >= smb2.SMB2_DIALECT_30:
                             self.signSMBv3(packet, connData['SigningSessionKey'], padLength=padLen)
                         else:
                             self.signSMBv2(packet, connData['SigningSessionKey'], padLength=padLen)
-                    if hasattr(packet, 'getData'):
-                        finalData.append(packet.getData() + padLen * b'\x00')
-                    else:
-                        finalData.append(packet + padLen * b'\x00')
+                if hasattr(packet, 'getData'):
+                    finalData.append(packet.getData() + padLen * b'\x00')
+                else:
+                    finalData.append(packet + padLen * b'\x00')
 
-            packetsToSend = [b"".join(finalData)]
+            finalData = b"".join(finalData)
+            if encryptResponse:
+                finalData = self._encryptSMB3(connId, finalData)
+            packetsToSend = [finalData]
 
         # We clear the compound requests
         connData['LastRequest'] = {}

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -2929,8 +2929,16 @@ class SMB2Commands:
                 raise Exception('SMB2 not supported, fallbacking')
         else:
             negRequest = smb2.SMB2Negotiate(recvPacket['Data'])
-            offered = set(negRequest['Dialects'])
-            selected = next((d for d in _SUPPORTED_DIALECTS if d in offered), smb2.SMB2_DIALECT_002)
+            # SMB2Negotiate.Dialects consumes all remaining bytes, including SMB 3.1.1
+            # negotiate contexts, so only consider the number of dialects declared by
+            # the request.
+            offered = set(negRequest['Dialects'][:negRequest['DialectCount']])
+            selected = next((d for d in _SUPPORTED_DIALECTS if d in offered), None)
+            if selected is None:
+                respPacket['Status'] = STATUS_NOT_SUPPORTED
+                respPacket['Data'] = smb2.SMB2Error()
+                smbServer.setConnectionData(connId, connData)
+                return None, [respPacket], STATUS_NOT_SUPPORTED
             respSMBCommand['DialectRevision'] = selected
             connData['Dialect'] = selected
 

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -4873,7 +4873,11 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
         else:
             cipher = AES.new(key, AES.MODE_CCM, nonce=nonce[:11])
         cipher.update(aad)
-        return cipher.decrypt(ciphertext)
+        plain_data = cipher.decrypt_and_verify(ciphertext, data[4:20])
+        original_size = struct.unpack_from('<L', data, 36)[0]
+        if len(plain_data) != original_size:
+            raise ValueError('Invalid SMB2 transform original message size')
+        return plain_data
 
     def _encryptSMB3(self, connId, plain_data: bytes) -> bytes:
         """Wrap plain SMB2 bytes in an SMB2_TRANSFORM_HEADER encrypted with AES."""

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -4861,17 +4861,32 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
 
         Supports AES-128-GCM and AES-128-CCM depending on the negotiated cipher.
         """
+        if len(data) <= len(smb2.SMB2_TRANSFORM_HEADER()):
+            raise ValueError('Invalid SMB2 transform size')
+
         conn_data = self.getConnectionData(connId, False)
         key = conn_data.get('SessionDecryptionKey', b'')
-        cipher_id = struct.unpack_from('<H', data, 42)[0]
+        # EncryptionAlgorithm is repurposed as Flags for SMB 3.1.1 and MUST be 0x0001.
+        # The actual cipher is negotiated out-of-band and lives in the connection state.
+        flags = struct.unpack_from('<H', data, 42)[0]
+        if flags != 0x0001:
+            raise ValueError('Invalid SMB2 transform flags')
+
+        session_id = struct.unpack_from('<Q', data, 44)[0]
+        if session_id != conn_data.get('Uid', 0):
+            raise ValueError('Invalid SMB2 transform session ID')
+
+        cipher_id = conn_data.get('CipherId', 0)
         nonce = data[20:36]
         # AAD: all transform header fields except ProtocolId and Signature (bytes 20..52).
         aad = data[20:52]
         ciphertext = data[52:]
         if cipher_id == smb2.SMB2_ENCRYPTION_AES128_GCM:
             cipher = AES.new(key, AES.MODE_GCM, nonce=nonce[:12])
-        else:
+        elif cipher_id == smb2.SMB2_ENCRYPTION_AES128_CCM:
             cipher = AES.new(key, AES.MODE_CCM, nonce=nonce[:11])
+        else:
+            raise ValueError('Unsupported SMB2 encryption cipher')
         cipher.update(aad)
         plain_data = cipher.decrypt_and_verify(ciphertext, data[4:20])
         original_size = struct.unpack_from('<L', data, 36)[0]

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -4902,18 +4902,25 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
         transform = smb2.SMB2_TRANSFORM_HEADER()
         if cipher_id == smb2.SMB2_ENCRYPTION_AES128_GCM:
             nonce = os.urandom(12) + b'\x00' * 4
-        else:
+        elif cipher_id == smb2.SMB2_ENCRYPTION_AES128_CCM:
             nonce = os.urandom(11) + b'\x00' * 5
+        else:
+            raise ValueError('Unsupported SMB2 encryption cipher')
         transform['Nonce'] = nonce
         transform['OriginalMessageSize'] = len(plain_data)
-        transform['EncryptionAlgorithm'] = cipher_id
+        # This structure field is named EncryptionAlgorithm for SMB 3.0 compatibility,
+        # but for SMB 3.1.1 it is the Flags field and MUST contain 0x0001. The cipher
+        # itself is selected from the negotiated connection state.
+        transform['EncryptionAlgorithm'] = 0x0001
         transform['SessionID'] = conn_data.get('Uid', 0)
         # AAD: transform header bytes starting after ProtocolId and Signature (offset 20).
         aad = transform.getData()[20:]
         if cipher_id == smb2.SMB2_ENCRYPTION_AES128_GCM:
             cipher = AES.new(key, AES.MODE_GCM, nonce=nonce[:12])
-        else:
+        elif cipher_id == smb2.SMB2_ENCRYPTION_AES128_CCM:
             cipher = AES.new(key, AES.MODE_CCM, nonce=nonce[:11])
+        else:
+            raise ValueError('Unsupported SMB2 encryption cipher')
         cipher.update(aad)
         ciphertext = cipher.encrypt(plain_data)
         transform['Signature'] = cipher.digest()

--- a/tests/SMB_RPC/test_smbserver.py
+++ b/tests/SMB_RPC/test_smbserver.py
@@ -77,14 +77,16 @@
 import unittest
 from time import sleep
 from os.path import exists, join
-from os import mkdir, rmdir, remove
+from os import mkdir, rmdir, remove, urandom
 from multiprocessing import Process
 
 from six import PY2, StringIO, BytesIO, b, assertRaisesRegex, assertCountEqual
 
 from impacket.smb import SMB_DIALECT
-from impacket.smbserver import normalize_path, isInFileJail, SimpleSMBServer, SMBSERVER
+from impacket.smbserver import normalize_path, isInFileJail, SimpleSMBServer, SMBSERVER, SMB2Commands
 from impacket.smbconnection import SMBConnection, SessionError, compute_lmhash, compute_nthash
+from impacket.nt_errors import STATUS_NOT_SUPPORTED
+from impacket import smb3structs as smb2
 from threading import Thread
 
 import select
@@ -724,6 +726,229 @@ class SimpleSMBServer2FuncTests(SimpleSMBServerFuncTests):
             client.deleteDirectory(self.share_name, "unexistent")
 
         client.close()
+
+
+class SimpleSMBServer311FuncTests(SimpleSMBServer2FuncTests):
+    """Runs the full SimpleSMBServerFuncTests/SimpleSMBServer2FuncTests suite over SMB 3.1.1.
+
+    impacket's own SMBConnection client only ever negotiates AES-128-CCM (see smb3.py's
+    SMB2EncryptionCapabilities), so this exercises the encrypted request/response path with
+    that cipher end to end: negotiate, session setup, encrypted reads/writes/deletes and the
+    LOGOFF at teardown all flow through _encryptSMB3/_decryptSMB3 and the compound-response
+    finalization in processRequest. AES-128-GCM and the byte-level transform header checks
+    are covered separately in SMB2Server311UnitTests, since the client can't negotiate GCM.
+    """
+
+    server_smb2_support = True
+    client_preferred_dialect = smb2.SMB2_DIALECT_311
+
+
+class SMB2Server311UnitTests(unittest.TestCase):
+    """Unit tests for the SMB 3.1.1 additions to SMB2Commands and SMBSERVER.
+
+    These call the negotiate handler and the transform header encrypt/decrypt methods
+    directly against a live SMBSERVER instance, without going over the network, so they
+    can exercise both ciphers and inject malformed input that a real client wouldn't send.
+    """
+
+    address = "127.0.0.1"
+    port = 14461
+    conn_id = "unit-test-connection"
+
+    def setUp(self):
+        self.smbserver = SimpleSMBServer(listenAddress=self.address, listenPort=self.port,
+                                         smbserverclass=SMBSERVERForTests)
+        self.smbserver.setSMB2Support(True)
+        self.server = self.smbserver.getServer()
+        self.server.addConnection(self.conn_id, self.address, 55555)
+
+    def tearDown(self):
+        self.smbserver.stop()
+
+    def _connData(self):
+        return self.server.getConnectionData(self.conn_id, False)
+
+    @staticmethod
+    def _negotiateRequest(dialects, dialectCount=None):
+        negotiate = smb2.SMB2Negotiate()
+        negotiate['SecurityMode'] = 0
+        negotiate['Capabilities'] = 0
+        negotiate['ClientGuid'] = b'\x00' * 16
+        negotiate['ClientStartTime'] = b'\x00' * 8
+        negotiate['DialectCount'] = len(dialects) if dialectCount is None else dialectCount
+        negotiate['Dialects'] = dialects
+
+        packet = smb2.SMB2Packet()
+        packet['Command'] = smb2.SMB2_NEGOTIATE
+        packet['MessageID'] = 0
+        packet['Data'] = negotiate.getData()
+        return packet
+
+    def test_negotiate_rejects_dialect_the_client_never_offered(self):
+        """A request offering only an unsupported dialect must get STATUS_NOT_SUPPORTED,
+        not a silent downgrade to 2.002 (see fortra/impacket#2216 review comment).
+        """
+        recvPacket = self._negotiateRequest([smb2.SMB2_DIALECT_30])
+
+        respCommands, respPackets, errorCode = SMB2Commands.smbNegotiate(
+            self.conn_id, self.server, recvPacket, isSMB1=False)
+
+        self.assertIsNone(respCommands)
+        self.assertEqual(errorCode, STATUS_NOT_SUPPORTED)
+        self.assertEqual(len(respPackets), 1)
+        self.assertEqual(respPackets[0]['Status'], STATUS_NOT_SUPPORTED)
+
+    def test_negotiate_ignores_dialects_leaking_past_dialect_count(self):
+        """SMB2Negotiate.Dialects is a greedy array that consumes all remaining bytes,
+        including the SMB 3.1.1 negotiate contexts appended after it. A request declaring
+        one unsupported dialect, followed by bytes that happen to look like a supported
+        one, must still be rejected: only DialectCount entries are real dialects.
+        """
+        recvPacket = self._negotiateRequest([smb2.SMB2_DIALECT_30, smb2.SMB2_DIALECT_311], dialectCount=1)
+
+        respCommands, respPackets, errorCode = SMB2Commands.smbNegotiate(
+            self.conn_id, self.server, recvPacket, isSMB1=False)
+
+        self.assertEqual(errorCode, STATUS_NOT_SUPPORTED)
+
+    def test_encrypt_transform_flags_are_always_0x0001(self):
+        """The transform header's Flags/EncryptionAlgorithm field is fixed at 0x0001 for
+        SMB 3.1.1 regardless of the negotiated cipher: the cipher itself is carried in the
+        connection state, not in this field (MS-SMB2 3.1.4.3, 3.1.4.1.1).
+        """
+        for cipherId in (smb2.SMB2_ENCRYPTION_AES128_CCM, smb2.SMB2_ENCRYPTION_AES128_GCM):
+            with self.subTest(cipherId=cipherId):
+                connData = self._connData()
+                connData['SessionEncryptionKey'] = urandom(16)
+                connData['CipherId'] = cipherId
+                self.server.setConnectionData(self.conn_id, connData)
+
+                wireData = self.server._encryptSMB3(self.conn_id, b'plaintext SMB2 payload', 0xAABBCCDD)
+                transform = smb2.SMB2_TRANSFORM_HEADER(wireData)
+
+                self.assertEqual(transform['EncryptionAlgorithm'], 0x0001)
+                self.assertEqual(transform['SessionID'], 0xAABBCCDD)
+
+    def test_encrypt_decrypt_round_trip_both_ciphers(self):
+        """A message encrypted for a given cipher must decrypt back to the same plaintext."""
+        for cipherId in (smb2.SMB2_ENCRYPTION_AES128_CCM, smb2.SMB2_ENCRYPTION_AES128_GCM):
+            with self.subTest(cipherId=cipherId):
+                key = urandom(16)
+                connData = self._connData()
+                connData['SessionEncryptionKey'] = key
+                connData['SessionDecryptionKey'] = key
+                connData['CipherId'] = cipherId
+                connData['Uid'] = 0x1122334455667788
+                self.server.setConnectionData(self.conn_id, connData)
+
+                plainText = b'legitimate SMB2 response payload'
+                wireData = self.server._encryptSMB3(self.conn_id, plainText, connData['Uid'])
+                recovered = self.server._decryptSMB3(self.conn_id, wireData)
+
+                self.assertEqual(recovered, plainText)
+
+    def test_decrypt_rejects_corrupted_ciphertext(self):
+        """A single flipped bit in the ciphertext must be rejected, not silently decrypted
+        into garbage and processed further (MS-SMB2 3.3.5.2.1: signature verification).
+        """
+        key = urandom(16)
+        connData = self._connData()
+        connData['SessionEncryptionKey'] = key
+        connData['SessionDecryptionKey'] = key
+        connData['CipherId'] = smb2.SMB2_ENCRYPTION_AES128_GCM
+        connData['Uid'] = 0x1122334455667788
+        self.server.setConnectionData(self.conn_id, connData)
+
+        wireData = self.server._encryptSMB3(self.conn_id, b'legitimate SMB2 response payload', connData['Uid'])
+
+        tampered = bytearray(wireData)
+        tampered[-1] ^= 0xFF
+
+        with self.assertRaises(ValueError):
+            self.server._decryptSMB3(self.conn_id, bytes(tampered))
+
+    def test_compound_response_uses_a_single_transform_header(self):
+        """An encrypted compound response must be one TRANSFORM_HEADER wrapping the whole
+        chain, not one TRANSFORM_HEADER per command (MS-SMB2 3.1.4.3): decrypting the wire
+        data once should yield both SMB2 responses, linked by NextCommand.
+        """
+        connData = self._connData()
+        key = urandom(16)
+        connData['Authenticated'] = True
+        connData['SignatureEnabled'] = False
+        connData['SessionEncryptionKey'] = key
+        connData['SessionDecryptionKey'] = key
+        connData['CipherId'] = smb2.SMB2_ENCRYPTION_AES128_GCM
+        connData['EncryptData'] = True
+        connData['Dialect'] = smb2.SMB2_DIALECT_311
+        connData['Uid'] = 0x99
+        self.server.setConnectionData(self.conn_id, connData)
+
+        def echoRequest(messageId):
+            packet = smb2.SMB2Packet()
+            packet['Command'] = smb2.SMB2_ECHO
+            packet['MessageID'] = messageId
+            packet['CreditCharge'] = 1
+            packet['CreditRequestResponse'] = 1
+            packet['Data'] = smb2.SMB2Echo()
+            return packet
+
+        first = echoRequest(0)
+        firstBytes = first.getData()
+        padLen = (-len(firstBytes)) % 8
+        first['NextCommand'] = len(firstBytes) + padLen
+        firstBytes = first.getData() + padLen * b'\x00'
+
+        secondBytes = echoRequest(1).getData()
+
+        responses = self.server.processRequest(self.conn_id, firstBytes + secondBytes)
+
+        self.assertEqual(len(responses), 1)
+        self.assertEqual(responses[0][:4], b'\xfdSMB')
+
+        plainText = self.server._decryptSMB3(self.conn_id, responses[0])
+        firstResponse = smb2.SMB2Packet(plainText)
+        self.assertEqual(firstResponse['Command'], smb2.SMB2_ECHO)
+        self.assertNotEqual(firstResponse['NextCommand'], 0)
+
+        secondResponse = smb2.SMB2Packet(plainText[firstResponse['NextCommand']:])
+        self.assertEqual(secondResponse['Command'], smb2.SMB2_ECHO)
+
+    def test_encrypted_logoff_response_keeps_the_real_session_id(self):
+        """smb2Logoff() clears connData['Uid'] before the response is encrypted later in
+        processRequest, so an encrypted LOGOFF response used to carry SessionId 0 in its
+        transform header instead of the session that was actually logged off.
+        """
+        sessionId = 0x1122334455667788
+        connData = self._connData()
+        key = urandom(16)
+        connData['Authenticated'] = True
+        connData['SignatureEnabled'] = False
+        connData['SessionEncryptionKey'] = key
+        connData['SessionDecryptionKey'] = key
+        connData['CipherId'] = smb2.SMB2_ENCRYPTION_AES128_GCM
+        connData['EncryptData'] = True
+        connData['Dialect'] = smb2.SMB2_DIALECT_311
+        connData['Uid'] = sessionId
+        self.server.setConnectionData(self.conn_id, connData)
+
+        logoffRequest = smb2.SMB2Packet()
+        logoffRequest['Command'] = smb2.SMB2_LOGOFF
+        logoffRequest['MessageID'] = 0
+        logoffRequest['SessionID'] = sessionId
+        logoffRequest['Data'] = smb2.SMB2Logoff()
+
+        responses = self.server.processRequest(self.conn_id, logoffRequest.getData())
+
+        self.assertEqual(len(responses), 1)
+        self.assertEqual(responses[0][:4], b'\xfdSMB')
+
+        # connData['Uid'] is 0 by now (smb2Logoff already cleared it), so the transform
+        # header is checked directly rather than through _decryptSMB3's own session
+        # lookup, which is written for validating incoming requests against live sessions.
+        transform = smb2.SMB2_TRANSFORM_HEADER(responses[0])
+        self.assertEqual(transform['SessionID'], sessionId)
+        self.assertEqual(self._connData()['Uid'], 0)
 
 
 if __name__ == "__main__":

--- a/tests/SMB_RPC/test_smbserver.py
+++ b/tests/SMB_RPC/test_smbserver.py
@@ -690,6 +690,7 @@ class SimpleSMBServer2FuncTestsClientFallBack(SimpleSMBServerFuncTests):
 class SimpleSMBServer2FuncTests(SimpleSMBServerFuncTests):
 
     server_smb2_support = True
+    client_preferred_dialect = smb2.SMB2_DIALECT_002
 
     # When listing files in a share, SMB2 response doesn't include "." and ".."
     share_list = [SimpleSMBServerFuncTests.share_file,
@@ -726,6 +727,11 @@ class SimpleSMBServer2FuncTests(SimpleSMBServerFuncTests):
             client.deleteDirectory(self.share_name, "unexistent")
 
         client.close()
+
+
+class SimpleSMBServer21FuncTests(SimpleSMBServer2FuncTests):
+
+    client_preferred_dialect = smb2.SMB2_DIALECT_21
 
 
 class SimpleSMBServer311FuncTests(SimpleSMBServer2FuncTests):


### PR DESCRIPTION
Hello maintainers 👋

Closes #1981.
Closes #1829.

`smbserver.py` only negotiated SMB 2.0.2 regardless of what the client offered. This PR adds real SMB 3.1.1 support on the server side.

**What this PR does:**

- Dialect selection: the server now picks the best common dialect from what the client offers (`0x0311 > 0x0210 > 0x0202`). When an SMB1 negotiate arrives with `SMB 2.???`, the server responds with the wildcard dialect so the client sends a proper SMB2 negotiate, which can then land on 3.1.1.

- Negotiate contexts: for dialect 3.1.1 the server appends `SMB2_PREAUTH_INTEGRITY_CAPABILITIES` (SHA-512, no salt) and `SMB2_ENCRYPTION_CAPABILITIES` (AES-128-GCM preferred, AES-128-CCM fallback) to the negotiate response.

- Pre-authentication integrity hash: the server maintains a connection-level pre-auth hash across the negotiate exchange and forks it into a session-level hash at session setup, updating it with each request/response pair.

- Signing key derivation: once authentication succeeds the raw session key is replaced by the SP 800-108 counter-mode KBKDF output (`label="SMBSigningKey\x00"`, `context=session pre-auth hash`, `L=128`).

- AES-CMAC signing: a new `signSMBv3` method signs outgoing packets with AES-CMAC instead of HMAC-SHA256, as required for the SMB 3.x dialect family.

- Session encryption: when the client offers encryption ciphers, the server derives `SessionEncryptionKey` and `SessionDecryptionKey` via KBKDF, sets `SMB2_SESSION_FLAG_ENCRYPT_DATA` in the session setup response, and wraps all subsequent traffic in `SMB2_TRANSFORM_HEADER` (AES-128-GCM or AES-128-CCM). Incoming encrypted packets are decrypted before processing.

The `validateNegotiateInfo` response now echoes back the negotiated dialect instead of always returning `0x0202`.

Best regards