### PR TITLE
krb5: add optional connection timeout for Kerberos and kpasswd requests

### DIFF
--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -80,7 +80,7 @@ def getKerberosTGSRequestEnctypes(etypes=None):
     return normalizedEtypes
 
 
-def sendReceive(data, host, kdcHost, port=88):
+def sendReceive(data, host, kdcHost, port=88, timeout=None):
     if kdcHost is None:
         targetHost = host
     else:
@@ -92,7 +92,9 @@ def sendReceive(data, host, kdcHost, port=88):
     try:
         af, socktype, proto, canonname, sa = socket.getaddrinfo(targetHost, port, 0, socket.SOCK_STREAM)[0]
         s = socket.socket(af, socktype, proto)
+        s.settimeout(timeout)
         s.connect(sa)
+        s.settimeout(None)
     except socket.error as e:
         raise socket.error("Connection error (%s:%s)" % (targetHost, port), e)
 
@@ -124,7 +126,7 @@ def sendReceive(data, host, kdcHost, port=88):
 
     return r
 
-def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcHost=None, requestPAC=True, serverName=None, kerberoast_no_preauth=False):
+def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcHost=None, requestPAC=True, serverName=None, kerberoast_no_preauth=False, timeout=None):
 
     # Convert to binary form, just in case we're receiving strings
     if isinstance(lmhash, str):
@@ -217,14 +219,14 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
     message = encoder.encode(asReq)
 
     try:
-        r = sendReceive(message, domain, kdcHost)
+        r = sendReceive(message, domain, kdcHost, timeout=timeout)
     except KerberosError as e:
         if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
             if supportedCiphers[0] in (constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value, constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value) and aesKey == b'':
                 supportedCiphers = (int(constants.EncryptionTypes.rc4_hmac.value),)
                 seq_set_iter(reqBody, 'etype', supportedCiphers)
                 message = encoder.encode(asReq)
-                r = sendReceive(message, domain, kdcHost)
+                r = sendReceive(message, domain, kdcHost, timeout=timeout)
             else:
                 raise
         else:
@@ -290,7 +292,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
         # No salt for this etype (e.g. no AES key on the account), fall back to RC4.
         from impacket.ntlm import compute_lmhash, compute_nthash
         return getKerberosTGT(clientName, password, domain, compute_lmhash(password), compute_nthash(password),
-                              aesKey, kdcHost, requestPAC, serverName, kerberoast_no_preauth)
+                              aesKey, kdcHost, requestPAC, serverName, kerberoast_no_preauth, timeout)
     else:
         key = cipher.string_to_key(password, encryptionTypesData[enctype], None)
 
@@ -355,14 +357,14 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
         seq_set_iter(reqBody, 'etype', ( (int(cipher.enctype),)))
 
         try:
-            tgt = sendReceive(encoder.encode(asReq), domain, kdcHost)
+            tgt = sendReceive(encoder.encode(asReq), domain, kdcHost, timeout=timeout)
         except Exception as e:
             if str(e).find('KDC_ERR_ETYPE_NOSUPP') >= 0:
                 if lmhash == b'' and nthash == b'' and (aesKey == b'' or aesKey is None):
                     from impacket.ntlm import compute_lmhash, compute_nthash
                     lmhash = compute_lmhash(password)
                     nthash = compute_nthash(password)
-                    return getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey, kdcHost, requestPAC)
+                    return getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey, kdcHost, requestPAC, timeout=timeout)
             raise
 
 
@@ -401,7 +403,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
 
     return tgt, cipher, key, sessionKey
 
-def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey, renew = False, etypes = None):
+def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey, renew = False, etypes = None, timeout=None):
 
     requestEtypes = getKerberosTGSRequestEnctypes(etypes)
 
@@ -482,7 +484,7 @@ def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey, renew =
     seq_set_iter(reqBody, 'etype', requestEtypes)
 
     message = encoder.encode(tgsReq)
-    r = sendReceive(message, domain, kdcHost)
+    r = sendReceive(message, domain, kdcHost, timeout=timeout)
 
     # Get the session key
 
@@ -512,7 +514,7 @@ def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey, renew =
     else:
         # Let's extract the Ticket, change the domain and keep asking
         domain = spn.components[1]
-        return getKerberosTGS(serverName, domain, kdcHost, r, cipher, newSessionKey, etypes=requestEtypes)
+        return getKerberosTGS(serverName, domain, kdcHost, r, cipher, newSessionKey, etypes=requestEtypes, timeout=timeout)
 
 ################################################################################
 # DCE RPC Helpers

