### PR TITLE
Standardize Kerberos TGS enctype negotiation

### DIFF
--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -47,7 +47,7 @@ from impacket.examples.utils import parse_identity, ldap_login
 from impacket.krb5 import constants
 from impacket.krb5.asn1 import TGS_REP, AS_REP
 from impacket.krb5.ccache import CCache
-from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGS
+from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGS, RC4_PREFERRED_TGS_ENCTYPES
 from impacket.krb5.types import Principal
 from impacket.ldap import ldap, ldapasn1
 from impacket.ntlm import compute_lmhash, compute_nthash
@@ -374,7 +374,8 @@ class GetUserSPNs:
                         tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(principalName, self.__domain,
                                                                                 self.__kdcIP,
                                                                                 TGT['KDC_REP'], TGT['cipher'],
-                                                                                TGT['sessionKey'])
+                                                                                TGT['sessionKey'],
+                                                                                etypes=RC4_PREFERRED_TGS_ENCTYPES)
                         self.outputTGS(tgs, oldSessionKey, sessionKey, sAMAccountName,
                                        self.__targetDomain + "/" + sAMAccountName, fd)
                     except Exception as e:
@@ -433,7 +434,8 @@ class GetUserSPNs:
                     tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(principalName, self.__domain,
                                                                             self.__kdcIP,
                                                                             TGT['KDC_REP'], TGT['cipher'],
-                                                                            TGT['sessionKey'])
+                                                                            TGT['sessionKey'],
+                                                                            etypes=RC4_PREFERRED_TGS_ENCTYPES)
                     self.outputTGS(tgs, oldSessionKey, sessionKey, username, username, fd)
                 except Exception as e:
                     logging.debug("Exception:", exc_info=True)

--- a/examples/getPac.py
+++ b/examples/getPac.py
@@ -45,7 +45,7 @@ from impacket.krb5 import constants
 from impacket.krb5.asn1 import AP_REQ, AS_REP, TGS_REQ, Authenticator, TGS_REP, seq_set, seq_set_iter, PA_FOR_USER_ENC, \
     EncTicketPart, AD_IF_RELEVANT, Ticket as TicketAsn1
 from impacket.krb5.crypto import Key, _enctype_table, _HMACMD5, Enctype
-from impacket.krb5.kerberosv5 import getKerberosTGT, sendReceive
+from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGSRequestEnctypes, sendReceive
 from impacket.krb5.pac import PACTYPE, PAC_INFO_BUFFER, KERB_VALIDATION_INFO, PAC_CLIENT_INFO_TYPE, PAC_CLIENT_INFO, \
     PAC_SERVER_CHECKSUM, PAC_SIGNATURE_DATA, PAC_PRIVSVR_CHECKSUM, PAC_UPN_DNS_INFO, UPN_DNS_INFO
 from impacket.krb5.types import Principal, KerberosTime, Ticket
@@ -242,8 +242,7 @@ class S4U2SELF:
 
         reqBody['till'] = KerberosTime.to_asn1(now)
         reqBody['nonce'] = random.getrandbits(31)
-        seq_set_iter(reqBody, 'etype',
-                      (int(cipher.enctype),int(constants.EncryptionTypes.rc4_hmac.value)))
+        seq_set_iter(reqBody, 'etype', getKerberosTGSRequestEnctypes())
 
         # If you comment these two lines plus enc_tkt_in_skey as option, it is bassically a S4USelf
         myTicket = ticket.to_asn1(TicketAsn1())

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -74,7 +74,7 @@ from impacket.krb5.asn1 import AP_REQ, AS_REP, TGS_REQ, Authenticator, TGS_REP, 
 from impacket.krb5.ccache import CCache, Credential
 from impacket.krb5.crypto import Key, _enctype_table, _HMACMD5, _AES256CTS, Enctype, string_to_key, _get_checksum_profile, Cksumtype
 from impacket.krb5.constants import TicketFlags, encodeFlags, ApplicationTagNumbers
-from impacket.krb5.kerberosv5 import getKerberosTGS, getKerberosTGT, sendReceive
+from impacket.krb5.kerberosv5 import getKerberosTGS, getKerberosTGT, getKerberosTGSRequestEnctypes, sendReceive
 from impacket.krb5.types import Principal, KerberosTime, Ticket
 from impacket.ntlm import compute_nthash
 from impacket.winregistry import hexdump
@@ -348,14 +348,7 @@ class GETST:
 
             reqBody['till'] = KerberosTime.to_asn1(now)
             reqBody['nonce'] = random.getrandbits(31)
