### PR TITLE
Fix SMB3 directory leasing parent tracking

### DIFF
--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -1272,16 +1272,14 @@ class SMB3:
         self.GlobalFileTable[pathName] = fileEntry
 
         if self._Connection['Dialect'] >= SMB2_DIALECT_30 and self._Connection['SupportsDirectoryLeasing'] is True:
-           # Is this file NOT on the root directory?
-           if len(fileName.split('\\')) > 2:
-               parentDir = ntpath.dirname(pathName)
-           if parentDir in self.GlobalFileTable:
-               raise Exception("Don't know what to do now! :-o")
-           else:
-               parentEntry = copy.deepcopy(FILE)
-               parentEntry['LeaseKey']   = uuid.generate()
-               parentEntry['LeaseState'] = SMB2_LEASE_NONE
-               self.GlobalFileTable[parentDir] = parentEntry
+            # Root-level files do not have a parent directory to track.
+            if ntpath.dirname(fileName):
+                parentDir = ntpath.dirname(pathName)
+                if parentDir not in self.GlobalFileTable:
+                    parentEntry = copy.deepcopy(FILE)
+                    parentEntry['LeaseKey']   = uuid.generate()
+                    parentEntry['LeaseState'] = SMB2_LEASE_NONE
+                    self.GlobalFileTable[parentDir] = parentEntry
 
         packet = self.SMB_PACKET()
         packet['Command'] = SMB2_CREATE

--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -1261,10 +1261,13 @@ class SMB3:
             if fileName[0] == '\\':
                 fileName = fileName[1:]
 
-        if self._Session['TreeConnectTable'][treeId]['IsDfsShare'] is True:
+        treeEntry = self._Session['TreeConnectTable'][treeId]
+        if treeEntry['IsDfsShare'] is True:
             pathName = fileName
         else:
-            pathName = '\\\\' + self._Connection['ServerName'] + '\\' + fileName
+            pathName = '\\\\' + self._Connection['ServerName'] + '\\' + treeEntry['ShareName']
+            if fileName:
+                pathName += '\\' + fileName
 
         fileEntry = copy.deepcopy(FILE)
         fileEntry['LeaseKey']   = uuid.generate()
@@ -1272,8 +1275,8 @@ class SMB3:
         self.GlobalFileTable[pathName] = fileEntry
 
         if self._Connection['Dialect'] >= SMB2_DIALECT_30 and self._Connection['SupportsDirectoryLeasing'] is True:
-            # Root-level files do not have a parent directory to track.
-            if ntpath.dirname(fileName):
+            # The share root itself has no parent directory to track.
+            if fileName:
                 parentDir = ntpath.dirname(pathName)
                 if parentDir not in self.GlobalFileTable:
                     parentEntry = copy.deepcopy(FILE)

--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -1277,7 +1277,9 @@ class SMB3:
         if self._Connection['Dialect'] >= SMB2_DIALECT_30 and self._Connection['SupportsDirectoryLeasing'] is True:
             # The share root itself has no parent directory to track.
             if fileName:
-                parentDir = ntpath.dirname(pathName)
+                # ntpath.dirname preserves the trailing separator for a UNC
+                # share root, while pathName stores the root without it.
+                parentDir = ntpath.dirname(pathName).rstrip('\\')
                 if parentDir not in self.GlobalFileTable:
                     parentEntry = copy.deepcopy(FILE)
                     parentEntry['LeaseKey']   = uuid.generate()

--- a/tests/SMB_RPC/test_smb3.py
+++ b/tests/SMB_RPC/test_smb3.py
@@ -64,7 +64,8 @@ class SMB3CreateTests(unittest.TestCase):
                 self.assertIn(path_name, client.GlobalFileTable)
 
                 if has_parent:
-                    self.assertIn(ntpath.dirname(path_name), client.GlobalFileTable)
+                    parent_dir = ntpath.dirname(path_name).rstrip('\\')
+                    self.assertIn(parent_dir, client.GlobalFileTable)
                     self.assertEqual(len(client.GlobalFileTable), 2)
                 else:
                     self.assertEqual(list(client.GlobalFileTable), [path_name])
@@ -79,6 +80,17 @@ class SMB3CreateTests(unittest.TestCase):
         self.assert_create_reaches_send(client, file_name)
 
         self.assertIs(client.GlobalFileTable[parent_dir], parent_entry)
+
+    def test_root_entry_is_reused_for_root_level_file(self):
+        client = self.create_client(share_name='IPC$')
+
+        self.assert_create_reaches_send(client, '')
+        self.assert_create_reaches_send(client, r'\lsarpc')
+
+        self.assertEqual(
+            set(client.GlobalFileTable),
+            {r'\\server\IPC$', r'\\server\IPC$\lsarpc'},
+        )
 
 
 if __name__ == '__main__':

--- a/tests/SMB_RPC/test_smb3.py
+++ b/tests/SMB_RPC/test_smb3.py
@@ -24,10 +24,10 @@ class _SendReached(Exception):
 class SMB3CreateTests(unittest.TestCase):
 
     @staticmethod
