### PR TITLE
Fix ST Request When Using RC4 TGT Against AES_only

### DIFF
--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -453,7 +453,23 @@ def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey, renew =
 
     message = encoder.encode(tgsReq)
 
-    r = sendReceive(message, domain, kdcHost)
+    try:
+        r = sendReceive(message, domain, kdcHost)
+    except KerberosError as e:
+        # The requested etypes (derived from the TGT session key) are not supported by the
+        # target service, e.g. an RC4 TGT against an AES-only account. Retry advertising AES
+        # so a valid TGT can still obtain a ticket (RC4-capable targets already succeeded above,
+        # so this preserves the RC4 preference and only kicks in when RC4 is refused).
+        if e.getErrorCode() != constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
+            raise
+        seq_set_iter(reqBody, 'etype',
+                          (
+                              int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value),
+                              int(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value),
+                          )
+                    )
+        message = encoder.encode(tgsReq)
+        r = sendReceive(message, domain, kdcHost)
 
     # Get the session key
 


### PR DESCRIPTION
I ran into this during a live engagement while kerberoasting over LDAP with NetExec (PR https://github.com/Pennyw0rth/NetExec/pull/1316) and Impacket against a Windows Server 2022 DC. The service-ticket request kept failing with:

`Kerberos SessionError: KDC_ERR_ETYPE_NOSUPP (KDC has no support for encryption type)`
and no ticket was returned. 
<img width="3292" height="222" alt="image" src="https://github.com/user-attachments/assets/1af15f2b-8443-47d5-8461-74203a960d74" />
<img width="3088" height="1294" alt="image" src="https://github.com/user-attachments/assets/eaab32ba-d35d-4863-967e-a7fcb638b626" />


The target account's `msDS-SupportedEncryptionTypes` was 0 (unset), so at first this looked odd but after tracing it end-to-end I found the root cause.
<img width="2036" height="258" alt="image" src="https://github.com/user-attachments/assets/0cf04fa9-0f39-4764-aadd-39efedd28fb4" />


I traced it with stock Impacket against the live DC:

AS-REQ, NT hash (RC4 TGT)     -> TGT GRANTED, session-key etype = 23 (rc4)
AS-REQ, cleartext (AES TGT)   -> TGT GRANTED, session-key etype = 18 (aes256)
TGS-REQ 'target', RC4 TGT     -> DENIED: KDC_ERR_ETYPE_NOSUPP   (req etypes: 23,16,3)
TGS-REQ 'target', AES TGT     -> GRANTED, ticket enc-part etype = 18 (aes256)

The failure is not at the TGT step. The RC4 TGT is granted fine (it belongs to my authenticating account, which still supports RC4). The break is at the service-ticket step, because `getKerberosTGS` builds its req-body etype list from a fixed set plus the TGT session-key cipher:
<img width="1634" height="446" alt="image" src="https://github.com/user-attachments/assets/d82fe7f0-9307-435f-8ff0-033130a37837" />

AES only ever enters this list through cipher.enctype. With an RC4 TGT (cipher.enctype = 23) the advertised etypes are effectively {rc4, des3, des} no AES. 

When the target service account is AES-only, the KDC has nothing to match and returns KDC_ERR_ETYPE_NOSUPP, even though the TGT is perfectly valid. So a valid TGT cannot reach an AES-only service whenever its session key is RC4 (e.g. an RC4-derived TGT from an NT hash, or a deliberately-requested RC4 TGT).
<img width="3044" height="1222" alt="image" src="https://github.com/user-attachments/assets/aab06dcf-8d5a-40ae-8767-afec8a34ff91" />

And Then it returns KDC_ERR_ETYPE_NOSUPP
<img width="3218" height="860" alt="image" src="https://github.com/user-attachments/assets/ce728594-3c13-4529-a01c-e755908e6290" />

Why the target refused RC4 despite msDS-SupportedEncryptionTypes = 0
This turned out to be Microsoft's RC4 hardening rollout (CVE-2026-20833): when an account's `msDS-SupportedEncryptionTypes` is unset/0, the KDC now defaults it to AES-only (0x18) (enforcement April 2026). So this isn't a misconfiguration or an edge case. It's becoming the default for patched domains, and any RC4-derived TGS-REQ will hit this more and more often.

After Fix on KDC_ERR_ETYPE_NOSUPP, retry the TGS-REQ advertising AES:
<img width="3028" height="1202" alt="image" src="https://github.com/user-attachments/assets/349c6780-f219-4855-a874-3d2212fe718e" />

<img width="2900" height="1300" alt="image" src="https://github.com/user-attachments/assets/ed50a871-cb20-422e-a36f-1a0df5f5e96d" />

<img width="3308" height="864" alt="image" src="https://github.com/user-attachments/assets/0bdc091c-5b82-4627-acd2-829b1d31ba4b" />
