### PR TITLE
Fix MSSQL named-pipe Kerberos ticket selection

### DIFF
--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -610,13 +610,15 @@ class CCache:
         f.close()
 
     @classmethod
-    def parseFile(cls, domain='', username='', target=''):
+    def parseFile(cls, domain='', username='', target='', anySPN=True):
         """
         parses the CCache file specified in the KRB5CCNAME environment variable
 
         :param domain: an optional domain name of a user
         :param username: an optional username of a user
         :param target: an optional SPN of a target system
+        :param anySPN: whether a ticket for another service on the same host can
+                       satisfy the target lookup
 
         :return: domain, username, TGT, TGS
         """
@@ -634,13 +636,13 @@ class CCache:
         creds = None
         if target != '':
             principal = '%s@%s' % (target.upper(), domain.upper())
-            creds = ccache.getCredential(principal)
+            creds = ccache.getCredential(principal, anySPN=anySPN)
 
         TGT = None
         TGS = None
         if creds is None:
             principal = 'krbtgt/%s@%s' % (domain.upper(), domain.upper())
-            creds = ccache.getCredential(principal)
+            creds = ccache.getCredential(principal, anySPN=anySPN)
             if creds is not None:
                 LOG.debug('Using TGT from cache')
                 TGT = creds.toTGT()

--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -1295,6 +1295,23 @@ class MSSQL:
 
         return resp
 
+    def _get_mssql_service_spn(self, domain=""):
+        if not self.pipe_name:
+            return "MSSQLSvc/%s:%d" % (self.remoteName, self.port)
+
+        hostname = self.remoteName
+        if "." not in hostname and domain:
+            hostname = "%s.%s" % (hostname, domain)
+
+        # The conventional pipe for a named instance contains
+        # MSSQL$<instance>. Without that component, no instance name is
+        # available, so use the host-only SPN.
+        for component in self.pipe_name.replace("/", "\\").split("\\"):
+            if component.upper().startswith("MSSQL$") and len(component) > 6:
+                return "MSSQLSvc/%s:%s" % (hostname, component[6:])
+
+        return "MSSQLSvc/%s" % hostname
+
     # This is where we compute the pre login TDS packet
     def preLogin(self):
         # First we initiate the structure
@@ -1880,14 +1897,15 @@ class MSSQL:
         )
 
         if useCache:
+            mssqlSpn = self._get_mssql_service_spn(domain)
             domain, username, TGT, TGS = CCache.parseFile(
                 domain,
                 username,
-                "MSSQLSvc/%s:%d" % (self.remoteName, self.port),
+                mssqlSpn,
                 anySPN=not bool(self.pipe_name),
             )
 
-            if TGS is None:
+            if TGS is None and not self.pipe_name:
                 # search for the port's instance name instead (instance name based SPN)
                 LOG.debug(
                     "Searching target's instances to look for port number %s"
@@ -1964,9 +1982,16 @@ class MSSQL:
                 #         FQDN is the fully qualified domain name of the server.
                 #         port is the TCP port number.
                 #         instancename is the name of the SQL Server instance.
+                if self.pipe_name:
+                    serviceSpn = self._get_mssql_service_spn(domain)
+                else:
+                    serviceSpn = "MSSQLSvc/%s.%s:%d" % (
+                        self.remoteName.split(".")[0],
+                        domain,
+                        self.port,
+                    )
                 serverName = Principal(
-                    "MSSQLSvc/%s.%s:%d"
-                    % (self.remoteName.split(".")[0], domain, self.port),
+                    serviceSpn,
                     type=constants.PrincipalNameType.NT_SRV_INST.value,
                 )
                 try:

--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -1801,20 +1801,39 @@ class MSSQL:
                     kerberos=False,
                 )
             else:
+                from impacket.krb5.ccache import CCache
+
                 # A TGS supplied to this method is for MSSQLSvc. The SMB layer
