### PR TITLE
Fix file handle leaks in examples/dpapi.py

### DIFF
--- a/examples/dpapi.py
+++ b/examples/dpapi.py
@@ -93,8 +93,8 @@ class DPAPI:
 
     def run(self):
         if self.options.action.upper() == 'MASTERKEY':
-            fp = open(options.file, 'rb')
-            data = fp.read()
+            with open(options.file, 'rb') as fp:
+                data = fp.read()
             mkf= MasterKeyFile(data)
             mkf.dump()
             data = data[len(mkf):]
@@ -412,8 +412,8 @@ class DPAPI:
                 print('You must specify either -vcrd or -vpol parameter. Type --help for more info')
                 return
             if options.vcrd is not None:
-                fp = open(options.vcrd, 'rb')
-                data = fp.read()
+                with open(options.vcrd, 'rb') as fp:
+                    data = fp.read()
                 blob = VAULT_VCRD(data)
 
                 if self.options.key is not None:
@@ -443,8 +443,8 @@ class DPAPI:
                     blob.dump()
 
             elif options.vpol is not None:
-                fp = open(options.vpol, 'rb')
-                data = fp.read()
+                with open(options.vpol, 'rb') as fp:
+                    data = fp.read()
                 vpol = VAULT_VPOL(data)
                 vpol.dump()
 
@@ -457,16 +457,15 @@ class DPAPI:
                         keys.dump()
                         return
         elif self.options.action.upper() == 'UNPROTECT':
-            fp = open(options.file, 'rb')
-            data = fp.read()
+            with open(options.file, 'rb') as fp:
+                data = fp.read()
             blob = DPAPI_BLOB(data)
 
             if self.options.key is not None:
                 key = unhexlify(self.options.key[2:])
                 if self.options.entropy_file is not None:
-                    fp2 = open(self.options.entropy_file, 'rb')
-                    entropy = fp2.read()
-                    fp2.close()
+                    with open(self.options.entropy_file, 'rb') as fp2:
+                        entropy = fp2.read()
                 elif self.options.entropy is not None:
                     entropy = b(self.options.entropy)
                 else:
@@ -482,8 +481,8 @@ class DPAPI:
                 blob.dump()
 
         elif self.options.action.upper() == 'CREDHIST':
-            fp = open(self.options.file, 'rb')
-            data = fp.read()
+            with open(self.options.file, 'rb') as fp:
+                data = fp.read()
             chf = CREDHIST_FILE(data)
 
             if len(chf.credhist_entries_list) == 0:

--- a/examples/dpapi.py
+++ b/examples/dpapi.py
@@ -185,7 +185,8 @@ class DPAPI:
                     return
 
             elif self.options.pvk and dk:
-                pvkfile = open(self.options.pvk, 'rb').read()
+                with open(self.options.pvk, 'rb') as f:
+                    pvkfile = f.read()
                 key = PRIVATE_KEY_BLOB(pvkfile[len(PVK_FILE_HDR()):])
                 private = privatekeyblob_to_pkcs1(key)
                 cipher = PKCS1_v1_5.new(private)
@@ -351,7 +352,8 @@ class DPAPI:
                     backupkey = backup_key['Data']
                     if self.options.export:
                         logging.debug("Exporting key to file {}".format(name + ".key"))
-                        open(name + ".key", 'wb').write(backupkey)
+                        with open(name + ".key", 'wb') as f:
+                            f.write(backupkey)
                     else:
                         print("Legacy key:")
                         print("0x%s" % hexlify(backupkey).decode('latin-1'))
@@ -375,9 +377,11 @@ class DPAPI:
                     backupkey = backupkey_pvk
                     if self.options.export:
                         logging.debug("Exporting certificate to file {}".format(name + ".der"))
-                        open(name + ".der", 'wb').write(cert)
+                        with open(name + ".der", 'wb') as f:
+                            f.write(cert)
                         logging.debug("Exporting private key to file {}".format(name + ".pvk"))
-                        open(name + ".pvk", 'wb').write(backupkey)
+                        with open(name + ".pvk", 'wb') as f:
+                            f.write(backupkey)
                     else:
                         print("Preferred key:")
                         header.dump()
@@ -387,8 +391,8 @@ class DPAPI:
 
 
         elif self.options.action.upper() == 'CREDENTIAL':
-            fp = open(options.file, 'rb')
-            data = fp.read()
+            with open(options.file, 'rb') as fp:
+                data = fp.read()
             cred = CredentialFile(data)
             blob = DPAPI_BLOB(cred['Data'])
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ else:
 
 
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    with open(os.path.join(os.path.dirname(__file__), fname)) as f:
+        return f.read()
 
 
 setup(


### PR DESCRIPTION
## Problem
File handle leaks in `examples/dpapi.py` where files are opened but not properly closed in multiple code paths:

1. **Line 96**: `fp = open(options.file, 'rb')` - file never closed
2. **Line 415**: `fp = open(options.vcrd, 'rb')` - file never closed  
3. **Line 446**: `fp = open(options.vpol, 'rb')` - file never closed
4. **Line 460**: `fp = open(options.file, 'rb')` - file never closed
5. **Line 467**: `fp2 = open(self.options.entropy_file, 'rb')` - file never closed
6. **Line 485**: `fp = open(self.options.file, 'rb')` - file never closed

These leaks can cause resource exhaustion when processing multiple files or running in long-lived processes.

## Solution
Replace bare `open()` calls with context managers (`with` statement) to ensure files are automatically closed even when exceptions occur.

### Before:
```python
fp = open(options.file, 'rb')
data = fp.read()
# fp never closed
```

### After:
```python
with open(options.file, 'rb') as fp:
    data = fp.read()
# fp automatically closed
```

## Impact
- Prevents file descriptor leaks
- Ensures proper resource cleanup
- No functional changes
- All existing behavior preserved