### PR TITLE
Fix bare except clauses in impacket/ntlm.py

### DIFF
--- a/impacket/ntlm.py
+++ b/impacket/ntlm.py
@@ -601,11 +601,11 @@ def getNTLMSSPType1(workstation='', domain='', signingRequired = False, use_ntlm
     if encoding is not None:
         try:
             workstation.encode('utf-16le')
-        except:
+        except (UnicodeEncodeError, AttributeError):
             workstation = workstation.decode(encoding)
         try:
             domain.encode('utf-16le')
-        except:
+        except (UnicodeEncodeError, AttributeError):
             domain = domain.decode(encoding)
 
     # Let's prepare a Type 1 NTLMSSP Message
@@ -642,15 +642,15 @@ def getNTLMSSPType3(type1, type2, user, password, domain, lmhash = '', nthash = 
     if encoding is not None:
         try:
             user.encode('utf-16le')
-        except:
+        except (UnicodeEncodeError, AttributeError):
             user = user.decode(encoding)
         try:
             password.encode('utf-16le')
-        except:
+        except (UnicodeEncodeError, AttributeError):
             password = password.decode(encoding)
         try:
             domain.encode('utf-16le')
-        except:
+        except (UnicodeEncodeError, AttributeError):
             domain = user.decode(encoding)
 
     ntlmChallenge = NTLMAuthChallenge(type2)


### PR DESCRIPTION
Replace bare `except:` clauses with `except (UnicodeEncodeError, AttributeError):` in `impacket/ntlm.py`.

Bare `except:` catches `BaseException` including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which is almost never intentional. All five instances here guard `str.encode('utf-16le')` calls — the only exceptions that can be raised are `UnicodeEncodeError` (when a byte string can't be re-encoded) or `AttributeError` (when the object lacks an `encode` method).

Changes in `impacket/ntlm.py`:
- Line 604: workstation utf-16le encoding check
- Line 608: domain utf-16le encoding check  
- Line 645: user utf-16le encoding check
- Line 649: password utf-16le encoding check
- Line 653: domain utf-16le encoding check (authenticate message)