### PR TITLE
Add ntlmrelayx option to choose LDAP computer account container

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -195,7 +195,7 @@ def start_servers(options, threads):
         c.setLootdir(options.lootdir)
         c.setOutputFile(options.output_file)
         c.setdumpHashes(options.dump_hashes)
-        c.setLDAPOptions(options.no_dump, options.no_da, options.no_acl, options.no_validate_privs, options.escalate_user, options.add_computer, options.delegate_access, options.dump_laps, options.dump_gmsa, options.dump_adcs, options.sid, options.add_dns_record)
+        c.setLDAPOptions(options.no_dump, options.no_da, options.no_acl, options.no_validate_privs, options.escalate_user, options.add_computer, options.add_computer_container, options.delegate_access, options.dump_laps, options.dump_gmsa, options.dump_adcs, options.sid, options.add_dns_record)
         c.setRPCOptions(options.rpc_mode, options.rpc_use_smb, options.auth_smb, options.hashes_smb, options.rpc_smb_port, options.icpr_ca_name)
         c.setMSSQLOptions(options.query)
         c.setInteractive(options.interactive)
@@ -405,6 +405,8 @@ if __name__ == '__main__':
     commonoptions = parser.add_argument_group("Common options for SMB and LDAP")
     commonoptions.add_argument('--add-computer', action='store', metavar=('COMPUTERNAME', 'PASSWORD'), required=False, nargs='*', help='Attempt to add a new computer account via SMB or LDAP, depending on the specified target. '
         'This argument can be used either with the LDAP or the SMB service, as long as the target is a domain controller.')
+    commonoptions.add_argument('--add-computer-container', action='store', required=False, help='LDAP parent DN where the new computer account will be created when using --add-computer. '
+        'If omitted, the domain default computer container will be used.')
 
     #IMAP options
     imapoptions = parser.add_argument_group("IMAP client options")

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -124,6 +124,18 @@ class LDAPAttack(ProtocolAttack):
             # Launch locally listening interactive shell.
             self.tcp_shell = TcpShell()
 
