### PR TITLE
fix: change ccache.py Credential addresses/authData init from tuple to list

### DIFF
--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -215,8 +215,8 @@ class Credential:
         )
 
     def __init__(self, data=None, ccache_version=None):
-        self.addresses = ()
-        self.authData = ()
+        self.addresses = []
+        self.authData = []
         self.header = None
         self.ticket = None
         self.secondTicket = None


### PR DESCRIPTION
Fixes #2119. Tuple () initializers on self.addresses and self.authData cause AttributeError when .append() is called later during parsing.