### PR TITLE
Fallback to RC4 when KDC omits etype salt info  Body

### DIFF
--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -256,6 +256,11 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
         key = Key(cipher.enctype, nthash)
     elif aesKey != b'':
         key = Key(cipher.enctype, aesKey)
+    elif enctype not in encryptionTypesData:
+        # No salt for this etype (e.g. no AES key on the account), fall back to RC4.
+        from impacket.ntlm import compute_lmhash, compute_nthash
+        return getKerberosTGT(clientName, password, domain, compute_lmhash(password), compute_nthash(password),
+                              aesKey, kdcHost, requestPAC, serverName, kerberoast_no_preauth)
     else:
         key = cipher.string_to_key(password, encryptionTypesData[enctype], None)
 


### PR DESCRIPTION
This PR fixes a `KeyError` in `getKerberosTGT` when authenticating with a cleartext password against accounts that have no AES keys (e.g. after a password reset via `SAMR`, which only regenerates LM/NT hashes).

When no `NT hash` is provided, impacket requests `AES256` first. Some KDCs accept the `AS-REQ` but return a `PREAUTH_FAILED` response with no `PA-ETYPE-INFO2` entry for the requested etype (e.g. etype 18). Without salt data, cipher.string_to_key() crashes with `KeyError: 18`.

The fix mirrors the existing `KDC_ERR_ETYPE_NOSUPP` fallback: if the requested etype is missing from encryptionTypesData, retry with RC4 using hashes derived from the password.

Account without AES keys : 

<img width="1919" height="877" alt="2" src="https://github.com/user-attachments/assets/dc7fc05b-bdea-491c-aa90-8560772f6f63" />

Before : 

<img width="1908" height="1051" alt="1" src="https://github.com/user-attachments/assets/58e07bf2-732d-49d5-8642-afa66614fb08" />

After : 

<img width="1917" height="225" alt="3" src="https://github.com/user-attachments/assets/e85ded6c-55ab-4697-968d-126bf3ee1974" />