--- a/impacket/krb5/kpasswd.py
+++ b/impacket/krb5/kpasswd.py
@@ -283,7 +283,7 @@ def decodeKPasswdReply(encoded, cipher, subKey):
 
 def changePassword(clientName, domain, newPasswd,
                    oldPasswd="", oldLmhash="", oldNthash="", aesKey="", TGT=None,
-                   kdcHost=None, kpasswdHost=None, kpasswdPort=KRB5_KPASSWD_PORT, subKey=None):
+                   kdcHost=None, kpasswdHost=None, kpasswdPort=KRB5_KPASSWD_PORT, subKey=None, timeout=None):
     """
     Change the password of the requesting user with RFC 3244 Kerberos Change-Password protocol.
 
@@ -304,19 +304,21 @@ def changePassword(clientName, domain, newPasswd,
     :param int kpasswdPort:     TCP port where kpasswd is exposed (Default: 464)
     :param string subKey:       Subkey to use to encrypt the password change request
                                 (Default: generate a random one)
+    :param int timeout:         connection timeout in seconds, for both the TGT retrieval and the
+                                kpasswd exchange (Default: None, blocks indefinitely)
 
     :return void:               Raise an KPasswdError exception on error.
     """
     setPassword(
         clientName, domain, None, None, newPasswd,
         oldPasswd, oldLmhash, oldNthash, aesKey, TGT,
-        kdcHost, kpasswdHost, kpasswdPort, subKey
+        kdcHost, kpasswdHost, kpasswdPort, subKey, timeout
     )
 
 
 def setPassword(clientName, domain, targetName, targetDomain, newPasswd,
                 oldPasswd="", oldLmhash="", oldNthash="", aesKey="", TGT=None,
-                kdcHost=None, kpasswdHost=None, kpasswdPort=KRB5_KPASSWD_PORT, subKey=None):
+                kdcHost=None, kpasswdHost=None, kpasswdPort=KRB5_KPASSWD_PORT, subKey=None, timeout=None):
     """
     Set the password of a target account with RFC 3244 Kerberos Set-Password protocol.
     Requires "Reset password" permission on the target, for the user.
@@ -341,6 +343,8 @@ def setPassword(clientName, domain, targetName, targetDomain, newPasswd,
     :param int kpasswdPort:     TCP port where kpasswd is exposed (Default: 464)
     :param string subKey:       Subkey to use to encrypt the password change request
                                 (Default: generate a random one)
+    :param int timeout:         connection timeout in seconds, for both the TGT retrieval and the
+                                kpasswd exchange (Default: None, blocks indefinitely)
 
     :return bool:               True if successful, raise an KPasswdError exception on error.
     """
@@ -370,7 +374,8 @@ def setPassword(clientName, domain, targetName, targetDomain, newPasswd,
 
     if TGT is None:
         tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(
-            userName, oldPasswd, domain, oldLmhash, oldNthash, aesKey, kdcHost, serverName=KRB5_KPASSWD_TGT_SPN
+            userName, oldPasswd, domain, oldLmhash, oldNthash, aesKey, kdcHost, serverName=KRB5_KPASSWD_TGT_SPN,
+            timeout=timeout
         )
     else:
         tgt = TGT["KDC_REP"]
@@ -393,7 +398,7 @@ def setPassword(clientName, domain, targetName, targetDomain, newPasswd,
     )
 
     # Send the request to KPASSWD
-    kpasswordRep = sendReceive(kpasswordReq, domain, kpasswdHost, kpasswdPort)
+    kpasswordRep = sendReceive(kpasswordReq, domain, kpasswdHost, kpasswdPort, timeout=timeout)
 
     # Decode the result
     success, resultCode, resultCodeMessage, message = decodeKPasswdReply(kpasswordRep, cipher, subKey)

--- a/tests/misc/test_kerberosv5.py
+++ b/tests/misc/test_kerberosv5.py
@@ -54,7 +54,7 @@ class KerberosTGSEnctypeTests(TestCase):
     def _assert_request_enctypes(self, requestedEtypes, expectedEtypes):
         requests = []
 
-        def capture_request(data, domain, kdcHost):
+        def capture_request(data, domain, kdcHost, timeout=None):
             tgsReq = decoder.decode(data, asn1Spec=TGS_REQ())[0]
             requests.append(tuple(int(etype) for etype in tgsReq['req-body']['etype']))
             raise KerberosError(constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value)


### PR DESCRIPTION
`kerberosv5.sendReceive()` opens a raw TCP socket to the KDC and never calls `settimeout()`. If the KDC is unreachable (dropped packets, firewall, wrong `-dc-ip`, dead proxy hop), the connect blocks for as long as the OS TCP stack keeps retrying, well over a minute on Linux. `getKerberosTGT`, `getKerberosTGS` and the `kpasswd` module all inherit this since they call `sendReceive` internally.

With the current default, `sendReceive` against an unreachable KDC was still blocked after 12 seconds with zero feedback (had to kill it externally). A connection that's actively refused already fails in milliseconds, this only affects the routable-but-unresponsive case.

**What this PR does:**

- `sendReceive(data, host, kdcHost, port=88, timeout=None)`: sets a socket timeout for the connect phase only, then resets it to blocking before send/recv, so a slow but legitimate KDC exchange isn't cut short once connected.
- `getKerberosTGT(...)` and `getKerberosTGS(...)`: add a `timeout` parameter and thread it through their internal `sendReceive` calls, including the RC4/AES etype retry paths.
- `kpasswd.changePassword()` and `kpasswd.setPassword()`: add a `timeout` parameter, applied to both the TGT retrieval and the kpasswd exchange itself.

Default is `None` everywhere, so existing callers see no behaviour change.

Tested against an unreachable KDC with `timeout=2`: `sendReceive`, `getKerberosTGT` and `kpasswd.changePassword` each failed cleanly in ~2.00s instead of hanging.

Related to #987, which touches the same function for the same underlying issue but is a hardcoded 2 second timeout with no way to configure or disable it, and has been stale since 2020. This adds a proper opt-in parameter instead, following the same approach as #2217 did for LDAP.

Best regards