-            seq_set_iter(reqBody, 'etype',
-                         (
-                             int(constants.EncryptionTypes.rc4_hmac.value),
-                             int(constants.EncryptionTypes.des3_cbc_sha1_kd.value),
-                             int(constants.EncryptionTypes.des_cbc_md5.value),
-                             int(cipher.enctype)
-                         )
-                         )
+            seq_set_iter(reqBody, 'etype', getKerberosTGSRequestEnctypes())
             message = encoder.encode(tgsReq)
 
             logging.info('Requesting S4U2Proxy')
@@ -535,8 +528,7 @@ class GETST:
 
         reqBody['till'] = KerberosTime.to_asn1(now)
         reqBody['nonce'] = random.getrandbits(31)
-        seq_set_iter(reqBody, 'etype',
-                     (int(cipher.enctype), int(constants.EncryptionTypes.rc4_hmac.value)))
+        seq_set_iter(reqBody, 'etype', getKerberosTGSRequestEnctypes())
 
         if self.__options.u2u:
             seq_set_iter(reqBody, 'additional-tickets', (ticket.to_asn1(TicketAsn1()),))
@@ -764,14 +756,7 @@ class GETST:
 
         reqBody['till'] = KerberosTime.to_asn1(now)
         reqBody['nonce'] = random.getrandbits(31)
-        seq_set_iter(reqBody, 'etype',
-                     (
-                         int(constants.EncryptionTypes.rc4_hmac.value),
-                         int(constants.EncryptionTypes.des3_cbc_sha1_kd.value),
-                         int(constants.EncryptionTypes.des_cbc_md5.value),
-                         int(cipher.enctype)
-                     )
-                     )
+        seq_set_iter(reqBody, 'etype', getKerberosTGSRequestEnctypes())
         message = encoder.encode(tgsReq)
 
         logging.info('Requesting S4U2Proxy')

--- a/examples/goldenPac.py
+++ b/examples/goldenPac.py
@@ -719,7 +719,7 @@ class MS14_068:
 
         reqBody['till'] = KerberosTime.to_asn1(now)
         reqBody['nonce'] = random.SystemRandom().getrandbits(31)
-        seq_set_iter(reqBody, 'etype', (cipher.enctype,))
+        seq_set_iter(reqBody, 'etype', getKerberosTGSRequestEnctypes())
         reqBody['enc-authorization-data'] = noValue
         reqBody['enc-authorization-data']['etype'] = int(cipher.enctype)
         reqBody['enc-authorization-data']['cipher'] = encryptedEncodedIfRelevant
@@ -789,9 +789,10 @@ class MS14_068:
 
         encTGSRepPart = decoder.decode(plainText, asn1Spec = EncTGSRepPart())[0]
 
-        newSessionKey = Key(cipher.enctype, encTGSRepPart['key']['keyvalue'].asOctets())
-    
-        return r, cipher, sessionKey, newSessionKey
+        newSessionKey = Key(encTGSRepPart['key']['keytype'], encTGSRepPart['key']['keyvalue'].asOctets())
+        newCipher = _enctype_table[encTGSRepPart['key']['keytype']]
+
+        return r, newCipher, sessionKey, newSessionKey
 
     def getForestSid(self):
         logging.debug('Calling NRPC DsrGetDcNameEx()')
@@ -1055,11 +1056,12 @@ if __name__ == '__main__':
     from impacket.dcerpc.v5 import transport
     from impacket.krb5.types import Principal, Ticket, KerberosTime
     from impacket.krb5 import constants
-    from impacket.krb5.kerberosv5 import sendReceive, getKerberosTGT, getKerberosTGS, KerberosError
+    from impacket.krb5.kerberosv5 import sendReceive, getKerberosTGT, getKerberosTGS, \
+        getKerberosTGSRequestEnctypes, KerberosError
     from impacket.krb5.asn1 import AS_REP, TGS_REQ, AP_REQ, TGS_REP, Authenticator, EncASRepPart, AuthorizationData, \
         AD_IF_RELEVANT, seq_set, seq_set_iter, KERB_PA_PAC_REQUEST, \
         EncTGSRepPart, ETYPE_INFO2_ENTRY