-                # must acquire its own cifs/<host> ticket, using the TGT or cache.
+                # must use an exact cifs/<host> ticket or acquire one from a TGT.
+                smbCacheDomain = domain
+                smbCacheUsername = username
+                smbTGT = TGT
+                smbTGS = None
+                if useCache and smbTGT is None:
+                    (
+                        smbCacheDomain,
+                        smbCacheUsername,
+                        smbTGT,
+                        smbTGS,
+                    ) = CCache.parseFile(
+                        domain,
+                        username,
+                        "cifs/%s" % self.remoteName,
+                        anySPN=False,
+                    )
+
                 self._create_named_pipe_transport(
-                    username,
+                    smbCacheUsername,
                     password,
-                    domain,
+                    smbCacheDomain,
                     lmhash,
                     nthash,
                     kerberos=True,
                     aesKey=aesKey,
                     kdcHost=kdcHost,
-                    TGT=TGT,
-                    TGS=None,
-                    useCache=useCache,
+                    TGT=smbTGT,
+                    TGS=smbTGS,
+                    useCache=False,
                 )
 
         resp = self._negotiate_encryption()
@@ -1862,7 +1881,10 @@ class MSSQL:
 
         if useCache:
             domain, username, TGT, TGS = CCache.parseFile(
-                domain, username, "MSSQLSvc/%s:%d" % (self.remoteName, self.port)
+                domain,
+                username,
+                "MSSQLSvc/%s:%d" % (self.remoteName, self.port),
+                anySPN=not bool(self.pipe_name),
             )
 
             if TGS is None:
@@ -1886,6 +1908,7 @@ class MSSQL:
                         username,
                         "MSSQLSvc/%s.%s:%s"
                         % (self.remoteName.split(".")[0], domain, instanceName),
+                        anySPN=not bool(self.pipe_name),
                     )
 
         # First of all, we need to get a TGT for the user

--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -1295,23 +1295,6 @@ class MSSQL:
 
         return resp
 
-    def _get_mssql_service_spn(self, domain=""):
-        if not self.pipe_name:
-            return "MSSQLSvc/%s:%d" % (self.remoteName, self.port)
-
-        hostname = self.remoteName
-        if "." not in hostname and domain:
-            hostname = "%s.%s" % (hostname, domain)
-
-        # The conventional pipe for a named instance contains
-        # MSSQL$<instance>. Without that component, no instance name is
-        # available, so use the host-only SPN.
-        for component in self.pipe_name.replace("/", "\\").split("\\"):
-            if component.upper().startswith("MSSQL$") and len(component) > 6:
-                return "MSSQLSvc/%s:%s" % (hostname, component[6:])
-
-        return "MSSQLSvc/%s" % hostname
-
     # This is where we compute the pre login TDS packet
     def preLogin(self):
         # First we initiate the structure
@@ -1897,15 +1880,14 @@ class MSSQL:
         )
 
         if useCache:
-            mssqlSpn = self._get_mssql_service_spn(domain)
             domain, username, TGT, TGS = CCache.parseFile(
                 domain,
                 username,
-                mssqlSpn,
+                "MSSQLSvc/%s:%d" % (self.remoteName, self.port),
                 anySPN=not bool(self.pipe_name),
             )
 
