### PR TITLE
Fix DCOM interface context loss after same-target disconnect + test

### DIFF
--- a/impacket/dcerpc/v5/dcomrt.py
+++ b/impacket/dcerpc/v5/dcomrt.py
@@ -1132,15 +1132,29 @@ class DCOMConnection:
         #print INTERFACE.CONNECTIONS
 
 class CLASS_INSTANCE:
-    def __init__(self, ORPCthis, stringBinding):
+    def __init__(self, ORPCthis, stringBinding, portmap=None):
         self.__stringBindings = stringBinding
         self.__ORPCthis = ORPCthis
         self.__authType = RPC_C_AUTHN_WINNT
         self.__authLevel = RPC_C_AUTHN_LEVEL_PKT_PRIVACY
+        self.__connectionInfo = None
+        if portmap is not None:
+            self.set_connection_info(portmap)
     def get_ORPCthis(self):
         return self.__ORPCthis
     def get_string_bindings(self):
         return self.__stringBindings
+    def set_connection_info(self, portmap):
+        rpcTransport = portmap.get_rpc_transport()
+        kerberos = rpcTransport.get_kerberos()
+        remoteHost = None
+        remoteName = None
+        if kerberos:
+            remoteHost = rpcTransport.getRemoteHost()
+            remoteName = rpcTransport.getRemoteName()
+        self.__connectionInfo = (portmap.get_credentials(), kerberos, rpcTransport.get_kdcHost(), remoteHost, remoteName)
+    def get_connection_info(self):
+        return self.__connectionInfo
     def get_auth_level(self):
         if RPC_C_AUTHN_LEVEL_NONE < self.__authLevel < RPC_C_AUTHN_LEVEL_PKT_PRIVACY:
             if self.__authType == RPC_C_AUTHN_WINNT:
@@ -1340,15 +1354,19 @@ class INTERFACE:
 
                 dcomInterface = transport.DCERPCTransportFactory(stringBinding)
 
-                if DCOMConnection.PORTMAPS[self.__target].get_rpc_transport().get_kerberos():
-                    dcomInterface.setRemoteHost(DCOMConnection.PORTMAPS[self.__target].get_rpc_transport().getRemoteHost())
-                    dcomInterface.setRemoteName(DCOMConnection.PORTMAPS[self.__target].get_rpc_transport().getRemoteName())
+                connectionInfo = self.__cinstance.get_connection_info()
+                if connectionInfo is None:
+                    self.__cinstance.set_connection_info(DCOMConnection.PORTMAPS[self.__target])
+                    connectionInfo = self.__cinstance.get_connection_info()
+                credentials, kerberos, kdcHost, remoteHost, remoteName = connectionInfo
+                if kerberos:
+                    dcomInterface.setRemoteHost(remoteHost)
+                    dcomInterface.setRemoteName(remoteName)
 
                 if hasattr(dcomInterface, 'set_credentials'):
                     # This method exists only for selected protocol sequences.
-                    dcomInterface.set_credentials(*DCOMConnection.PORTMAPS[self.__target].get_credentials())
-                    dcomInterface.set_kerberos(DCOMConnection.PORTMAPS[self.__target].get_rpc_transport().get_kerberos(),
-                                               DCOMConnection.PORTMAPS[self.__target].get_rpc_transport().get_kdcHost())
+                    dcomInterface.set_credentials(*credentials)
+                    dcomInterface.set_kerberos(kerberos, kdcHost)
                 dcomInterface.set_connect_timeout(300)
                 dce = dcomInterface.get_dce_rpc()
 
@@ -1640,7 +1658,7 @@ class IActivation:
                 secBinding = SECURITYBINDING(securityBindings)
                 securityBindings = securityBindings[len(secBinding):]
 
-        classInstance = CLASS_INSTANCE(ORPCthis, stringBindings)
+        classInstance = CLASS_INSTANCE(ORPCthis, stringBindings, self.__portmap)
         return IRemUnknown2(INTERFACE(classInstance, b''.join(resp['ppInterfaceData'][0]['abData']), ipidRemUnknown,
                                       target=self.__portmap.get_rpc_transport().getRemoteName()))
 
@@ -1804,7 +1822,7 @@ class IRemoteSCMActivator:
         size = propsOut.fromString(propOutput)
         propsOut.fromStringReferents(propOutput[size:])
 
