### PR TITLE
Modernize byte string normalization

### DIFF
--- a/examples/goldenPac.py
+++ b/examples/goldenPac.py
@@ -571,11 +571,11 @@ class MS14_068:
         # 2) PAC_CLIENT_INFO
         pacClientInfo = PAC_CLIENT_INFO()
         pacClientInfo['ClientId'] = unixTime
-        try:
-            name = self.__username.encode('utf-16le')
-        except UnicodeDecodeError:
+        username = self.__username
+        if isinstance(username, bytes):
             import sys
-            name = self.__username.decode(sys.getfilesystemencoding()).encode('utf-16le')
+            username = username.decode(sys.getfilesystemencoding())
+        name = username.encode('utf-16le')
         pacClientInfo['NameLength'] = len(name)
         pacClientInfo['Name'] = name
         pacClientInfoBlob = pacClientInfo.getData()

--- a/examples/karmaSMB.py
+++ b/examples/karmaSMB.py
@@ -381,12 +381,10 @@ class KarmaSMBServer(Thread):
             targetFile = '/'
         
         # 2. We change the filename in the request for our targetFile
-        try:
-            ntCreateRequest['Buffer'] = targetFile.encode('utf-16le')
-        except UnicodeDecodeError:
-            import sys
-            ntCreateRequest['Buffer'] = targetFile.decode(sys.getfilesystemencoding()).encode('utf-16le')
-        ntCreateRequest['NameLength'] = len(targetFile)*2
+        if isinstance(targetFile, bytes):
+            targetFile = targetFile.decode(sys.getfilesystemencoding())
+        ntCreateRequest['Buffer'] = targetFile.encode('utf-16le')
+        ntCreateRequest['NameLength'] = len(ntCreateRequest['Buffer'])
         recvPacket['Data'] = ntCreateRequest.getData()
 
         # 3. We call the original call with our modified data

--- a/examples/services.py
+++ b/examples/services.py
@@ -223,11 +223,10 @@ class SVCCTL:
             if self.__options.password is not None:
                 s = rpctransport.get_smb_connection()
                 key = s.getSessionKey()
-                try:
-                    password = (self.__options.password+'\x00').encode('utf-16le')
-                except UnicodeDecodeError:
-                    import sys
-                    password = (self.__options.password+'\x00').decode(sys.getfilesystemencoding()).encode('utf-16le')
+                password = self.__options.password
+                if isinstance(password, bytes):
+                    password = password.decode(sys.getfilesystemencoding())
+                password = (password + '\x00').encode('utf-16le')
                 password = encryptSecret(key, password)
             else:
                 password = NULL

--- a/impacket/dcerpc/v5/dtypes.py
+++ b/impacket/dcerpc/v5/dtypes.py
@@ -71,11 +71,10 @@ class WIDESTR(NDRUniFixedArray):
 
     def __setitem__(self, key, value):
         if key == 'Data':
-            try:
-                self.fields[key] = value.encode('utf-16le')
-            except UnicodeDecodeError:
+            if isinstance(value, bytes):
                 import sys
-                self.fields[key] = value.decode(sys.getfilesystemencoding()).encode('utf-16le')
+                value = value.decode(sys.getfilesystemencoding())
+            self.fields[key] = value.encode('utf-16le')
 
             self.data = None        # force recompute
         else:
@@ -112,15 +111,11 @@ class STR(NDRSTRUCT):
 
     def __setitem__(self, key, value):
         if key == 'Data':
-            try:
-                if not isinstance(value, binary_type):
-                    self.fields[key] = value.encode('utf-8')
-                else:
-                    # if it is a binary type (str in Python 2, bytes in Python 3), then we assume it is a raw buffer
-                    self.fields[key] = value
-            except UnicodeDecodeError:
-                import sys
-                self.fields[key] = value.decode(sys.getfilesystemencoding()).encode('utf-8')
+            if not isinstance(value, binary_type):
+                self.fields[key] = value.encode('utf-8')
+            else:
+                # If it is bytes, then we assume it is a raw buffer.
+                self.fields[key] = value
             self.fields['MaximumCount'] = None
             self.fields['ActualCount'] = None
             self.data = None        # force recompute