-            if TGS is None and not self.pipe_name:
+            if TGS is None:
                 # search for the port's instance name instead (instance name based SPN)
                 LOG.debug(
                     "Searching target's instances to look for port number %s"
@@ -1982,16 +1964,9 @@ class MSSQL:
                 #         FQDN is the fully qualified domain name of the server.
                 #         port is the TCP port number.
                 #         instancename is the name of the SQL Server instance.
-                if self.pipe_name:
-                    serviceSpn = self._get_mssql_service_spn(domain)
-                else:
-                    serviceSpn = "MSSQLSvc/%s.%s:%d" % (
-                        self.remoteName.split(".")[0],
-                        domain,
-                        self.port,
-                    )
                 serverName = Principal(
-                    serviceSpn,
+                    "MSSQLSvc/%s.%s:%d"
+                    % (self.remoteName.split(".")[0], domain, self.port),
                     type=constants.PrincipalNameType.NT_SRV_INST.value,
                 )
                 try:

--- a/tests/misc/test_ccache.py
+++ b/tests/misc/test_ccache.py
@@ -116,6 +116,41 @@ class CCACHETests(unittest.TestCase):
                 self.assertIsNone(TGS)
                 self.assertIsNotNone(TGT)
 
+    @pytest.mark.skipif(PY2, reason="requires python 3.3 or higher")
+    def test_ccache_parseFile_can_require_exact_spn(self):
+        if not PY2:
+            ccache = mock.Mock()
+            tgt_credential = mock.Mock()
+            tgt = object()
+            tgt_credential.toTGT.return_value = tgt
+            ccache.getCredential.side_effect = [None, tgt_credential]
+
+            with mock.patch.object(CCache, "loadFile", return_value=ccache):
+                domain, username, TGT, TGS = CCache.parseFile(
+                    self.domain,
+                    self.username,
+                    "cifs/server.innovation.rocks",
+                    anySPN=False,
+                )
+
+            self.assertEqual(domain, self.domain)
+            self.assertEqual(username, self.username)
+            self.assertIs(TGT, tgt)
+            self.assertIsNone(TGS)
+            self.assertEqual(
+                ccache.getCredential.call_args_list,
+                [
+                    mock.call(
+                        "CIFS/SERVER.INNOVATION.ROCKS@INNOVATION.ROCKS",
+                        anySPN=False,
+                    ),
+                    mock.call(
+                        "krbtgt/INNOVATION.ROCKS@INNOVATION.ROCKS",
+                        anySPN=False,
+                    ),
+                ],
+            )
+
     def test_credential_with_authdata_roundtrip(self):
         # Regression test for a credential that carries authorization data.
         # Credential.authData started as a tuple and was never turned into a

--- a/tests/misc/test_tds.py
+++ b/tests/misc/test_tds.py
@@ -386,66 +386,6 @@ class TDSTests(unittest.TestCase):
             useCache=False,
         )
 
-    def test_named_pipe_kerberos_spn_uses_pipe_instance(self):
-        client = tds.MSSQL(
-            "10.0.0.5",
-            pipe_name=r"MSSQL$SQLEXPRESS\sql\query",
-            remoteName="sql.example.com",
-        )
-
-        self.assertEqual(
-            client._get_mssql_service_spn("DOMAIN"),
-            "MSSQLSvc/sql.example.com:SQLEXPRESS",
-        )
-
-    def test_named_pipe_kerberos_spn_uses_default_instance_form(self):
-        client = tds.MSSQL(
-            "10.0.0.5",
-            pipe_name=r"sql\query",
-            remoteName="sql.example.com",
-        )
-
-        self.assertEqual(
-            client._get_mssql_service_spn("DOMAIN"),
-            "MSSQLSvc/sql.example.com",
-        )
-
-    def test_named_pipe_kerberos_requests_ticket_for_pipe_instance(self):
-        client = tds.MSSQL(
-            "10.0.0.5",
-            pipe_name=r"MSSQL$SQLEXPRESS\sql\query",
-            remoteName="sql.example.com",
-        )
-        sql_tgt = {
-            "KDC_REP": object(),
-            "cipher": object(),
-            "sessionKey": object(),
-        }
-        client._create_named_pipe_transport = mock.Mock()
-        client._negotiate_encryption = mock.Mock(
-            return_value={"Encryption": tds.TDS_ENCRYPT_REQ}
-        )
-
-        with mock.patch(
-            "impacket.krb5.kerberosv5.getKerberosTGS",
-            side_effect=RuntimeError("stop after TGS request"),
-        ) as get_tgs:
-            with self.assertRaisesRegex(RuntimeError, "stop after TGS request"):
-                client.kerberosLogin(
-                    None,
-                    "sql_user",
-                    "",
-                    "DOMAIN",
-                    TGT=sql_tgt,
-                    useCache=False,
-                )
-
-        server_name = get_tgs.call_args[0][0]
-        self.assertEqual(
-            str(server_name),
-            "MSSQLSvc/sql.example.com:SQLEXPRESS",
-        )
-
     def test_named_pipe_kerberos_uses_tgt_for_smb_and_exact_mssql_tgs(self):
         client = tds.MSSQL(
             "10.0.0.5",
@@ -493,7 +433,7 @@ class TDSTests(unittest.TestCase):
                 mock.call(
                     "DOMAIN",
                     "sql_user",
-                    "MSSQLSvc/sql.example.com:SQLEXPRESS",
+                    "MSSQLSvc/sql.example.com:1433",
                     anySPN=False,
                 ),
             ],

--- a/tests/misc/test_tds.py
+++ b/tests/misc/test_tds.py
@@ -341,6 +341,117 @@ class TDSTests(unittest.TestCase):
             kerberos=False,
         )
 