-    from impacket.krb5.crypto import Key
+    from impacket.krb5.crypto import Key, _enctype_table
     from impacket.dcerpc.v5.ndr import NDRULONG
     from impacket.dcerpc.v5.samr import NULL, GROUP_MEMBERSHIP, SE_GROUP_MANDATORY, SE_GROUP_ENABLED_BY_DEFAULT, \
         SE_GROUP_ENABLED, USER_NORMAL_ACCOUNT, USER_DONT_EXPIRE_PASSWORD

--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -80,7 +80,7 @@ from impacket.krb5.pac import KERB_SID_AND_ATTRIBUTES, PAC_SIGNATURE_DATA, PAC_L
     VALIDATION_INFO, PAC_CLIENT_INFO, KERB_VALIDATION_INFO, UPN_DNS_INFO_FULL, PAC_REQUESTOR_INFO, PAC_UPN_DNS_INFO, PAC_ATTRIBUTES_INFO, PAC_REQUESTOR, \
     PAC_ATTRIBUTE_INFO
 from impacket.krb5.types import KerberosTime, Principal
-from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGS
+from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGS, getKerberosTGSRequestEnctypes
 
 from impacket.krb5 import constants, pac
 from impacket.krb5.asn1 import AP_REQ, TGS_REQ, Authenticator, seq_set, seq_set_iter, PA_FOR_USER_ENC, Ticket as TicketAsn1
@@ -604,8 +604,7 @@ class TICKETER:
 
         reqBody['till'] = KerberosTime.to_asn1(now)
         reqBody['nonce'] = random.getrandbits(31)
-        seq_set_iter(reqBody, 'etype',
-                     (int(cipher.enctype), int(constants.EncryptionTypes.rc4_hmac.value)))
+        seq_set_iter(reqBody, 'etype', getKerberosTGSRequestEnctypes())
 
         seq_set_iter(reqBody, 'additional-tickets', (ticket.to_asn1(TicketAsn1()),))
 

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -93,7 +93,7 @@ from impacket.krb5.asn1 import Ticket as TicketAsn1, EncTicketPart, AP_REQ, seq_
     seq_set_iter, TGS_REP, EncTGSRepPart, KERB_KEY_LIST_REP
 from impacket.krb5.constants import ProtocolVersionNumber, TicketFlags, PrincipalNameType, encodeFlags, EncryptionTypes
 from impacket.krb5.crypto import string_to_key, Key, _enctype_table
-from impacket.krb5.kerberosv5 import sendReceive
+from impacket.krb5.kerberosv5 import getKerberosTGSRequestEnctypes, sendReceive
 from impacket.krb5.types import KerberosTime, Principal, Ticket
 try:
     from Cryptodome.Cipher import DES, ARC4, AES
@@ -4093,15 +4093,11 @@ class KeyListSecrets:
 
         reqBody['till'] = KerberosTime.to_asn1(now)
         reqBody['nonce'] = rand.getrandbits(31)
-        seq_set_iter(reqBody, 'etype',
-                     (
-                         int(cipher.enctype),
-                         int(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value),
-                         int(constants.EncryptionTypes.rc4_hmac.value),
-                         int(constants.EncryptionTypes.rc4_hmac_exp.value),
-                         int(constants.EncryptionTypes.rc4_hmac_old_exp.value)
-                     )
-                     )
+        requestEtypes = getKerberosTGSRequestEnctypes() + (
+            int(constants.EncryptionTypes.rc4_hmac_exp.value),
+            int(constants.EncryptionTypes.rc4_hmac_old_exp.value),
+        )
+        seq_set_iter(reqBody, 'etype', requestEtypes)
 
         message = encoder.encode(tgsReq)
         # Let's send our TGS Request, the response will include the FULL TGT with the keys!!!

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -50,6 +50,36 @@ except NotImplementedError:
     rand = random
     pass
 
+# TGS request etypes describe the session keys the client can use for the
+# requested ticket. They are independent from the enctype of the TGT session
+# key used to protect the request.
+DEFAULT_TGS_ENCTYPES = (
+    int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value),
+    int(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value),
+    int(constants.EncryptionTypes.rc4_hmac.value),
+    int(constants.EncryptionTypes.des3_cbc_sha1_kd.value),
+    int(constants.EncryptionTypes.des_cbc_md5.value),
+)
+
+RC4_PREFERRED_TGS_ENCTYPES = (
+    int(constants.EncryptionTypes.rc4_hmac.value),
+    int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value),
+    int(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value),
+    int(constants.EncryptionTypes.des3_cbc_sha1_kd.value),
+    int(constants.EncryptionTypes.des_cbc_md5.value),
+)
+
+
+def getKerberosTGSRequestEnctypes(etypes=None):
+    if etypes is None:
+        return DEFAULT_TGS_ENCTYPES
+
+    normalizedEtypes = tuple(int(getattr(etype, 'value', etype)) for etype in etypes)
+    if len(normalizedEtypes) == 0:
+        raise ValueError('At least one TGS request enctype must be specified')
+    return normalizedEtypes
+
+
 def sendReceive(data, host, kdcHost, port=88):
     if kdcHost is None:
         targetHost = host
