### PR TITLE
IP: add DSCP and ECN accessors to the IP class

### DIFF
--- a/impacket/ImpactPacket.py
+++ b/impacket/ImpactPacket.py
@@ -892,6 +892,24 @@ class IP(Header):
     def set_ip_tos(self,value):
         self.set_byte(1, value)
 
+    # RFC 2474/3168 split the old ToS byte into a 6 bit DSCP field
+    # (high bits) and a 2 bit ECN field (low bits).
+    def get_ip_dscp(self):
+        return self.get_byte(1) >> 2
+
+    def set_ip_dscp(self, value):
+        n = self.get_byte(1) & 0x03
+        n |= (value & 0x3F) << 2
+        self.set_byte(1, n)
+
+    def get_ip_ecn(self):
+        return self.get_byte(1) & 0x03
+
+    def set_ip_ecn(self, value):
+        n = self.get_byte(1) & 0xFC
+        n |= value & 0x03
+        self.set_byte(1, n)
+
     def get_ip_len(self):
         if self.is_BSD:
             return self.get_word(2, order = '=')

--- a/tests/ImpactPacket/test_IP.py
+++ b/tests/ImpactPacket/test_IP.py
@@ -21,6 +21,32 @@ class TestIP(unittest.TestCase):
         fragments = ip.fragment_by_size(8)
         self.assertEqual(fragments, [ip])
 
+    def test_dscp_and_ecn_defaults(self):
+        ip = IP()
+        self.assertEqual(ip.get_ip_dscp(), 0)
+        self.assertEqual(ip.get_ip_ecn(), 0)
+
+    def test_set_dscp_keeps_ecn(self):
+        ip = IP()
+        ip.set_ip_ecn(3)
+        ip.set_ip_dscp(46)  # EF
+        self.assertEqual(ip.get_ip_dscp(), 46)
+        self.assertEqual(ip.get_ip_ecn(), 3)
+        self.assertEqual(ip.get_ip_tos(), (46 << 2) | 3)
+
+    def test_set_ecn_keeps_dscp(self):
+        ip = IP()
+        ip.set_ip_dscp(46)
+        ip.set_ip_ecn(2)
+        self.assertEqual(ip.get_ip_dscp(), 46)
+        self.assertEqual(ip.get_ip_ecn(), 2)
+
+    def test_dscp_ecn_derived_from_tos(self):
+        ip = IP()
+        ip.set_ip_tos(0xB9)
+        self.assertEqual(ip.get_ip_dscp(), 46)
+        self.assertEqual(ip.get_ip_ecn(), 1)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=1)


### PR DESCRIPTION
Closes #211.

The IP class only lets you read/write the whole ToS byte, but that byte has been the DiffServ field for a long time now, so this adds get/set for the DSCP and ECN parts separately, the same way IP6 exposes its traffic class. get_ip_tos/set_ip_tos are untouched and still cover the full byte, the new helpers just read and write the same one so you can set DSCP without clobbering ECN and vice versa. Added a few tests for the split.