+    def test_named_pipe_kerberos_uses_exact_cifs_cache_ticket(self):
+        client = tds.MSSQL(
+            "10.0.0.5",
+            pipe_name=r"MSSQL$SQLEXPRESS\sql\query",
+            remoteName="sql.example.com",
+        )
+        smb_tgt = object()
+        smb_tgs = object()
+        client._create_named_pipe_transport = mock.Mock()
+        client._negotiate_encryption = mock.Mock(
+            side_effect=RuntimeError("stop after SMB setup")
+        )
+
+        with mock.patch(
+            "impacket.krb5.ccache.CCache.parseFile",
+            return_value=("DOMAIN", "cache_user", smb_tgt, smb_tgs),
+        ) as parse_file:
+            with self.assertRaisesRegex(RuntimeError, "stop after SMB setup"):
+                client.kerberosLogin(
+                    None,
+                    "sql_user",
+                    "",
+                    "DOMAIN",
+                )
+
+        parse_file.assert_called_once_with(
+            "DOMAIN",
+            "sql_user",
+            "cifs/sql.example.com",
+            anySPN=False,
+        )
+        client._create_named_pipe_transport.assert_called_once_with(
+            "cache_user",
+            "",
+            "DOMAIN",
+            "",
+            "",
+            kerberos=True,
+            aesKey="",
+            kdcHost=None,
+            TGT=smb_tgt,
+            TGS=smb_tgs,
+            useCache=False,
+        )
+
+    def test_named_pipe_kerberos_uses_tgt_for_smb_and_exact_mssql_tgs(self):
+        client = tds.MSSQL(
+            "10.0.0.5",
+            pipe_name=r"MSSQL$SQLEXPRESS\sql\query",
+            remoteName="sql.example.com",
+        )
+        smb_tgt = object()
+        sql_tgs = {
+            "KDC_REP": b"not-an-asn1-ticket",
+            "cipher": object(),
+            "sessionKey": object(),
+        }
+        client._create_named_pipe_transport = mock.Mock()
+        client._negotiate_encryption = mock.Mock(
+            return_value={"Encryption": tds.TDS_ENCRYPT_REQ}
+        )
+
+        with mock.patch(
+            "impacket.krb5.ccache.CCache.parseFile",
+            side_effect=[
+                ("DOMAIN", "cache_user", smb_tgt, None),
+                ("DOMAIN", "cache_user", None, sql_tgs),
+            ],
+        ) as parse_file, mock.patch(
+            "pyasn1.codec.der.decoder.decode",
+            side_effect=RuntimeError("stop after cache lookup"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "stop after cache lookup"):
+                client.kerberosLogin(
+                    None,
+                    "sql_user",
+                    "",
+                    "DOMAIN",
+                )
+
+        self.assertEqual(
+            parse_file.call_args_list,
+            [
+                mock.call(
+                    "DOMAIN",
+                    "sql_user",
+                    "cifs/sql.example.com",
+                    anySPN=False,
+                ),
+                mock.call(
+                    "DOMAIN",
+                    "sql_user",
+                    "MSSQLSvc/sql.example.com:1433",
+                    anySPN=False,
+                ),
+            ],
+        )
+        client._create_named_pipe_transport.assert_called_once_with(
+            "cache_user",
+            "",
+            "DOMAIN",
+            "",
+            "",
+            kerberos=True,
+            aesKey="",
+            kdcHost=None,
+            TGT=smb_tgt,
+            TGS=None,
+            useCache=False,
+        )
+
     @staticmethod
     def _text_pointer_row_data(payload):
         pointer = b"PTR!"

--- a/tests/misc/test_tds.py
+++ b/tests/misc/test_tds.py
@@ -386,6 +386,66 @@ class TDSTests(unittest.TestCase):
             useCache=False,
         )
 
