### PR TITLE
ccache: support FILE prefix in KRB5CCNAME

### DIFF
--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -589,6 +589,12 @@ class CCache:
         credential.secondTicket['length'] = 0
         self.credentials.append(credential)
 
+    @staticmethod
+    def normalizeFileName(fileName):
+        if fileName and fileName.upper().startswith('FILE:'):
+            fileName = fileName[5:]
+        return fileName
+
     @classmethod
     def loadFile(cls, fileName):
         if fileName is None:
@@ -596,6 +602,7 @@ class CCache:
             LOG.debug('The specified path is not correct or the KRB5CCNAME environment variable is not defined')
             return None
 
+        fileName = cls.normalizeFileName(fileName)
         try:
             f = open(fileName, 'rb')
             data = f.read()


### PR DESCRIPTION
This fixes loading Kerberos credential caches when KRB5CCNAME uses the FILE: cache identifier format.

Previously, the KRB5CCNAME value was passed directly to open(), causing valid cache identifiers such as FILE:/tmp/krb5cc to be treated as literal filesystem paths.

This change normalizes FILE-prefixed cache names before loading the cache file.

Fixes #2249 