@@ -173,11 +168,10 @@ class WSTR(NDRSTRUCT):
 
     def __setitem__(self, key, value):
         if key == 'Data':
-            try:
-                self.fields[key] = value.encode('utf-16le')
-            except UnicodeDecodeError:
+            if isinstance(value, bytes):
                 import sys
-                self.fields[key] = value.decode(sys.getfilesystemencoding()).encode('utf-16le')
+                value = value.decode(sys.getfilesystemencoding())
+            self.fields[key] = value.encode('utf-16le')
             self.fields['MaximumCount'] = None
             self.fields['ActualCount'] = None
             self.data = None        # force recompute
@@ -376,9 +370,7 @@ class RPC_UNICODE_STRING(NDRSTRUCT):
 
     def __setitem__(self, key, value):
         if key == 'Data' and isinstance(value, NDR) is False:
-            try:
-                value.encode('utf-16le')
-            except UnicodeDecodeError:
+            if isinstance(value, bytes):
                 import sys
                 value = value.decode(sys.getfilesystemencoding())
             self['Length'] = len(value)*2

--- a/impacket/dcerpc/v5/rrp.py
+++ b/impacket/dcerpc/v5/rrp.py
@@ -692,36 +692,28 @@ def checkNullString(string):
         return string
 
 def packValue(valueType, value):
+    if valueType in (REG_EXPAND_SZ, REG_MULTI_SZ, REG_SZ) and isinstance(value, bytes):
+        import sys
+        value = value.decode(sys.getfilesystemencoding())
+
     if valueType == REG_DWORD:
         retData = pack('<L', value)
     elif valueType == REG_DWORD_BIG_ENDIAN:
         retData = pack('>L', value)
     elif valueType == REG_EXPAND_SZ:
-        try:
-            retData = checkNullString(value).encode('utf-16le')
-        except UnicodeDecodeError:
-            import sys
-            retData = value.decode(sys.getfilesystemencoding()).encode('utf-16le')
+        retData = checkNullString(value).encode('utf-16le')
     elif valueType == REG_MULTI_SZ:
-        try:
-            v = checkNullString(value)
-            # REG_MULTI_SZ must end with 2 null-bytes
-            if v[-2:-1] != '\x00':
-                v = v + '\x00'
-            retData = v.encode('utf-16le')
-        except UnicodeDecodeError:
-            import sys
-            retData = value.decode(sys.getfilesystemencoding()).encode('utf-16le')
+        v = checkNullString(value)
+        # REG_MULTI_SZ must end with 2 null-bytes
+        if v[-2:-1] != '\x00':
+            v = v + '\x00'
+        retData = v.encode('utf-16le')
     elif valueType == REG_QWORD:
         retData = pack('<Q', value)
     elif valueType == REG_QWORD_LITTLE_ENDIAN:
         retData = pack('>Q', value)
     elif valueType == REG_SZ:
-        try:
-            retData = checkNullString(value).encode('utf-16le')
-        except UnicodeDecodeError:
-            import sys
-            retData = value.decode(sys.getfilesystemencoding()).encode('utf-16le')
+        retData = checkNullString(value).encode('utf-16le')
     else:
         retData = value
 