-        classInstance = CLASS_INSTANCE(ORPCthis, stringBindings)
+        classInstance = CLASS_INSTANCE(ORPCthis, stringBindings, self.__portmap)
         classInstance.set_auth_level(scmr['remoteReply']['authnHint'])
         classInstance.set_auth_type(self.__portmap.get_auth_type())
         return IRemUnknown2(INTERFACE(classInstance, b''.join(propsOut['ppIntfData'][0]['abData']), ipidRemUnknown,
@@ -1968,7 +1986,7 @@ class IRemoteSCMActivator:
         size = propsOut.fromString(propOutput)
         propsOut.fromStringReferents(propOutput[size:])
 
-        classInstance = CLASS_INSTANCE(ORPCthis, stringBindings)
+        classInstance = CLASS_INSTANCE(ORPCthis, stringBindings, self.__portmap)
         classInstance.set_auth_level(scmr['remoteReply']['authnHint'])
         classInstance.set_auth_type(self.__portmap.get_auth_type())
         return IRemUnknown2(INTERFACE(classInstance, b''.join(propsOut['ppIntfData'][0]['abData']), ipidRemUnknown,

--- a/tests/dcerpc/test_dcomrt.py
+++ b/tests/dcerpc/test_dcomrt.py
@@ -26,6 +26,7 @@ from __future__ import print_function
 
 import pytest
 import unittest
+from unittest.mock import Mock, patch
 from tests import RemoteTestCase
 from tests.dcerpc import DCERPCTests
 
@@ -36,6 +37,17 @@ from impacket.dcerpc.v5.dcom import scmp, vds, oaut, comev
 
 
 class InterfaceTests(unittest.TestCase):
+    def setUp(self):
+        self._portmaps = dcomrt.DCOMConnection.PORTMAPS.copy()
+        self._connections = dcomrt.INTERFACE.CONNECTIONS.copy()
+        dcomrt.DCOMConnection.PORTMAPS.clear()
+        dcomrt.INTERFACE.CONNECTIONS.clear()
+
+    def tearDown(self):
+        dcomrt.DCOMConnection.PORTMAPS.clear()
+        dcomrt.DCOMConnection.PORTMAPS.update(self._portmaps)
+        dcomrt.INTERFACE.CONNECTIONS.clear()
+        dcomrt.INTERFACE.CONNECTIONS.update(self._connections)
 
     def test_is_target_loopback(self):
         interface = dcomrt.INTERFACE.__new__(dcomrt.INTERFACE)
@@ -47,6 +59,49 @@ class InterfaceTests(unittest.TestCase):
         for target in ('192.0.2.1', '2001:db8::1', 'server.example.test'):
             interface._INTERFACE__target = target
             self.assertFalse(interface.is_target_loopback())
+
+    def test_interface_keeps_connection_info_after_portmap_is_removed(self):
+        target = 'issue-2212-target'
+        credentials = ('user', 'password', 'domain', '', '', '', None, None)
+        rpcTransport = Mock()
+        rpcTransport.get_kerberos.return_value = False
+        rpcTransport.get_kdcHost.return_value = None
+        portmap = Mock()
+        portmap.get_rpc_transport.return_value = rpcTransport
+        portmap.get_credentials.return_value = credentials
+        dce = Mock()
+        dcomInterface = Mock()
+        dcomInterface.get_dce_rpc.return_value = dce
+
+        orpc = dcomrt.ORPCTHIS()
+        orpc['extensions'] = dcomrt.NULL
+        orpc['flags'] = 1
+        classInstance = dcomrt.CLASS_INSTANCE(
+            orpc,
+            [{'wTowerId': 7, 'aNetworkAddr': target + '[49667]\x00'}],
+            portmap,
+        )
+        interface = dcomrt.INTERFACE(
+            classInstance,
+            None,
+            ipidRemUnknown=b'\x00' * 16,
+            iPid=b'\x11' * 16,
+            oxid=0x2222,
+            oid=0x3333,
+            target=target,
+        )
+
+        dcomrt.DCOMConnection.PORTMAPS[target] = portmap
+        del dcomrt.DCOMConnection.PORTMAPS[target]
+
+        with patch.object(dcomrt.transport, 'DCERPCTransportFactory', return_value=dcomInterface):
+            interface.connect(dcomrt.IID_IRemUnknown)
+
+        dcomInterface.set_credentials.assert_called_once_with(*credentials)
+        dcomInterface.set_kerberos.assert_called_once_with(False, None)
+        dcomInterface.set_connect_timeout.assert_called_once_with(300)
+        dce.connect.assert_called_once_with()
+        dce.bind.assert_called_once_with(dcomrt.IID_IRemUnknown)
 
 
 class DCOMTests(DCERPCTests):


### PR DESCRIPTION
Fixes #2212.

-  DCOM interfaces used `PORTMAPS[target]` to recover credentials and Kerberos settings when opening their RPC connection. 
-  A second `DCOMConnection` to the same target could disconnect and remove that shared entry, causing surviving interfaces to fail with `KeyError`.
- The fix makes each DCOM interface keep a small copy of the connection/auth info from the connection that created it. So normal interface setup no longer asks the shared dict
- This does not redesign DCOM keepalive/OID tracking, which still uses shared target-keyed state.