### PR TITLE
Fix IndexError in CCache.getCredential when handling 3-part SPNs in multi domain forests (e.g. dumped LDAP tickets using rubeus dump module)

### DIFF
--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -428,7 +428,24 @@ class CCache:
                 # Let's search for any TGT/TGS that matches the server w/o the SPN's service type/port, returns
                 # the first one
                 # If server has no '/' we assume it's a ST from S4U2Self without a service type
-                if c['server'].prettyPrint().find(b'/') >=0:
+                if c['server'].prettyPrint().count(b'/') >= 2:
+                    # 3-part SPN: service/host/domain@REALM
+                    # Seen when a service ticket is dumped from LSASS memory (e.g. via
+                    # Rubeus' `dump` command) rather than requested fresh - Windows caches
+                    # such tickets with the domain suffix appended as an extra SPN
+                    # component, e.g. LDAP/dc.domain.local/domain.local@REALM
+                    cachedParts = c['server'].prettyPrint().upper().split(b'/')
+                    cachedHost = cachedParts[1].split(b'@')[0].split(b':')[0].split(b'.')[0]
+                    cachedRealm = cachedParts[-1].split(b'@')[-1]
+
+                    serverParts = server.upper().split('/')
+                    searchHost = serverParts[1].split('@')[0].split(':')[0].split('.')[0]
+                    searchRealm = serverParts[-1].split('@')[-1]
+
+                    if cachedHost == b(searchHost) and cachedRealm == b(searchRealm):
+                        LOG.debug('Returning cached credential for %s' % c['server'].prettyPrint().upper().decode('utf-8'))
+                        return c
+                elif c['server'].prettyPrint().find(b'/') >=0:
                     # Let's take the port out for comparison
                     cachedSPN = (c['server'].prettyPrint().upper().split(b'/')[1].split(b'@')[0].split(b':')[0] + b'@' + c['server'].prettyPrint().upper().split(b'/')[1].split(b'@')[1])
                     searchSPN = '%s@%s' % (server.upper().split('/')[1].split('@')[0].split(':')[0],

--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -435,14 +435,21 @@ class CCache:
                     # such tickets with the domain suffix appended as an extra SPN
                     # component, e.g. LDAP/dc.domain.local/domain.local@REALM
                     cachedParts = c['server'].prettyPrint().upper().split(b'/')
-                    cachedHost = cachedParts[1].split(b'@')[0].split(b':')[0].split(b'.')[0]
+                    cachedHost = cachedParts[1].split(b'@')[0].split(b':', 1)[0]
                     cachedRealm = cachedParts[-1].split(b'@')[-1]
 
                     serverParts = server.upper().split('/')
-                    searchHost = serverParts[1].split('@')[0].split(':')[0].split('.')[0]
-                    searchRealm = serverParts[-1].split('@')[-1]
+                    searchHost = b(serverParts[1].split('@')[0].split(':', 1)[0])
+                    searchRealm = b(serverParts[-1].split('@')[-1])
 
-                    if cachedHost == b(searchHost) and cachedRealm == b(searchRealm):
+                    hostsMatch = cachedHost == searchHost
+
+                    # Allow short-name/FQDN matching only when at least one
+                    # side is actually an unqualified hostname.
+                    if not hostsMatch and (b'.' not in cachedHost or b'.' not in searchHost):
+                        hostsMatch = cachedHost.split(b'.', 1)[0] == searchHost.split(b'.', 1)[0]
+
+                    if hostsMatch and cachedRealm == searchRealm:
                         LOG.debug('Returning cached credential for %s' % c['server'].prettyPrint().upper().decode('utf-8'))
                         return c
                 elif c['server'].prettyPrint().find(b'/') >=0:

--- a/tests/misc/test_ccache.py
+++ b/tests/misc/test_ccache.py
@@ -21,7 +21,9 @@ if PY2:
     FileNotFoundError = IOError
 else:
     from unittest import mock
-from impacket.krb5.ccache import AuthData, CCache, CountedOctetString, Credential
+from impacket.krb5 import types
+from impacket.krb5.ccache import AuthData, CCache, CountedOctetString, Credential, Principal
+from impacket.krb5.constants import PrincipalNameType
 
 
 class CCACHETests(unittest.TestCase):
@@ -137,6 +139,27 @@ class CCACHETests(unittest.TestCase):
         self.assertEqual(len(reparsed.authData), 1)
         self.assertEqual(reparsed.authData[0]["authtype"], 1)
         self.assertEqual(reparsed.authData[0]["authdata"]["data"], b"\xde\xad\xbe\xef")
+
+    def test_ccache_getCredential_three_part_spn(self):
+        # Regression test for the 3-part SPN fix (service/host/domain@REALM),
+        # seen in multi domain forests ldap tickets
+        realm = "FOREST.LOCAL"
+        cached_spn = "LDAP/DC01.CHILD-A.LOCAL/CHILD-A.LOCAL@{}".format(realm)
+
+        ccache = CCache()
+        cred = Credential()
+        cred["server"] = Principal()
+        cred["server"].fromPrincipal(types.Principal(cached_spn, type=PrincipalNameType.NT_SRV_INST.value))
+        ccache.credentials.append(cred)
+
+        # Exact same 3-part SPN -> should match
+        self.assertIsNotNone(ccache.getCredential(cached_spn))
+
+        # Short hostname request for the same host -> should match
+        self.assertIsNotNone(ccache.getCredential("LDAP/DC01/CHILD-A.LOCAL@{}".format(realm)))
+
+        # Same short hostname, different child domain -> must not match
+        self.assertIsNone(ccache.getCredential("LDAP/DC01.CHILD-B.LOCAL/CHILD-B.LOCAL@{}".format(realm)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary
`CCache.getCredential()` crashes with `IndexError: list index out of range` when the cached credential's server principal has a 3-component SPN of the form `service/host/domain@REALM`, instead of the expected 2-component `service/host@REALM`.

### Environment
impacket version: 0.14.0.dev0+20260729.95945.570f283 (latest master at time of testing)
Python 3.14

### How did I get here
While working through a red-team lab (CRTE), I obtained admin on a host and extracted a service ticket for a privileged user via `Rubeus`' `dump` module:

long story short I got into a machine in the lab as administrator, used `rubeus`'s `triage` module to list kerberos tickets in memory, note how some service tickets has 3 parts in their SPNs, such as `mgmtadmin`'s `ldap` service tickets

<img width="1221" height="788" alt="triage_module" src="https://github.com/user-attachments/assets/559bf6c4-7878-4b1f-81b9-3e6ffe27e7e8" />

I then used the `dump` module to dump the tickets to transfer to linux and convert to the `.ccache` with `ticketConverter.py`

<img width="1880" height="973" alt="dump_ticket" src="https://github.com/user-attachments/assets/5e51da3e-59a8-4e8f-a742-26b17bb24926" />

This produces a ticket with a 3-part SPN. Confirmed via Rubeus.exe triage on the source Windows host, which already shows the ticket's service name with 3 components before any conversion: `LDAP/us-dc.us.techcorp.local/us.techcorp.local`

`ticketConverter.py` (`kirbi` → `ccache`) preserves this unchanged; it only appends the realm suffix for display, consistent with `impacket`'s normal `prettyPrint` format:

```bash
$ echo doIGjzCCBougAwIBBaEDAgEWooIFajCCBWZhggViMIIFXqADAgEFoRMbEVVTLlRFQ0hDT1JQLkxPQ0FMoj0wO6ADAgECoTQwMhsETERBUBsXdXMtZGMudXMudGVjaGNvcnAubG9jYWwbEXVzLnRlY2hjb3JwLmxvY2Fso4IFATCCBP2gAwIBEqEDAgEMooIE7wSCBOsgBQ8qpdU57zsejnpXQwbmfR3774JIGCXcJstaimQGUb+7L8cSnjSaneILGPMsSrmAuVMkpI3VKetpBB7Zquk6O8lEg+gUy3kjUIXb47b5MjxI7SEMumUwP7NeamD3C7/IKiPQHN9on0ZlrjlalX6zkjQ+syDzzC5PSvZrT2CPZla0d6m8cLjji/y62dzZDcZS+/NCJymmBlsSlrJzYALlfDkcfxEuLJVFok/90EsN2HeLHz7AFTy4+v8e2hx1y6FaYeP48yKOFbo9mSMx4khKT6dJDDn9EEajxHJwvNpDvdj5favMfjUi7gPwKFhCF6gvlRhPfPCBWi9s1g8n4U9uVhRQ08qzuEfdrmTTn2ORGnqWpzYbGlYHH4amyMLvE44w6lyd+4g2cDEEX1xK4awosN88edg35/1zdAdNuAhroJO98RdwB9aDXPGO6XKciG0Y8w6h3hzTTXhEh+his4VRN/Hl94Y4/mwcEUVIa6J0gLgGieMurFuo6dsHU7GSpbedKbthF8+ebhpVjXfz77jbKBuq2vSrdqke14HhFklzs5RNQmMA15leKjEHgxwQaDhMbTfFcpn3B68xvB3Z6S6ObXFAhA8lOcQpQ0RnfUc3rmkPTjRnbw7bIVjS2D5t66K22jygIfkwSO1OzAtFVeKaCIAGVQejvG3E4OthiBL6t19JxI2EKMcXSpCf9qugkr5EA9Usc1LzHTZf3qgN/HkxDAaa8bu8EaNF7h7eiI+IXInUvMlhXDKrYCHahUFl5GmHSUCNrgPTcfrQOBYnQe4S9SpvFZS4sMrXpK6dY7DYDwPfK2825A1/mJHCnnEXFpvAmYS876llDKE4G6Dv8HbU0NtgLcpToSArROvL5Ru/X3Bk5OvUDEb81ymuhQhYrlPqrR7b8at2uBdot591IgH1SlfU96iyDcpRD1ZslaIg5J4Gf3l2niZsL4zhmoMERaH68aSCxI1zETSs0q6o/xbz9xI0CQ5yac52p16U/OxnQkVrlEgo+gYMskCOe6uNrIrDhQfGenEJV6tCC1VALWW7VJlqeQrgXQKNIDI7nmd3hFx87n72fCNI/q3b5urkAtHRLXDgL/Thny+tScvgMlvpQ03NRsvY3/QgBorWestVQqAMn7htl9gA4koXtXnsSb4HswEKBLxeul0zWVERkB7838hd2LsBIjHdiXUPU/6vMi4qb6iaKlsc28WHy2R3WcXgZwJ4dQI5EJGXnD2fw5dxUmLRHLviM3LPwMpb69JCaVJJ9FyvH/YuEyW1BqcfNRR/k7vD2aUP6/Qd8sQSI6ReJyB1QS6FhUxCC6+Y5Gw6uT8wsTio8RG69lTekjPaHGTdaU8N7HdolPi+Bw8Sa2SleIxBqVBAQDNZiceScQb9Uvn472xUi2F0z/j+yIxVpRma8vJdhCWcpFZElnZvUsaiKNaLCHUEiEWFuO0l3cBa3S1tewmCoJcHwCThw7yuNjuJYWsQRHpuRr9x4LzT8HJMyLoo6WM265INfxn1L/cAkVtRZVVma+vxPrBF0nNHKGg2wR/zwE79Av6aKu38q64awQKU+g/QoAtx4CskxkDAbdiIXTDuZDCYc0KDsR6kiTMG5Ry4GVOGHk5SXG+mfjygoysyEDo7BY6P+xhNaxXPUBN8Youv5acmNzCpVXbZwAVxNb7Qi5RD5hgXD6OCAQ8wggELoAMCAQCiggECBIH/fYH8MIH5oIH2MIHzMIHwoCswKaADAgESoSIEILfb3yaYP9OToI0VltwdHQs9j8ZTKL81I6A7rpFctazboRMbEVVTLlRFQ0hDT1JQLkxPQ0FMohYwFKADAgEBoQ0wCxsJbWdtdGFkbWluowcDBQBApQAApREYDzIwMjYwNzI5MjA1OTQxWqYRGA8yMDI2MDczMDA2NDk1MFqnERgPMjAyNjA4MDUxMTA0NTBaqBMbEVVTLlRFQ0hDT1JQLkxPQ0FMqT0wO6ADAgECoTQwMhsETERBUBsXdXMtZGMudXMudGVjaGNvcnAubG9jYWwbEXVzLnRlY2hjb3JwLmxvY2Fs > ticket.b64
(02:32:51) [ arch@jeff | /tmp/lab ]
$ base64 -d ticket.b64 > ticket.kirbi
(02:33:01) [ arch@jeff | /tmp/lab ]
$ ticketConverter.py ticket.kirbi ticket.ccache
Impacket v0.13.1 - Copyright Fortra, LLC and its affiliated companies

[*] converting kirbi to ccache...
[+] done
(02:33:18) [ arch@jeff | /tmp/lab ]
$ export KRB5CCNAME=ticket.ccache
(02:33:22) [ arch@jeff | /tmp/lab ]
$ klist
Ticket cache: FILE:ticket.ccache
Default principal: mgmtadmin@US.TECHCORP.LOCAL

Valid starting       Expires              Service principal
07/29/2026 21:59:41  07/30/2026 07:49:50  LDAP/us-dc.us.techcorp.local/us.techcorp.local@US.TECHCORP.LOCAL
	renew until 08/05/2026 12:04:50
```

`mgmtadmin` had a genericWrite on another user, after trying to exploit it I found that Any impacket-based tool relying on `CCache.getCredential()` with `anySPN=True` then crashes with `[-] Got error: list index out of range`, e.g adding a shadow credentials using `certipy` or configuring `rbcd` via `rbcd.py`, here's the full output for both tools
```bash
$ certipy -debug shadow auto -u mgmtadmin@US.TECHCORP.LOCAL -k -no-pass -account 'US-HELPDESK' -dc-ip 192.168.1.2 -target-ip 192.168.1.2 -target US-DC -dc-host US-DC
Certipy v5.1.0 - by Oliver Lyak (ly4k)

[+] Domain retrieved from CCache: US.TECHCORP.LOCAL
[+] Username retrieved from CCache: mgmtadmin
[+] Nameserver: '192.168.1.2'
[+] DC IP: '192.168.1.2'
[+] DC Host: 'US-DC'
[+] Target IP: '192.168.1.2'
[+] Remote Name: 'US-DC'
[+] Domain: 'US.TECHCORP.LOCAL'
[+] Username: 'MGMTADMIN'
[+] Authenticating to LDAP server using Kerberos authentication
[+] Using LDAP channel binding for Kerberos authentication
[+] Checking for Kerberos ticket cache
[+] Loaded Kerberos cache from mgmtadmin.ccache
[-] Got error: list index out of range
Traceback (most recent call last):
  File "/usr/share/certipy/certipy/entry.py", line 67, in main
    actions[options.action](options)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/usr/share/certipy/venv/lib/python3.14/site-packages/certipy/commands/parsers/shadow.py", line 30, in entry
    shadow.entry(options)
    ~~~~~~~~~~~~^^^^^^^^^
  File "/usr/share/certipy/venv/lib/python3.14/site-packages/certipy/commands/shadow.py", line 846, in entry
    actions[options.shadow_action]()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/share/certipy/venv/lib/python3.14/site-packages/certipy/commands/shadow.py", line 317, in auto
    user = self.connection.get_user(self.account)
           ^^^^^^^^^^^^^^^
  File "/usr/share/certipy/venv/lib/python3.14/site-packages/certipy/commands/shadow.py", line 94, in connection
    self._connection.connect()
    ~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/share/certipy/venv/lib/python3.14/site-packages/certipy/lib/ldap.py", line 652, in connect
    self._kerberos_login(ldap_conn)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/usr/share/certipy/venv/lib/python3.14/site-packages/certipy/lib/ldap.py", line 868, in _kerberos_login
    cipher, session_key, blob, username = get_kerberos_type1(
                                          ~~~~~~~~~~~~~~~~~~^
        self.target,
        ^^^^^^^^^^^^
    ...<2 lines>...
        signing=self.target.ldap_signing and not connection.server.ssl,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/share/certipy/venv/lib/python3.14/site-packages/certipy/lib/kerberos.py", line 604, in get_kerberos_type1
    tgs, cipher, session_key, username, domain = get_tgs(target, target_name, service)
                                                 ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/certipy/venv/lib/python3.14/site-packages/certipy/lib/kerberos.py", line 758, in get_tgs
    creds = ccache.getCredential(principal)
  File "/usr/share/certipy/venv/lib/python3.14/site-packages/impacket/krb5/ccache.py", line 433, in getCredential
    cachedSPN = (c['server'].prettyPrint().upper().split(b'/')[1].split(b'@')[0].split(b':')[0] + b'@' + c['server'].prettyPrint().upper().split(b'/')[1].split(b'@')[1])
                                                                                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

```bash
$ rbcd.py -debug us.techcorp.local/mgmtadmin -k -no-pass -delegate-to 'US-HELPDESK$' -delegate-from 'EVIL-PC$' -dc-ip 192.168.1.2 -action 'write' -use-ldapsImpacket v0.13.1 - Copyright Fortra, LLC and its affiliated companies

[+] Impacket Library Installation Path: /usr/lib/python3.14/site-packages/impacket
[+] Using Kerberos Cache: mgmtadmin.ccache
[+] SPN LDAP/US-DC@US.TECHCORP.LOCAL not found in cache
[+] AnySPN is True, looking for another suitable SPN
Traceback (most recent call last):
  File "/usr/bin/rbcd.py", line 317, in main
    ldap_server, ldap_session = init_ldap_session(domain, username, password, lmhash, nthash, args.k, args.dc_ip, args.dc_host, args.aesKey, args.use_ldaps)
                                ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/impacket/examples/utils.py", line 247, in init_ldap_session
    return _init_ldap_connection(target, use_ldaps, domain, username, password, lmhash, nthash, k, dc_ip, aesKey)
  File "/usr/lib/python3.14/site-packages/impacket/examples/utils.py", line 225, in _init_ldap_connection
    ldap3_kerberos_login(ldap_session, target, username, password, domain, lmhash, nthash, aesKey, kdcHost=dc_ip)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/impacket/examples/utils.py", line 133, in ldap3_kerberos_login
    domain, user, TGT, TGS = CCache.parseFile(domain, user, target)
                             ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/impacket/krb5/ccache.py", line 637, in parseFile
    creds = ccache.getCredential(principal)
  File "/usr/lib/python3.14/site-packages/impacket/krb5/ccache.py", line 433, in getCredential
    cachedSPN = (c['server'].prettyPrint().upper().split(b'/')[1].split(b'@')[0].split(b':')[0] + b'@' + c['server'].prettyPrint().upper().split(b'/')[1].split(b'@')[1])
                                                                                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
[-] list index out of range
```
Confirmed reproducible on latest impacket master, independent of certipy/rbcd versions.

### Root cause
In `impacket/krb5/ccache.py`, `getCredential()`'s `anySPN` fallback branch assumes the cached SPN always has exactly 2 slash-separated components:
```python
cachedSPN = (c['server'].prettyPrint().upper().split(b'/')[1].split(b'@')[0].split(b':')[0] + b'@' + c['server'].prettyPrint().upper().split(b'/')[1].split(b'@')[1])
```

For a 3-part SPN, `split(b'/')[1]` yields a string with no `@` in it, so the second `.split(b'@')[1]` throws IndexError.

For reference, I confirmed bloodyAD does not hit this bug, since it uses `minikerberos`, which parses SPNs from structured `ASN.1 sname` components `('/'.join(tgs['ticket']['sname']['name-string'])`) rather than raw byte-splitting, and never assumes a fixed number of components.

### Fix

Added an explicit branch for 3-part SPNs, comparing normalized short-hostname + realm on both sides. Existing 2-part and hostname-only branches are unchanged.

The fix is included in this PR's diff and has been pushed to the branch, ready for review.

### Testing
- Reproduced original crash on impacket master with a real 3-part-SPN ccache from a Rubeus dump.
- confirmed certipy shadow auto and rbcd.py both succeed against the same ccache.
- Ran the full existing test suite before and after the change, diffed results,  identical pass/fail counts (58 failed, 38 passed; pre-existing failures unrelated to this change, appear network/env-dependent).
- `tests/misc/test_ccache.py` (6/6) passes unmodified.

This is purely additive (new branch), no existing branch logic was changed. Happy to add a dedicated regression test with a 3-part-SPN ccache fixture if maintainers want one committed.

PS: thank you for maintaining this incredible library, you guys rock