--- a/impacket/dcerpc/v5/samr.py
+++ b/impacket/dcerpc/v5/samr.py
@@ -2860,14 +2860,14 @@ def hSamrUnicodeChangePasswordUser2(dce, serverName='\x00', userName='', oldPass
         except:
             pass
 
+    if isinstance(newPassword, bytes):
+        import sys
+        newPassword = newPassword.decode(sys.getfilesystemencoding())
+
     newPwdHashNT = ntlm.NTOWFv1(newPassword)
 
     samUser = SAMPR_USER_PASSWORD()
-    try:
-        encoded_password = newPassword.encode('utf-16le')
-    except UnicodeDecodeError:
-        import sys
-        encoded_password = newPassword.decode(sys.getfilesystemencoding()).encode('utf-16le')
+    encoded_password = newPassword.encode('utf-16le')
 
     samUser['Buffer'] = b'A' * (512 - len(encoded_password)) + encoded_password
 

--- a/impacket/dcerpc/v5/srvs.py
+++ b/impacket/dcerpc/v5/srvs.py
@@ -1770,11 +1770,10 @@ class WCHAR_ARRAY(NDRSTRUCT):
 
     def __setitem__(self, key, value):
         if key == 'Data':
-            try:
-                self.fields[key] = value.encode('utf-16le')
-            except UnicodeDecodeError:
+            if isinstance(value, bytes):
                 import sys
-                self.fields[key] = value.decode(sys.getfilesystemencoding()).encode('utf-16le')
+                value = value.decode(sys.getfilesystemencoding())
+            self.fields[key] = value.encode('utf-16le')
             self.fields['ActualCount'] = None
             self.data = None        # force recompute
         else:

--- a/impacket/ntlm.py
+++ b/impacket/ntlm.py
@@ -599,13 +599,9 @@ def getNTLMSSPType1(workstation='', domain='', signingRequired = False, use_ntlm
     import sys
     encoding = sys.getfilesystemencoding()
     if encoding is not None:
-        try:
-            workstation.encode('utf-16le')
-        except:
+        if isinstance(workstation, bytes):
             workstation = workstation.decode(encoding)
-        try:
-            domain.encode('utf-16le')
-        except:
+        if isinstance(domain, bytes):
             domain = domain.decode(encoding)
 
     # Let's prepare a Type 1 NTLMSSP Message
@@ -640,18 +636,12 @@ def getNTLMSSPType3(type1, type2, user, password, domain, lmhash = '', nthash = 
     import sys
     encoding = sys.getfilesystemencoding()
     if encoding is not None:
-        try:
-            user.encode('utf-16le')
-        except:
+        if isinstance(user, bytes):
             user = user.decode(encoding)
-        try:
-            password.encode('utf-16le')
-        except:
+        if isinstance(password, bytes):
             password = password.decode(encoding)
-        try:
-            domain.encode('utf-16le')
-        except:
-            domain = user.decode(encoding)
+        if isinstance(domain, bytes):
+            domain = domain.decode(encoding)
 
     ntlmChallenge = NTLMAuthChallenge(type2)
 
@@ -804,11 +794,10 @@ def LMOWFv1(password, lmhash = '', nthash=''):
 
 def compute_nthash(password):
     # This is done according to Samba's encryption specification (docs/html/ENCRYPTION.html)
-    try:
-        password = str(password).encode('utf_16le')
-    except UnicodeDecodeError:
+    if isinstance(password, bytes):
         import sys
-        password = password.decode(sys.getfilesystemencoding()).encode('utf_16le')
+        password = password.decode(sys.getfilesystemencoding())
+    password = str(password).encode('utf_16le')
 
     hash = MD4.new()
     hash.update(password)

--- a/tests/SMB_RPC/test_ntlm.py
+++ b/tests/SMB_RPC/test_ntlm.py
@@ -312,6 +312,49 @@ class NTLMTests(unittest.TestCase):
         self.assertNotIn(ntlm.NTLMSSP_AV_DNS_DOMAINNAME,av_pairs)
         self.assertEqual(list(av_pairs), [ntlm.NTLMSSP_AV_DOMAINNAME])
 
+    def test_high_level_functions_decode_bytes_arguments(self):
+        class TrackedBytes(bytes):
+            def __new__(cls, value):
+                instance = super(TrackedBytes, cls).__new__(cls, value)
+                instance.decode_called = False
+                return instance
+
+            def decode(self, encoding):
+                self.decode_called = True
+                return super(TrackedBytes, self).decode(encoding)
+
+        workstation = TrackedBytes(b'workstation')
+        type1_domain = TrackedBytes(b'domain')
+        type1 = ntlm.getNTLMSSPType1(workstation, type1_domain)
+        self.assertEqual(type1.getWorkstation(), 'workstation')
+        self.assertTrue(workstation.decode_called)
+        self.assertTrue(type1_domain.decode_called)
+
+        user = TrackedBytes(b'user')
+        password = TrackedBytes(b'password')
+        type3_domain = TrackedBytes(b'domain')
+
+        class NormalizationComplete(Exception):
+            pass
+
+        def stop_after_normalization(_):
+            raise NormalizationComplete()
+
+        original_challenge = ntlm.NTLMAuthChallenge
+        ntlm.NTLMAuthChallenge = stop_after_normalization
+        try:
+            with self.assertRaises(NormalizationComplete):
+                ntlm.getNTLMSSPType3(type1, None, user, password, type3_domain)
+        finally:
+            ntlm.NTLMAuthChallenge = original_challenge
+
+        self.assertTrue(user.decode_called)
+        self.assertTrue(password.decode_called)
+        self.assertTrue(type3_domain.decode_called)
+
+    def test_compute_nthash_accepts_text_and_bytes(self):
+        self.assertEqual(ntlm.compute_nthash('Password'), ntlm.compute_nthash(b'Password'))
+
     def __pack_and_parse(self, message, expected):
         data = message.getData()
         hexdump(data)

--- a/tests/misc/test_text_encoding.py
+++ b/tests/misc/test_text_encoding.py
@@ -1,0 +1,70 @@
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright Fortra, LLC and its affiliated companies
+#
+# All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+import unittest
+
+from impacket.dcerpc.v5 import rrp, samr
+from impacket.dcerpc.v5.dtypes import RPC_UNICODE_STRING, STR, WIDESTR, WSTR
+from impacket.dcerpc.v5.srvs import WCHAR_ARRAY
+
+
+class TextEncodingTests(unittest.TestCase):
+
+    def test_wide_string_types_accept_bytes(self):
+        for string_type in (WIDESTR, WSTR, WCHAR_ARRAY):
+            value = string_type()
+            value['Data'] = b'test'
+
+            self.assertEqual(value['Data'], 'test')
+            self.assertEqual(value.fields['Data'], 'test'.encode('utf-16le'))
+
+    def test_rpc_unicode_string_accepts_bytes(self):
+        value = RPC_UNICODE_STRING()
+        value['Data'] = b'test'
+
+        self.assertEqual(value['Data'], 'test')
+        self.assertEqual(value['Length'], 8)
+        self.assertEqual(value['MaximumLength'], 8)
+
+    def test_str_preserves_raw_bytes(self):
+        value = STR()
+        value['Data'] = b'\xff'
+
+        self.assertEqual(value.fields['Data'], b'\xff')
+
+    def test_registry_string_types_accept_bytes(self):
+        for value_type in (rrp.REG_EXPAND_SZ, rrp.REG_SZ):
+            self.assertEqual(
+                rrp.packValue(value_type, b'value'),
+                'value\x00'.encode('utf-16le'),
+            )
+
+        self.assertEqual(
+            rrp.packValue(rrp.REG_MULTI_SZ, b'one\x00two\x00'),
+            'one\x00two\x00\x00'.encode('utf-16le'),
+        )
+
+    def test_samr_password_change_accepts_bytes(self):
+        class FakeDCE:
+            def request(self, request):
+                return request
+
+        request = samr.hSamrUnicodeChangePasswordUser2(
+            FakeDCE(),
+            userName='user',
+            oldPassword='OldPassword1!',
+            newPassword=b'NewPassword2!',
+        )
+
+        self.assertIsInstance(request, samr.SamrUnicodeChangePasswordUser2)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=1)


### PR DESCRIPTION
(Superseed #2234)

Modernize byte-string normalization for Python 3 by replacing exception-driven encoding checks with explicit `bytes` handling.

This change:
* Normalizes byte inputs before UTF-16LE encoding in DCE/RPC string types, registry values, SAMR password changes, and related examples.
* Correctly handles byte arguments in NTLM high-level functions and NT hash computation.
* Fixes NTLM domain normalization to decode the domain value itself.
* Uses the encoded filename length for KarmaSMB requests.
* Adds regression tests for text and byte inputs.