@@ -366,7 +396,9 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
 
     return tgt, cipher, key, sessionKey
 
-def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey, renew = False):
+def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey, renew = False, etypes = None):
+
+    requestEtypes = getKerberosTGSRequestEnctypes(etypes)
 
     # Decode the TGT
     try:
@@ -442,34 +474,10 @@ def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey, renew =
 
     reqBody['till'] = KerberosTime.to_asn1(now)
     reqBody['nonce'] = rand.getrandbits(31)
-    seq_set_iter(reqBody, 'etype',
-                      (
-                          int(constants.EncryptionTypes.rc4_hmac.value),
-                          int(constants.EncryptionTypes.des3_cbc_sha1_kd.value),
-                          int(constants.EncryptionTypes.des_cbc_md5.value),
-                          int(cipher.enctype)
-                       )
-                )
+    seq_set_iter(reqBody, 'etype', requestEtypes)
 
     message = encoder.encode(tgsReq)
-
-    try:
-        r = sendReceive(message, domain, kdcHost)
-    except KerberosError as e:
-        # The requested etypes (derived from the TGT session key) are not supported by the
-        # target service, e.g. an RC4 TGT against an AES-only account. Retry advertising AES
-        # so a valid TGT can still obtain a ticket (RC4-capable targets already succeeded above,
-        # so this preserves the RC4 preference and only kicks in when RC4 is refused).
-        if e.getErrorCode() != constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
-            raise
-        seq_set_iter(reqBody, 'etype',
-                          (
-                              int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value),
-                              int(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value),
-                          )
-                    )
-        message = encoder.encode(tgsReq)
-        r = sendReceive(message, domain, kdcHost)
+    r = sendReceive(message, domain, kdcHost)
 
     # Get the session key
 
@@ -499,7 +507,7 @@ def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey, renew =
     else:
         # Let's extract the Ticket, change the domain and keep asking
         domain = spn.components[1]
-        return getKerberosTGS(serverName, domain, kdcHost, r, cipher, newSessionKey)
+        return getKerberosTGS(serverName, domain, kdcHost, r, cipher, newSessionKey, etypes=requestEtypes)
 
 ################################################################################
 # DCE RPC Helpers

