### PR TITLE
Check cached TGT matches requested user in getST.py

### DIFF
--- a/examples/getST.py
+++ b/examples/getST.py
@@ -782,25 +782,20 @@ class GETST:
         tgt = None
 
         # Do we have a TGT cached?
-        domain, _, TGT, _ = CCache.parseFile(self.__domain)
-
+        domain, username, TGT, _ = CCache.parseFile(self.__domain)
 
         if TGT is not None:
-            expectedUser = Principal((self.__user, self.__domain.upper()), type=constants.PrincipalNameType.NT_UNKNOWN.value)
-            cachedUser = TGT['client']
-
-            # Ignore principal type; only verify the requested user within the selected realm.
-            if expectedUser != cachedUser:
+            if self.__user.lower() != username.lower():
                 logging.warning(
-                    "Cached TGT belongs to '%s', "
-                    "but the requested principal is '%s@%s'. "
+                    "Cached TGT belongs to '%s@%s', "
+                    "but the requested principal is for '%s@%s'. "
                     "Ignoring cached TGT and requesting a new one.",
-                    cachedUser, self.__user, self.__domain
+                    username, domain, self.__user, self.__domain
                 )
             else:
                 tgt, cipher, sessionKey = TGT['KDC_REP'], TGT['cipher'], TGT['sessionKey']
                 oldSessionKey = sessionKey
-            
+
         if tgt is None:
             # Still no TGT
             userName = Principal(self.__user, type=constants.PrincipalNameType.NT_PRINCIPAL.value)

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -784,10 +784,22 @@ class GETST:
         # Do we have a TGT cached?
         domain, _, TGT, _ = CCache.parseFile(self.__domain)
 
-        # ToDo: Check this TGT belogns to the right principal
+
         if TGT is not None:
-            tgt, cipher, sessionKey = TGT['KDC_REP'], TGT['cipher'], TGT['sessionKey']
-            oldSessionKey = sessionKey
+            expectedUser = Principal((self.__user, self.__domain.upper()), type=constants.PrincipalNameType.NT_UNKNOWN.value)
+            cachedUser = TGT['client']
+
+            # Ignore principal type; only verify the requested user within the selected realm.
+            if expectedUser != cachedUser:
+                logging.warning(
+                    "Cached TGT belongs to '%s', "
+                    "but the requested principal is '%s@%s'. "
+                    "Ignoring cached TGT and requesting a new one.",
+                    cachedUser, self.__user, self.__domain
+                )
+            else:
+                tgt, cipher, sessionKey = TGT['KDC_REP'], TGT['cipher'], TGT['sessionKey']
+                oldSessionKey = sessionKey
             
         if tgt is None:
             # Still no TGT

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -782,15 +782,22 @@ class GETST:
         tgt = None
 
         # Do we have a TGT cached?
-        domain, username, TGT, _ = CCache.parseFile(self.__domain)
+        domain, _, TGT, _ = CCache.parseFile(self.__domain)
 
         if TGT is not None:
-            if self.__user.lower() != username.lower():
+            cachedClientPrincipal = TGT['client']
+            cachedUser = cachedClientPrincipal.components[0]['data'].decode('utf-8')
+            cachedDomain = cachedClientPrincipal.realm['data'].decode('utf-8')
+
+            if (self.__user.lower() != cachedUser.lower()) or (self.__domain.lower() != cachedDomain.lower()):
                 logging.warning(
                     "Cached TGT belongs to '%s@%s', "
-                    "but the requested principal is for '%s@%s'. "
+                    "but the requested principal is '%s@%s'. "
                     "Ignoring cached TGT and requesting a new one.",
-                    username, domain, self.__user, self.__domain
+                    cachedUser,
+                    cachedDomain,
+                    self.__user,
+                    self.__domain,
                 )
             else:
                 tgt, cipher, sessionKey = TGT['KDC_REP'], TGT['cipher'], TGT['sessionKey']

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -786,7 +786,7 @@ class GETST:
 
         if TGT is not None:
             cachedClientPrincipal = TGT['client']
-            cachedUser = cachedClientPrincipal.components[0]['data'].decode('utf-8')
+            cachedUser = "/".join(component["data"].decode("utf-8") for component in cachedClientPrincipal.components)
             cachedDomain = cachedClientPrincipal.realm['data'].decode('utf-8')
 
             if (self.__user.lower() != cachedUser.lower()) or (self.__domain.lower() != cachedDomain.lower()):

--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -321,6 +321,7 @@ class Credential:
         tgt['KDC_REP'] = encoder.encode(tgt_rep)
         tgt['cipher'] = cipher
         tgt['sessionKey'] = crypto.Key(cipher.enctype, self['key']['keyvalue'])
+        tgt['client'] = self['client']
         return tgt
 
     def toTGS(self, newSPN=None):


### PR DESCRIPTION
Cached Kerberos TGTs are only reused when they belong to the same principal requested via the CLI. 

Previously, getST.py reused a cached TGT based only on realm/domain resolution from CCache.parseFile(), without validating that the cached credential belonged to the requested username. 

This could result in incorrect credential reuse when multiple principals exist within the same realm. 

This change adds a principal equality check using impacket.krb5.types.Principal, ensuring both username and realm match before reusing a cached TGT.

* Add principal-level validation for cached TGT reuse in getST.py
* Invalidate cached TGT when username does not match requested principal
* Fall back to requesting a new TGT when mismatch is detected