### PR TITLE
fix: NDR.__str__ returns `bytes`

### DIFF
--- a/impacket/dcerpc/v5/ndr.py
+++ b/impacket/dcerpc/v5/ndr.py
@@ -24,6 +24,7 @@ import random
 import inspect
 from struct import pack, unpack_from, calcsize
 from six import with_metaclass, PY3
+from binascii import hexlify
 
 from impacket import LOG
 from impacket.dcerpc.v5.enum import Enum
@@ -143,7 +144,7 @@ class NDR(object):
         return self.fields[key]
 
     def __str__(self):
-        return self.getData()
+        return str(hexlify(self.getData()).decode("ascii"))
 
     def __len__(self):
         # XXX: improve


### PR DESCRIPTION
Python throws an error when a call to `__str__` returns something other than an instance of `str`:

```
>>> from impacket.dcerpc.v5.srvs import SHARE_INFO_1
>>> str(SHARE_INFO_1())
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    str(SHARE_INFO_1())
    ~~~^^^^^^^^^^^^^^^^
TypeError: __str__ returned non-string (type bytes)
```

Wrapped the current result with a call to `str`.