### PR TITLE
Fix AttributeError when parsing a credential with auth data

### DIFF
--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -215,8 +215,8 @@ class Credential:
         )
 
     def __init__(self, data=None, ccache_version=None):
-        self.addresses = ()
-        self.authData = ()
+        self.addresses = []
+        self.authData = []
         self.header = None
         self.ticket = None
         self.secondTicket = None
@@ -228,14 +228,12 @@ class Credential:
                 self.header = self.CredentialHeaderV4(data)
 
             data = data[len(self.header):]
-            self.addresses = []
             for address in range(self.header['num_address']):
                 ad = Address(data)
                 data = data[len(ad):]
                 self.addresses.append(ad)
             num_authdata = unpack('!L', data[:4])[0]
             data = data[calcsize('!L'):]
-            self.authData = []
             for authdata in range(num_authdata):
                 ad = AuthData(data)
                 data = data[len(ad):]

--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -235,6 +235,7 @@ class Credential:
                 self.addresses.append(ad)
             num_authdata = unpack('!L', data[:4])[0]
             data = data[calcsize('!L'):]
+            self.authData = []
             for authdata in range(num_authdata):
                 ad = AuthData(data)
                 data = data[len(ad):]

--- a/tests/misc/test_ccache.py
+++ b/tests/misc/test_ccache.py
@@ -21,7 +21,7 @@ if PY2:
     FileNotFoundError = IOError
 else:
     from unittest import mock
-from impacket.krb5.ccache import CCache, Credential
+from impacket.krb5.ccache import AuthData, CCache, CountedOctetString, Credential
 
 
 class CCACHETests(unittest.TestCase):
@@ -115,6 +115,28 @@ class CCACHETests(unittest.TestCase):
                 self.assertEqual(username, self.username)
                 self.assertIsNone(TGS)
                 self.assertIsNotNone(TGT)
+
+    def test_credential_with_authdata_roundtrip(self):
+        # Regression test for a credential that carries authorization data.
+        # Credential.authData started as a tuple and was never turned into a
+        # list, so parsing any credential with auth-data raised
+        # AttributeError: 'tuple' object has no attribute 'append'.
+        ccache = CCache.loadFile(self.cache_v4_file)
+        cred = ccache.credentials[0]
+
+        octet = CountedOctetString()
+        octet["data"] = b"\xde\xad\xbe\xef"
+        octet["length"] = len(octet["data"])
+        ad = AuthData()
+        ad["authtype"] = 1
+        ad["authdata"] = octet
+        cred.authData = [ad]
+
+        reparsed = Credential(cred.getData())
+
+        self.assertEqual(len(reparsed.authData), 1)
+        self.assertEqual(reparsed.authData[0]["authtype"], 1)
+        self.assertEqual(reparsed.authData[0]["authdata"]["data"], b"\xde\xad\xbe\xef")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem
`Credential.authData` is initialized as a tuple `()` and, unlike `addresses`, is never reassigned to a list before the parse loop runs `self.authData.append(ad)`. Parsing any ccache credential that carries authorization data therefore raises:

`AttributeError: 'tuple' object has no attribute 'append'` (in `Credential.__init__`, `impacket/krb5/ccache.py`).

Closes #2119.

## Fix
Initialize `self.authData = []` right before the auth-data loop, mirroring the existing `self.addresses = []` line a few lines above. Note: the issue also mentions `addresses`, but that attribute is already reassigned to a list before its own loop, so only `authData` was affected.

## Test
Added a regression test in `tests/misc/test_ccache.py` that attaches an auth-data entry to a credential, serializes it, and parses it back. It fails on the current code with the AttributeError and passes with the fix. Full `tests/misc/test_ccache.py`: 6 passed.