### PR TITLE
Add SMB_302 to possible SMB3 dialects

### DIFF
--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -25,7 +25,7 @@ from impacket.ntlm import compute_lmhash, compute_nthash
 # Propagated imports to clients.
 ## Dialects.
 from impacket.smb import SMB_DIALECT
-from impacket.smb3structs import SMB2_DIALECT_002, SMB2_DIALECT_21, SMB2_DIALECT_30, SMB2_DIALECT_311
+from impacket.smb3structs import SMB2_DIALECT_002, SMB2_DIALECT_21, SMB2_DIALECT_30, SMB2_DIALECT_302, SMB2_DIALECT_311
 
 ## Create Disposition.
 from impacket.smb import FILE_OPEN, FILE_OVERWRITE, FILE_OVERWRITE_IF
@@ -147,7 +147,7 @@ class SMBConnection:
             if preferredDialect == smb.SMB_DIALECT:
                 self._SMBConnection = smb.SMB(self._remoteName, self._remoteHost, self._myName, hostType,
                                               self._sess_port, self._timeout)
-            elif preferredDialect in [SMB2_DIALECT_002, SMB2_DIALECT_21, SMB2_DIALECT_30, SMB2_DIALECT_311]:
+            elif preferredDialect in [SMB2_DIALECT_002, SMB2_DIALECT_21, SMB2_DIALECT_30, SMB2_DIALECT_302, SMB2_DIALECT_311]:
                 self._SMBConnection = smb3.SMB3(self._remoteName, self._remoteHost, self._myName, hostType,
                                                 self._sess_port, self._timeout, preferredDialect=preferredDialect)
             else:


### PR DESCRIPTION
With commit https://github.com/fortra/impacket/commit/8f8172055c12d7c219c633a21fc74e2bd9aa1371 impacket will automatically negotiate SMB 3.1.1 which enforces signing. Since in NetExec we would still use unsigned SMB connections (e.g. for signing enforcement enumeration, see https://github.com/Pennyw0rth/NetExec/issues/1292) I would like to be able to specify the latest non-signing required SMB dialect which is SMB 3.0.2. However, currently this is simply missing in the options to create an SMB3 connection and therefore fails.

Keep in mind that https://github.com/fortra/impacket/commit/8f8172055c12d7c219c633a21fc74e2bd9aa1371 might also has affected impacket scripts or the relay server, but haven't tested those specifically.

Before&After:
<img width="1580" height="623" alt="image" src="https://github.com/user-attachments/assets/4a12d5a9-56b0-45a0-bac6-24c2d2926628" />