+    def getComputerContainer(self, domainDumper):
+        if self.config.addcomputercontainer is not None:
+            return self.config.addcomputercontainer
+
+        self.client.search(domainDumper.root, "(ObjectClass=domain)", attributes=['wellKnownObjects'])
+        # Computer well-known GUID
+        # https://social.technet.microsoft.com/Forums/windowsserver/en-US/d028952f-a25a-42e6-99c5-28beae2d3ac3/how-can-i-know-the-default-computer-container?forum=winservergen
+        return [
+            entry.decode('utf-8').split(":")[-1] for entry in self.client.entries[0]["wellKnownObjects"]
+            if b"AA312825768811D1ADED00C04FD8D5CD" in entry
+        ][0]
+
     def addComputer(self, parent, domainDumper):
         """
         Add a new computer. Parent is preferably CN=computers,DC=Domain,DC=local, but can
@@ -1108,13 +1120,7 @@ class LDAPAttack(ProtocolAttack):
         # Add a new computer if that is requested
         # privileges required are not yet enumerated, neither is ms-ds-MachineAccountQuota
         if self.config.addcomputer is not None:
-            self.client.search(domainDumper.root, "(ObjectClass=domain)", attributes=['wellKnownObjects'])
-            # Computer well-known GUID
-            # https://social.technet.microsoft.com/Forums/windowsserver/en-US/d028952f-a25a-42e6-99c5-28beae2d3ac3/how-can-i-know-the-default-computer-container?forum=winservergen
-            computerscontainer = [
-                entry.decode('utf-8').split(":")[-1] for entry in self.client.entries[0]["wellKnownObjects"]
-                if b"AA312825768811D1ADED00C04FD8D5CD" in entry
-            ][0]
+            computerscontainer = self.getComputerContainer(domainDumper)
             LOG.debug("Computer container is {}".format(computerscontainer))
             self.addComputer(computerscontainer, domainDumper)
 

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -78,6 +78,8 @@ class NTLMRelayxConfig:
         self.aclattack = True
         self.validateprivs = True
         self.escalateuser = None
+        self.addcomputer = None
+        self.addcomputercontainer = None
 
         # MSSQL options
         self.queries = []
@@ -193,13 +195,14 @@ class NTLMRelayxConfig:
     def setRandomTargets(self, randomtargets):
         self.randomtargets = randomtargets
 
-    def setLDAPOptions(self, dumpdomain, addda, aclattack, validateprivs, escalateuser, addcomputer, delegateaccess, dumplaps, dumpgmsa, dumpadcs, sid, adddnsrecord):
+    def setLDAPOptions(self, dumpdomain, addda, aclattack, validateprivs, escalateuser, addcomputer, addcomputercontainer, delegateaccess, dumplaps, dumpgmsa, dumpadcs, sid, adddnsrecord):
         self.dumpdomain = dumpdomain
         self.addda = addda
         self.aclattack = aclattack
         self.validateprivs = validateprivs
         self.escalateuser = escalateuser
         self.addcomputer = addcomputer
+        self.addcomputercontainer = addcomputercontainer
         self.delegateaccess = delegateaccess
         self.dumplaps = dumplaps
         self.dumpgmsa = dumpgmsa

--- a/tests/misc/test_ntlmrelayx_ldapattack.py
+++ b/tests/misc/test_ntlmrelayx_ldapattack.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright Fortra, LLC and its affiliated companies
+#
+# All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+
+import unittest
+from unittest import mock
+
+from impacket.examples.ntlmrelayx.attacks.ldapattack import LDAPAttack
+
+
+class _DomainDumper:
+    root = "DC=example,DC=com"
+
+
+class LDAPAttackTests(unittest.TestCase):
+    def test_get_computer_container_uses_configured_container(self):
+        attack = LDAPAttack.__new__(LDAPAttack)
+        attack.config = mock.Mock(addcomputercontainer="OU=Workstations,DC=example,DC=com")
+        attack.client = mock.Mock()
+
+        self.assertEqual(
+            attack.getComputerContainer(_DomainDumper()),
+            "OU=Workstations,DC=example,DC=com",
+        )
+        attack.client.search.assert_not_called()
+
+    def test_get_computer_container_falls_back_to_default_container(self):
+        attack = LDAPAttack.__new__(LDAPAttack)
+        attack.config = mock.Mock(addcomputercontainer=None)
+        attack.client = mock.Mock()
+        attack.client.entries = [
+            {
+                "wellKnownObjects": [
+                    b"B:32:AA312825768811D1ADED00C04FD8D5CD:CN=Computers,DC=example,DC=com",
+                ],
+            },
+        ]
+
+        self.assertEqual(
+            attack.getComputerContainer(_DomainDumper()),
+            "CN=Computers,DC=example,DC=com",
+        )
+        attack.client.search.assert_called_once_with(
+            "DC=example,DC=com",
+            "(ObjectClass=domain)",
+            attributes=["wellKnownObjects"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)


### PR DESCRIPTION
Adds `--add-computer-container` to `ntlmrelayx.py` so LDAP `--add-computer` operations can create the machine account under a caller-specified parent DN instead of always using the domain default computer container.

If the new option is omitted, existing behavior is preserved: ntlmrelayx resolves the default computer container from the domain `wellKnownObjects` value.

This option is used by the LDAP attack path only. SMB/SAMR computer creation behavior is unchanged.

Example:

```bash
ntlmrelayx.py -t ldap://dc.example.com --add-computer HOST01 Password123! \
  --add-computer-container 'OU=Workstations,DC=example,DC=com'
```

Reviewer notes:
- The value is a parent distinguished name, so both OUs and other valid LDAP containers are supported.
- Existing behavior is preserved when the option is not supplied.
- The `addComputer()` method already accepted a parent container; this change exposes that existing capability through CLI/config plumbing.

Tests added for:
- using a configured computer container
- falling back to the default `wellKnownObjects` computer container

Verification:

```bash
.venv/bin/python -m py_compile examples/ntlmrelayx.py impacket/examples/ntlmrelayx/utils/config.py impacket/examples/ntlmrelayx/attacks/ldapattack.py tests/misc/test_ntlmrelayx_ldapattack.py
.venv/bin/python -m unittest tests.misc.test_ntlmrelayx_ldapattack
```
