### PR TITLE
Fix BootpDecoder crash on truncated BOOTP messages (#1900)

### DIFF
--- a/impacket/ImpactDecoder.py
+++ b/impacket/ImpactDecoder.py
@@ -963,16 +963,24 @@ class BootpDecoder(Decoder):
         pass
 
     def decode(self, aBuffer):
+        # RFC 1542 section 2.1 requires a BOOTP message to be at least 300 octets (the
+        # 236-byte fixed header of RFC 951 plus its 64-byte vend field) and says shorter
+        # messages MUST be discarded. Decode them on a best-effort basis instead of
+        # crashing, but warn that the message is non-conformant. See issue #1900.
+        if len(aBuffer) < 236:
+            # Not even the fixed header is complete, so BootpPacket() would raise
+            # struct.error part-way through unpacking it. Zero-pad the message so the
+            # fields that did arrive can still be decoded.
+            LOG.warning('BOOTP message is %d bytes and does not hold the complete 236-byte fixed '
+                        'header; zero-padding it to decode the fields that are present '
+                        '(RFC 1542 section 2.1 requires at least 300 octets)' % len(aBuffer))
+            aBuffer = bytes(aBuffer) + b'\x00' * (236 - len(aBuffer))
+        elif len(aBuffer) < 300:
+            LOG.warning('BOOTP message is %d bytes, shorter than the 300-octet minimum required by '
+                        'RFC 1542 section 2.1; decoding it on a best-effort basis' % len(aBuffer))
         d = dhcp.BootpPacket(aBuffer)
         self.set_decoded_protocol( d )
         off = len(d.getData())
-        # RFC 1542 section 2.1 requires a BOOTP message to be at least 300 octets
-        # (the 236-byte fixed header plus the 64-byte vend field of RFC 951). Shorter
-        # messages are truncated/non-conformant; decode the fixed header on a best-effort
-        # basis instead of crashing, but warn so the caller knows. See issue #1900.
-        if len(aBuffer) < 300:
-            LOG.warning('BOOTP message is %d bytes, shorter than the 300-octet minimum required by '
-                        'RFC 1542 section 2.1; decoding the fixed header on a best-effort basis' % len(aBuffer))
         # A truncated message may not carry the 4-byte DHCP magic cookie at all, so only
         # read it when enough trailing bytes are present, otherwise DhcpPacket() raises
         # struct.error while unpacking the cookie field.

--- a/impacket/ImpactDecoder.py
+++ b/impacket/ImpactDecoder.py
@@ -966,9 +966,16 @@ class BootpDecoder(Decoder):
         d = dhcp.BootpPacket(aBuffer)
         self.set_decoded_protocol( d )
         off = len(d.getData())
-        # A plain BOOTP packet may carry no vendor-specific/DHCP options area at all
-        # (RFC 951). Only try to parse the DHCP magic cookie when there are enough
-        # trailing bytes for it, otherwise DhcpPacket() raises struct.error. See issue #1900.
+        # RFC 1542 section 2.1 requires a BOOTP message to be at least 300 octets
+        # (the 236-byte fixed header plus the 64-byte vend field of RFC 951). Shorter
+        # messages are truncated/non-conformant; decode the fixed header on a best-effort
+        # basis instead of crashing, but warn so the caller knows. See issue #1900.
+        if len(aBuffer) < 300:
+            LOG.warning('BOOTP message is %d bytes, shorter than the 300-octet minimum required by '
+                        'RFC 1542 section 2.1; decoding the fixed header on a best-effort basis' % len(aBuffer))
+        # A truncated message may not carry the 4-byte DHCP magic cookie at all, so only
+        # read it when enough trailing bytes are present, otherwise DhcpPacket() raises
+        # struct.error while unpacking the cookie field.
         if len(aBuffer) - off >= 4 and dhcp.DhcpPacket(aBuffer[off:])['cookie'] == dhcp.DhcpPacket.MAGIC_NUMBER:
             self.data_decoder = DHCPDecoder()
             packet = self.data_decoder.decode(aBuffer[off:])

--- a/impacket/ImpactDecoder.py
+++ b/impacket/ImpactDecoder.py
@@ -966,7 +966,10 @@ class BootpDecoder(Decoder):
         d = dhcp.BootpPacket(aBuffer)
         self.set_decoded_protocol( d )
         off = len(d.getData())
-        if dhcp.DhcpPacket(aBuffer[off:])['cookie'] == dhcp.DhcpPacket.MAGIC_NUMBER:
+        # A plain BOOTP packet may carry no vendor-specific/DHCP options area at all
+        # (RFC 951). Only try to parse the DHCP magic cookie when there are enough
+        # trailing bytes for it, otherwise DhcpPacket() raises struct.error. See issue #1900.
+        if len(aBuffer) - off >= 4 and dhcp.DhcpPacket(aBuffer[off:])['cookie'] == dhcp.DhcpPacket.MAGIC_NUMBER:
             self.data_decoder = DHCPDecoder()
             packet = self.data_decoder.decode(aBuffer[off:])
             d.contains(packet)

--- a/tests/ImpactPacket/test_bootp_issue1900.py
+++ b/tests/ImpactPacket/test_bootp_issue1900.py
@@ -14,24 +14,32 @@ from impacket import ImpactDecoder
 from impacket import dhcp
 
 
-class TestBootpWithoutOptions(unittest.TestCase):
-    def test_plain_bootp_no_options(self):
-        """A plain BOOTP packet with only the 236-byte fixed header and no
-        vendor-specific/DHCP options area must decode without raising
-        struct.error (issue #1900)."""
+class TestBootpTruncated(unittest.TestCase):
+    def test_truncated_bootp_without_cookie(self):
+        """A truncated BOOTP message carrying only the 236-byte fixed header is
+        shorter than the 300-octet minimum of RFC 1542 section 2.1 and has no
+        vend/DHCP options area at all. Decoding it is deliberate best-effort
+        behaviour: the fixed fields are returned instead of raising
+        struct.error, and a warning reports the undersized message (issue
+        #1900)."""
         packet = b'\x01\x01\x01\x00' + b'\x00' * 232
         self.assertEqual(len(packet), 236)
-        decoded = ImpactDecoder.BootpDecoder().decode(packet)
+        with self.assertLogs('impacket', level='WARNING') as logs:
+            decoded = ImpactDecoder.BootpDecoder().decode(packet)
+        self.assertTrue(any('RFC 1542' in message for message in logs.output))
         self.assertIsInstance(decoded, dhcp.BootpPacket)
         # No DHCP child protocol should be attached when there is no cookie.
         self.assertIsNone(decoded.child())
 
-    def test_bootp_with_dhcp_options_still_decodes(self):
-        """A BOOTP packet followed by the DHCP magic cookie and a message-type
-        option must still be recognised as DHCP."""
-        packet = (b'\x01\x01\x01\x00' + b'\x00' * 232 +
-                  b'\x63\x82\x53\x63' +  # DHCP magic cookie
-                  b'\x35\x01\x01')       # option 53 (message-type) = DHCPDISCOVER
+    def test_full_length_bootp_with_dhcp_options_still_decodes(self):
+        """A conformant, full-length (300 octet) BOOTP message carrying the DHCP
+        magic cookie and a message-type option must still be recognised as
+        DHCP."""
+        payload = b'\x01\x01\x01\x00' + b'\x00' * 232
+        payload += b'\x63\x82\x53\x63'  # DHCP magic cookie
+        payload += b'\x35\x01\x01'  # option 53 (message-type) = DHCPDISCOVER
+        packet = payload + b'\x00' * (300 - len(payload))  # pad to the RFC 1542 minimum
+        self.assertEqual(len(packet), 300)
         decoded = ImpactDecoder.BootpDecoder().decode(packet)
         self.assertIsInstance(decoded, dhcp.BootpPacket)
         self.assertIsInstance(decoded.child(), dhcp.DhcpPacket)

--- a/tests/ImpactPacket/test_bootp_issue1900.py
+++ b/tests/ImpactPacket/test_bootp_issue1900.py
@@ -15,13 +15,35 @@ from impacket import dhcp
 
 
 class TestBootpTruncated(unittest.TestCase):
-    def test_truncated_bootp_without_cookie(self):
-        """A truncated BOOTP message carrying only the 236-byte fixed header is
-        shorter than the 300-octet minimum of RFC 1542 section 2.1 and has no
-        vend/DHCP options area at all. Decoding it is deliberate best-effort
-        behaviour: the fixed fields are returned instead of raising
-        struct.error, and a warning reports the undersized message (issue
-        #1900)."""
+    """Best-effort decoding of truncated BOOTP messages.
+
+    RFC 1542 section 2.1 requires a BOOTP message to be at least 300 octets (the
+    236-byte fixed header of RFC 951 plus its 64-byte vend field) and says that
+    shorter messages MUST be discarded. Rather than discarding them, the decoder
+    deliberately decodes what is present and warns, instead of raising
+    struct.error. These are truncated messages, not RFC-valid plain BOOTP.
+    """
+
+    def test_incomplete_fixed_header_is_zero_padded(self):
+        """The 235-byte message reported in issue #1900 stops one byte inside the
+        128-byte 'file' field, so BootpPacket() used to raise struct.error. It
+        must now be zero-padded and decoded best-effort, with a warning."""
+        packet = b'\x01\x01\x01\x00' + b'\x00' * 231
+        self.assertEqual(len(packet), 235)
+        with self.assertLogs('impacket', level='WARNING') as logs:
+            decoded = ImpactDecoder.BootpDecoder().decode(packet)
+        self.assertTrue(any('zero-padding' in message for message in logs.output))
+        self.assertIsInstance(decoded, dhcp.BootpPacket)
+        # The fields that did arrive are decoded normally.
+        self.assertEqual(decoded['op'], 1)
+        self.assertEqual(decoded['htype'], 1)
+        self.assertEqual(decoded['hlen'], 1)
+        self.assertIsNone(decoded.child())
+
+    def test_fixed_header_only_without_cookie(self):
+        """A 236-byte message holds the complete fixed header but carries no
+        vend/DHCP options area, so there is no magic cookie to read. It must
+        decode without raising struct.error, and warn that it is undersized."""
         packet = b'\x01\x01\x01\x00' + b'\x00' * 232
         self.assertEqual(len(packet), 236)
         with self.assertLogs('impacket', level='WARNING') as logs:

--- a/tests/ImpactPacket/test_bootp_issue1900.py
+++ b/tests/ImpactPacket/test_bootp_issue1900.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright Fortra, LLC and its affiliated companies
+#
+# All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+import unittest
+from impacket import ImpactDecoder
+from impacket import dhcp
+
+
+class TestBootpWithoutOptions(unittest.TestCase):
+    def test_plain_bootp_no_options(self):
+        """A plain BOOTP packet with only the 236-byte fixed header and no
+        vendor-specific/DHCP options area must decode without raising
+        struct.error (issue #1900)."""
+        packet = b'\x01\x01\x01\x00' + b'\x00' * 232
+        self.assertEqual(len(packet), 236)
+        decoded = ImpactDecoder.BootpDecoder().decode(packet)
+        self.assertIsInstance(decoded, dhcp.BootpPacket)
+        # No DHCP child protocol should be attached when there is no cookie.
+        self.assertIsNone(decoded.child())
+
+    def test_bootp_with_dhcp_options_still_decodes(self):
+        """A BOOTP packet followed by the DHCP magic cookie and a message-type
+        option must still be recognised as DHCP."""
+        packet = (b'\x01\x01\x01\x00' + b'\x00' * 232 +
+                  b'\x63\x82\x53\x63' +  # DHCP magic cookie
+                  b'\x35\x01\x01')       # option 53 (message-type) = DHCPDISCOVER
+        decoded = ImpactDecoder.BootpDecoder().decode(packet)
+        self.assertIsInstance(decoded, dhcp.BootpPacket)
+        self.assertIsInstance(decoded.child(), dhcp.DhcpPacket)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #1900.

RFC 1542 section 2.1 requires a BOOTP message to be at least 300 octets — the
236-byte fixed header of RFC 951 plus its 64-byte `vend` field — and says
shorter messages MUST be discarded. `BootpDecoder.decode()` currently raises
`struct.error` on them instead, in two different places:

* Below 236 bytes the fixed header itself is incomplete, so
  `dhcp.BootpPacket(aBuffer)` fails part-way through unpacking it. The 235-byte
  packet reported in #1900 stops one byte inside the 128-byte `file` field,
  which is where `unpack requires a buffer of 128 bytes` comes from.
* At exactly 236 bytes the fixed header is complete but there is no vend/DHCP
  options area behind it, so reading the 4-byte DHCP magic cookie fails as well.

Rather than discarding these messages, the decoder now decodes them on a
best-effort basis and warns that they are non-conformant:

* a message shorter than the 236-byte fixed header is zero-padded, so the fields
  that did arrive are still decoded, and a warning reports the padding;
* the magic cookie is only read when at least 4 trailing bytes are present, so a
  message without them decodes as a plain `BootpPacket` with no DHCP child;
* any message shorter than the 300-octet minimum is reported through
  `LOG.warning`.

Conformant, full-length DHCP packets are unaffected — a DHCP child is still
attached only when the magic cookie is actually present.

`tests/ImpactPacket/test_bootp_issue1900.py` covers the exact 235-byte packet
from the issue (it reproduces `unpack requires a buffer of 128 bytes` without
the decoder change), a 236-byte message with no cookie, and a conformant
300-octet DHCP message.