--- a/tests/misc/test_kerberosv5.py
+++ b/tests/misc/test_kerberosv5.py
@@ -1,0 +1,112 @@
+from unittest import TestCase, mock
+
+from pyasn1.codec.der import decoder, encoder
+from pyasn1.type.univ import noValue
+
+from impacket.krb5 import constants
+from impacket.krb5.asn1 import AS_REP, TGS_REQ, seq_set
+from impacket.krb5.kerberosv5 import DEFAULT_TGS_ENCTYPES, RC4_PREFERRED_TGS_ENCTYPES, KerberosError, \
+    getKerberosTGS, getKerberosTGSRequestEnctypes
+from impacket.krb5.types import Principal
+
+
+class _RC4Cipher:
+    enctype = constants.EncryptionTypes.rc4_hmac.value
+
+    @staticmethod
+    def encrypt(key, keyUsage, data, iv):
+        return b'encrypted-authenticator'
+
+
+class KerberosTGSEnctypeTests(TestCase):
+    @staticmethod
+    def _build_rc4_tgt():
+        asRep = AS_REP()
+        asRep['pvno'] = 5
+        asRep['msg-type'] = constants.ApplicationTagNumbers.AS_REP.value
+        asRep['crealm'] = 'EXAMPLE.COM'
+        seq_set(
+            asRep,
+            'cname',
+            Principal('user', type=constants.PrincipalNameType.NT_PRINCIPAL.value).components_to_asn1,
+        )
+
+        asRep['ticket'] = noValue
+        asRep['ticket']['tkt-vno'] = 5
+        asRep['ticket']['realm'] = 'EXAMPLE.COM'
+        seq_set(
+            asRep['ticket'],
+            'sname',
+            Principal(
+                'krbtgt/EXAMPLE.COM',
+                type=constants.PrincipalNameType.NT_SRV_INST.value,
+            ).components_to_asn1,
+        )
+        asRep['ticket']['enc-part'] = noValue
+        asRep['ticket']['enc-part']['etype'] = constants.EncryptionTypes.rc4_hmac.value
+        asRep['ticket']['enc-part']['cipher'] = b'ticket'
+
+        asRep['enc-part'] = noValue
+        asRep['enc-part']['etype'] = constants.EncryptionTypes.rc4_hmac.value
+        asRep['enc-part']['cipher'] = b'reply'
+        return encoder.encode(asRep)
+
+    def _assert_request_enctypes(self, requestedEtypes, expectedEtypes):
+        requests = []
+
+        def capture_request(data, domain, kdcHost):
+            tgsReq = decoder.decode(data, asn1Spec=TGS_REQ())[0]
+            requests.append(tuple(int(etype) for etype in tgsReq['req-body']['etype']))
+            raise KerberosError(constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value)
+
+        with mock.patch('impacket.krb5.kerberosv5.sendReceive', side_effect=capture_request) as sendReceive:
+            with self.assertRaises(KerberosError):
+                getKerberosTGS(
+                    Principal('cifs/server.example.com', type=constants.PrincipalNameType.NT_SRV_INST.value),
+                    'EXAMPLE.COM',
+                    None,
+                    self._build_rc4_tgt(),
+                    _RC4Cipher(),
+                    object(),
+                    etypes=requestedEtypes,
+                )
+
+        sendReceive.assert_called_once()
+        self.assertEqual(requests, [expectedEtypes])
+
+    def test_default_tgs_enctypes_are_aes_first(self):
+        self.assertEqual(
+            getKerberosTGSRequestEnctypes(),
+            (
+                constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value,
+                constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value,
+                constants.EncryptionTypes.rc4_hmac.value,
+                constants.EncryptionTypes.des3_cbc_sha1_kd.value,
+                constants.EncryptionTypes.des_cbc_md5.value,
+            ),
+        )
+        self.assertEqual(getKerberosTGSRequestEnctypes(), DEFAULT_TGS_ENCTYPES)
+
+    def test_tgs_enctype_override_is_normalized(self):
+        self.assertEqual(
+            getKerberosTGSRequestEnctypes(
+                (
+                    constants.EncryptionTypes.rc4_hmac,
+                    constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value,
+                )
+            ),
+            (
+                constants.EncryptionTypes.rc4_hmac.value,
+                constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value,
+            ),
+        )
+
+    def test_empty_tgs_enctype_override_is_rejected(self):
+        with self.assertRaises(ValueError):
+            getKerberosTGSRequestEnctypes(())
+
+    def test_rc4_tgt_advertises_default_enctypes_in_one_request(self):
+        self._assert_request_enctypes(None, DEFAULT_TGS_ENCTYPES)
+
+    def test_rc4_preference_can_be_requested_explicitly(self):
+        self._assert_request_enctypes(RC4_PREFERRED_TGS_ENCTYPES, RC4_PREFERRED_TGS_ENCTYPES)


### PR DESCRIPTION
Coming from #2235 - Checking if there's a better way to standardize enctype negotiation across the whole project and avoid these retries on exception...

* Advertise AES256 and AES128 before legacy encryption types by default:
  * ... being the TGS etype field a prioritized list of enctypes the client supports for the new service-ticket session key, we don't need to send a request and on failure send another one.
* Add a reusable helper for normalizing TGS request enctypes.
* Preserve RC4 preference for Kerberoasting workflows while retaining AES fallback.
* Update manually constructed S4U, PAC, ticketer, and secretsdump TGS requests.
* Add unit coverage for default ordering, overrides, validation, and request construction.

Side effects on other examples:
* `getST.py`, `getPac.py`, and `ticketer.py`: S4U and U2U requests now advertise the common AES-first list instead of deriving it from the TGT cipher. The returned session key may therefore differ from the TGT session-key enctype.
* `goldenPac.py`: the returned session-key cipher can now differ from the request cipher, so it is selected from the response’s `keytype`.
* `secretsdump.py`: RODC key-list requests use the common list while retaining the two special export-RC4 enctypes.
* `GetUserSPNs.py`: explicitly uses the RC4-preferred list for Kerberoasting, with AES included as fallback for AES-only accounts.
* General SMB, LDAP, MSSQL, and other `getKerberosTGS()` consumers: default negotiation becomes AES-first and can handle RC4 TGTs targeting AES-only accounts without a retry.