+    def test_named_pipe_kerberos_spn_uses_pipe_instance(self):
+        client = tds.MSSQL(
+            "10.0.0.5",
+            pipe_name=r"MSSQL$SQLEXPRESS\sql\query",
+            remoteName="sql.example.com",
+        )
+
+        self.assertEqual(
+            client._get_mssql_service_spn("DOMAIN"),
+            "MSSQLSvc/sql.example.com:SQLEXPRESS",
+        )
+
+    def test_named_pipe_kerberos_spn_uses_default_instance_form(self):
+        client = tds.MSSQL(
+            "10.0.0.5",
+            pipe_name=r"sql\query",
+            remoteName="sql.example.com",
+        )
+
+        self.assertEqual(
+            client._get_mssql_service_spn("DOMAIN"),
+            "MSSQLSvc/sql.example.com",
+        )
+
+    def test_named_pipe_kerberos_requests_ticket_for_pipe_instance(self):
+        client = tds.MSSQL(
+            "10.0.0.5",
+            pipe_name=r"MSSQL$SQLEXPRESS\sql\query",
+            remoteName="sql.example.com",
+        )
+        sql_tgt = {
+            "KDC_REP": object(),
+            "cipher": object(),
+            "sessionKey": object(),
+        }
+        client._create_named_pipe_transport = mock.Mock()
+        client._negotiate_encryption = mock.Mock(
+            return_value={"Encryption": tds.TDS_ENCRYPT_REQ}
+        )
+
+        with mock.patch(
+            "impacket.krb5.kerberosv5.getKerberosTGS",
+            side_effect=RuntimeError("stop after TGS request"),
+        ) as get_tgs:
+            with self.assertRaisesRegex(RuntimeError, "stop after TGS request"):
+                client.kerberosLogin(
+                    None,
+                    "sql_user",
+                    "",
+                    "DOMAIN",
+                    TGT=sql_tgt,
+                    useCache=False,
+                )
+
+        server_name = get_tgs.call_args[0][0]
+        self.assertEqual(
+            str(server_name),
+            "MSSQLSvc/sql.example.com:SQLEXPRESS",
+        )
+
     def test_named_pipe_kerberos_uses_tgt_for_smb_and_exact_mssql_tgs(self):
         client = tds.MSSQL(
             "10.0.0.5",
@@ -433,7 +493,7 @@ class TDSTests(unittest.TestCase):
                 mock.call(
                     "DOMAIN",
                     "sql_user",
-                    "MSSQLSvc/sql.example.com:1433",
+                    "MSSQLSvc/sql.example.com:SQLEXPRESS",
                     anySPN=False,
                 ),
             ],


### PR DESCRIPTION
(Follow-up to #2202)

MSSQL connections over named pipes require two Kerberos service tickets:
* `cifs/<host>` for the outer SMB transport.
* `MSSQLSvc/<host>:<port>` for TDS authentication.

Previously, both layers used the default `CCache.getCredential(..., anySPN=True)` behavior. When an exact CIFS ticket was unavailable, the SMB layer could select an existing MSSQLSvc ticket for the same host and rewrite its `sname` to CIFS.

This also prevented fallback to an available TGT.

For example, a cache containing:
```text
krbtgt/NORTH.SEVENKINGDOMS.LOCAL
MSSQLSvc/castelblack.north.sevenkingdoms.local:1433
```
failed while opening the named pipe:
```text
SPN CIFS/... not found in cache
AnySPN is True, looking for another suitable SPN
Returning cached credential for MSSQLSVC/...:1433
Changing sname from MSSQLSvc/... to CIFS/... and hoping for the best
```
SMB subsequently rejected the substituted ticket.

## Changes
* Add a backward-compatible anySPN argument to CCache.parseFile().
  * It defaults to True, preserving existing behavior for all current callers.
* Require exact ccache matches for MSSQL named-pipe authentication:
  * cifs/<host> for SMB.
  * MSSQLSvc/<host>:<port> for TDS.
* Fall back to the cached TGT when the exact service ticket is unavailable.
* Resolve the SMB credentials before creating the named-pipe transport, preventing the lower SMB layer from selecting an unrelated service ticket.
* Keep existing TCP MSSQL and other Impacket ccache behavior unchanged.

## Result
A cache containing a TGT and an MSSQLSvc TGS now follows the expected flow:

SMB:
* No cached CIFS TGS
  * use cached TGT
  * request CIFS TGS

TDS:
* Use the cached MSSQLSvc TGS

Caches containing both exact CIFS and MSSQLSvc tickets continue to work without contacting the KDC.

A CIFS-only cache is no longer reused as an MSSQLSvc ticket.