-    def create_client(global_file_table=None):
+    def create_client(global_file_table=None, share_name='share'):
         client = object.__new__(SMB3)
         client._Session = {
-            'TreeConnectTable': {1: {'IsDfsShare': False}},
+            'TreeConnectTable': {1: {'IsDfsShare': False, 'ShareName': share_name}},
             'OpenTable': {},
         }
         client._Connection = {
@@ -46,7 +46,8 @@ class SMB3CreateTests(unittest.TestCase):
 
     def test_directory_leasing_parent_tracking(self):
         cases = (
-            (r'\lsarpc', False),
+            ('', False),
+            (r'\lsarpc', True),
             (r'folder\file.txt', True),
             (r'folder\child\file.txt', True),
         )
@@ -56,8 +57,10 @@ class SMB3CreateTests(unittest.TestCase):
                 client = self.create_client()
                 self.assert_create_reaches_send(client, file_name)
 
-                normalized_name = ntpath.normpath(file_name).lstrip('\\')
-                path_name = '\\\\server\\' + normalized_name
+                path_name = r'\\server\share'
+                if file_name:
+                    normalized_name = ntpath.normpath(file_name).lstrip('\\')
+                    path_name += '\\' + normalized_name
                 self.assertIn(path_name, client.GlobalFileTable)
 
                 if has_parent:
@@ -68,7 +71,7 @@ class SMB3CreateTests(unittest.TestCase):
 
     def test_existing_parent_entry_is_reused(self):
         file_name = r'folder\file.txt'
-        path_name = '\\\\server\\' + file_name
+        path_name = '\\\\server\\share\\' + file_name
         parent_dir = ntpath.dirname(path_name)
         parent_entry = object()
         client = self.create_client({parent_dir: parent_entry})

--- a/tests/SMB_RPC/test_smb3.py
+++ b/tests/SMB_RPC/test_smb3.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright Fortra, LLC and its affiliated companies
+#
+# All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+import ntpath
+import unittest
+from unittest.mock import Mock
+
+from impacket.smb3 import SMB3
+from impacket.smb3structs import SMB2_DIALECT_30, SMB3Packet
+
+
+class _SendReached(Exception):
+    pass
+
+
+class SMB3CreateTests(unittest.TestCase):
+
+    @staticmethod
+    def create_client(global_file_table=None):
+        client = object.__new__(SMB3)
+        client._Session = {
+            'TreeConnectTable': {1: {'IsDfsShare': False}},
+            'OpenTable': {},
+        }
+        client._Connection = {
+            'Dialect': SMB2_DIALECT_30,
+            'SupportsDirectoryLeasing': True,
+            'ServerName': 'server',
+        }
+        client.GlobalFileTable = {} if global_file_table is None else global_file_table
+        client.SMB_PACKET = SMB3Packet
+        client.sendSMB = Mock(side_effect=_SendReached)
+        return client
+
+    def assert_create_reaches_send(self, client, file_name):
+        with self.assertRaises(_SendReached):
+            client.create(1, file_name, 0, 0, 0, 0, 0)
+
+    def test_directory_leasing_parent_tracking(self):
+        cases = (
+            (r'\lsarpc', False),
+            (r'folder\file.txt', True),
+            (r'folder\child\file.txt', True),
+        )
+
+        for file_name, has_parent in cases:
+            with self.subTest(file_name=file_name):
+                client = self.create_client()
+                self.assert_create_reaches_send(client, file_name)
+
+                normalized_name = ntpath.normpath(file_name).lstrip('\\')
+                path_name = '\\\\server\\' + normalized_name
+                self.assertIn(path_name, client.GlobalFileTable)
+
+                if has_parent:
+                    self.assertIn(ntpath.dirname(path_name), client.GlobalFileTable)
+                    self.assertEqual(len(client.GlobalFileTable), 2)
+                else:
+                    self.assertEqual(list(client.GlobalFileTable), [path_name])
+
+    def test_existing_parent_entry_is_reused(self):
+        file_name = r'folder\file.txt'
+        path_name = '\\\\server\\' + file_name
+        parent_dir = ntpath.dirname(path_name)
+        parent_entry = object()
+        client = self.create_client({parent_dir: parent_entry})
+
+        self.assert_create_reaches_send(client, file_name)
+
+        self.assertIs(client.GlobalFileTable[parent_dir], parent_entry)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=1)


### PR DESCRIPTION
Fix SMB3 `GlobalFileTable` parent tracking when directory leasing is negotiated.

* Avoid referencing an uninitialized `parentDir` for shallow paths.
* Distinguish opening the share root from opening a root-level file.
* Include the share name in non-DFS global file keys.
* Reuse existing parent entries instead of raising an exception.
* Add regression coverage for share-root, root-level, nested, and repeated-parent cases.

This PR fixes https://github.com/fortra/impacket/issues/2256