### PR TITLE
smbserver: echo request SessionId/Uid in LogOff responses (fixes #1829)

### DIFF
--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -2158,11 +2158,13 @@ class SMBCommands:
             errorCode = STATUS_SMB_BAD_UID
         else:
             errorCode = STATUS_SUCCESS
+            # The session is closed, but the Uid is kept so the response can
+            # still carry the same Uid as the request. The actual teardown is
+            # done in processRequest() once the response has been built.
+            connData['SessionClosed'] = True
 
         respSMBCommand['Parameters'] = respParameters
         respSMBCommand['Data'] = respData
-        connData['Uid'] = 0
-        connData['Authenticated'] = False
 
         smbServer.setConnectionData(connId, connData)
 
@@ -4230,9 +4232,11 @@ class SMB2Commands:
             errorCode = STATUS_SMB_BAD_UID
         else:
             errorCode = STATUS_SUCCESS
-
-        connData['Uid'] = 0
-        connData['Authenticated'] = False
+            # The session is closed, but the Uid is kept so the response can
+            # still carry the same SessionID as the request. The actual
+            # teardown is done in processRequest() once the response has been
+            # built.
+            connData['SessionClosed'] = True
 
         smbServer.setConnectionData(connId, connData)
         return [respSMBCommand], None, errorCode
@@ -5188,6 +5192,13 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
             if encryptResponse:
                 finalData = self._encryptSMB3(connId, finalData, sessionId)
             packetsToSend = [finalData]
+
+        # A LogOff request was processed. The response has been built and
+        # signed with the session's state, so we can close the session now.
+        if connData.get('SessionClosed') is True:
+            connData['Uid'] = 0
+            connData['Authenticated'] = False
+            del connData['SessionClosed']
 
         # We clear the compound requests
         connData['LastRequest'] = {}

--- a/tests/SMB_RPC/test_smbserver.py
+++ b/tests/SMB_RPC/test_smbserver.py
@@ -83,10 +83,10 @@ from multiprocessing import Process
 from six import PY2, StringIO, BytesIO, b, assertRaisesRegex, assertCountEqual
 
 from impacket.smb import SMB_DIALECT
+from impacket import smb, smb3structs as smb2
 from impacket.smbserver import normalize_path, isInFileJail, SimpleSMBServer, SMBSERVER, SMB2Commands
 from impacket.smbconnection import SMBConnection, SessionError, compute_lmhash, compute_nthash
 from impacket.nt_errors import STATUS_NOT_SUPPORTED
-from impacket import smb3structs as smb2
 from threading import Thread
 
 import select
@@ -955,6 +955,81 @@ class SMB2Server311UnitTests(unittest.TestCase):
         transform = smb2.SMB2_TRANSFORM_HEADER(responses[0])
         self.assertEqual(transform['SessionID'], sessionId)
         self.assertEqual(self._connData()['Uid'], 0)
+
+
+class SMBServerLogOffUnitTests(unittest.TestCase):
+    """Unit tests for the LogOff command handling (see issue #1829).
+
+    The LogOff response must carry the same SessionID/Uid as the request, as
+    the client uses it to locate the session and validate the response
+    signature. The session teardown must only happen once the response has
+    been built.
+    """
+
+    def setUp(self):
+        self.server = SMBSERVERForTests(("127.0.0.1", 0))
+        self.connId = "logoff-test-conn"
+        self.sessionId = 0x1337
+        self.server.addConnection(self.connId, "127.0.0.1", 1234)
+        self.server._SMBSERVER__SMB2Support = True
+        connData = self.server.getConnectionData(self.connId, checkStatus=False)
+        connData['Uid'] = self.sessionId
+        connData['Authenticated'] = True
+        self.server.setConnectionData(self.connId, connData)
+
+    def tearDown(self):
+        self.server.server_close()
+
+    def test_smb2_logoff_response_echoes_session_id(self):
+        request = smb2.SMB2Packet()
+        request['Command'] = smb2.SMB2_LOGOFF
+        request['SessionID'] = self.sessionId
+        request['MessageID'] = 0x100
+
+        response = self.server.processRequest(self.connId, request.getData())
+
+        respPacket = smb2.SMB2Packet(data=response[0])
+        self.assertEqual(respPacket['SessionID'], self.sessionId)
+        self.assertEqual(respPacket['Status'], 0)
+
+        connData = self.server.getConnectionData(self.connId, checkStatus=False)
+        self.assertEqual(connData['Uid'], 0)
+        self.assertFalse(connData['Authenticated'])
+
+    def test_smb2_logoff_bad_uid_keeps_session(self):
+        request = smb2.SMB2Packet()
+        request['Command'] = smb2.SMB2_LOGOFF
+        request['SessionID'] = 0xDEAD
+        request['MessageID'] = 0x100
+
+        response = self.server.processRequest(self.connId, request.getData())
+
+        # Per MS-SMB2 the response echoes the request's SessionId (also on
+        # error), so the client can match it to its session; the session
+        # itself must survive the rejected LogOff.
+        respPacket = smb2.SMB2Packet(data=response[0])
+        self.assertEqual(respPacket['SessionID'], 0xDEAD)
+        self.assertNotEqual(respPacket['Status'], 0)
+
+        connData = self.server.getConnectionData(self.connId, checkStatus=False)
+        self.assertEqual(connData['Uid'], self.sessionId)
+        self.assertTrue(connData['Authenticated'])
+
+    def test_smb1_logoff_response_echoes_uid(self):
+        request = smb.NewSMBPacket()
+        request['Uid'] = self.sessionId
+        request['Mid'] = 0x100
+        request.addCommand(smb.SMBCommand(smb.SMB.SMB_COM_LOGOFF_ANDX))
+
+        response = self.server.processRequest(self.connId, request.getData())
+
+        respPacket = response[0]
+        self.assertEqual(respPacket['Uid'], self.sessionId)
+        self.assertEqual(respPacket['ErrorCode'], 0)
+
+        connData = self.server.getConnectionData(self.connId, checkStatus=False)
+        self.assertEqual(connData['Uid'], 0)
+        self.assertFalse(connData['Authenticated'])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #1829

## Problem

When a client sends an SMB1 `LogOff AndX` or SMB2 `LogOff` request, the
handlers (`smbComLogOffAndX`, `smb2Logoff`) cleared the session's `Uid`
*before* the response was assembled. The response header was then filled
from `connData['Uid']` in `processRequest()`, so the LogOff response
carried `SessionId = 0`.

Per MS-SMB2 2.2.2.1 the response must echo the `SessionId` from the
request. Clients that locate the session from the response header to
validate the response signature (signed with the session key) fail
because no session matches `SessionId 0`.

## Fix

- The LogOff handlers no longer tear down the session directly. On
  success they mark the connection with `SessionClosed`.
- `processRequest()` performs the teardown (`Uid = 0`,
  `Authenticated = False`) after the response has been built and signed,
  so the response carries the correct `SessionID`/`Uid`.
- Bonus: the session is no longer torn down when the LogOff is rejected
  with `STATUS_SMB_BAD_UID` (previously the teardown ran unconditionally,
  also on the error path).

## Tests

Added `SMBServerLogOffUnitTests` covering:

- SMB2 LogOff response echoes the request `SessionID` and the session is
  closed afterwards
- SMB2 LogOff with a mismatched `SessionID` keeps the session intact
- SMB1 LogOff response echoes the request `Uid` and the session is
  closed afterwards

```
python3 -m pytest tests/SMB_RPC/test_smbserver.py -q
193 passed, 4 skipped
```