### PR TITLE
Fix some SMB relay server syntax error

### DIFF
--- a/impacket/examples/ntlmrelayx/clients/smbrelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/smbrelayclient.py
@@ -431,6 +431,7 @@ class SMBRelayClient(ProtocolClient):
         flags2 = v1client.get_flags()[1]
         v1client.set_flags(flags2=flags2 & (~SMB.FLAGS2_EXTENDED_SECURITY))
         if sessionSetupData['Account'] != '':
+            LOG.debug("(SMB) sessionnSetupData Account is not empty. Send them to server")
             smb = NewSMBPacket()
             smb['Flags1'] = 8
 
@@ -440,7 +441,7 @@ class SMBRelayClient(ProtocolClient):
 
             sessionSetup['Parameters']['MaxBuffer'] = 65535
             sessionSetup['Parameters']['MaxMpxCount'] = 2
-            sessionSetup['Parameters']['VCNumber'] = os.getpid()
+            sessionSetup['Parameters']['VCNumber'] = os.getpid() & 0xFFFF
             sessionSetup['Parameters']['SessionKey'] = v1client._dialects_parameters['SessionKey']
             sessionSetup['Parameters']['AnsiPwdLength'] = len(sessionSetupData['AnsiPwd'])
             sessionSetup['Parameters']['UnicodePwdLength'] = len(sessionSetupData['UnicodePwd'])
@@ -466,6 +467,7 @@ class SMBRelayClient(ProtocolClient):
                 return smb, STATUS_SUCCESS
         else:
             # Anonymous login, send STATUS_ACCESS_DENIED so we force the client to send his credentials
+            LOG.debug("(SMB1) Anonymous login, send STATUS_ACCESS_DENIED")
             clientResponse = None
             errorCode = STATUS_ACCESS_DENIED
 

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -737,6 +737,7 @@ class SMBRelayServer(Thread):
             sessionSetupData['AnsiPwdLength'] = sessionSetupParameters['AnsiPwdLength']
             sessionSetupData['UnicodePwdLength'] = sessionSetupParameters['UnicodePwdLength']
             sessionSetupData.fromString(SMBCommand['Data'])
+            connData['Capabilities'] = sessionSetupParameters['Capabilities']
 
             client = connData['SMBClient']
             _, errorCode = client.sendStandardSecurityAuth(sessionSetupData)
@@ -826,7 +827,7 @@ class SMBRelayServer(Thread):
                 else:
                     # No more targets to process, just let the victim to fail later
                     LOG.info('(SMB): Connection from %s@%s controlled, but there are no more targets left!' % (self.authUser, connData['ClientIP']))
-                    return self.origsmbComTreeConnectAndX (connId, smbServer, recvPacket)
+                    return self.origsmbComTreeConnectAndX (connId, smbServer, SMBCommand, recvPacket)
 
             LOG.info('(SMB): Connection from %s@%s controlled, attacking target %s://%s' % (self.authUser, connData['ClientIP'], self.target.scheme, self.target.netloc))
 


### PR DESCRIPTION
Fix some syntax error with SMBv1 relay server and smbv1 relay client:
Moved to a separate PR from #2161 