### PR TITLE
[WMI] Support parsing UINT8 array objects in WMI GetObject 

### DIFF
--- a/impacket/dcerpc/v5/dcom/wmi.py
+++ b/impacket/dcerpc/v5/dcom/wmi.py
@@ -359,6 +359,8 @@ class ENCODED_VALUE(Structure):
                         unit['ObjectBlock'] = msb['ObjectBlock']
                         array.append(unit)
                         heapData = heapData[msb['EncodingLength']+4:]
+                elif cimType == CIM_TYPE_ENUM.CIM_ARRAY_UINT8.value:
+                    array = list(heapData)
                 else:
                     for item in range(numItems):
                         # ToDo: Learn to unpack the rest of the array of things

--- a/impacket/dcerpc/v5/dcom/wmi.py
+++ b/impacket/dcerpc/v5/dcom/wmi.py
@@ -361,6 +361,7 @@ class ENCODED_VALUE(Structure):
                         heapData = heapData[msb['EncodingLength']+4:]
                 elif cimType == CIM_TYPE_ENUM.CIM_ARRAY_UINT8.value:
                     array = list(heapData)
+                    array = array[:(dataSizeArray*numItems)]
                 else:
                     for item in range(numItems):
                         # ToDo: Learn to unpack the rest of the array of things

--- a/impacket/dcerpc/v5/dcom/wmi.py
+++ b/impacket/dcerpc/v5/dcom/wmi.py
@@ -360,7 +360,7 @@ class ENCODED_VALUE(Structure):
                         array.append(unit)
                         heapData = heapData[msb['EncodingLength']+4:]
                 elif cimType == CIM_TYPE_ENUM.CIM_ARRAY_UINT8.value:
-                    array = list(heapData)[:(dataSizeArray*numItems)]
+                    array = list(heapData[:dataSizeArray*numItems])
                 else:
                     for item in range(numItems):
                         # ToDo: Learn to unpack the rest of the array of things

--- a/impacket/dcerpc/v5/dcom/wmi.py
+++ b/impacket/dcerpc/v5/dcom/wmi.py
@@ -360,8 +360,7 @@ class ENCODED_VALUE(Structure):
                         array.append(unit)
                         heapData = heapData[msb['EncodingLength']+4:]
                 elif cimType == CIM_TYPE_ENUM.CIM_ARRAY_UINT8.value:
-                    array = list(heapData)
-                    array = array[:(dataSizeArray*numItems)]
+                    array = list(heapData)[:(dataSizeArray*numItems)]
                 else:
                     for item in range(numItems):
                         # ToDo: Learn to unpack the rest of the array of things

--- a/tests/SMB_RPC/test_wmi.py
+++ b/tests/SMB_RPC/test_wmi.py
@@ -260,6 +260,35 @@ class WMITests(RemoteTestCase, unittest.TestCase):
             _ = iWbemServices.DeleteClass(className)
             dcom.disconnect()
 
+    def test_IWbemServices_GetObject_uint8_array(self):
+        dcom, iWbemServices = self._connect_wmi()
+        className = "DummyClass_%s" % uuid.uuid4().hex
+        propertyName = "Bytes"
+        expectedValue = [0, 1, 127, 255]
+        cimType = wmi.CIM_TYPE_ENUM.CIM_ARRAY_UINT8.value
+        previousCimTypeName = wmi.CIM_TYPE_TO_NAME.get(cimType)
+        try:
+            # The class serializer needs this type name to construct the remote fixture.
+            wmi.CIM_TYPE_TO_NAME[cimType] = 'uint8'
+            dummyClass, _ = iWbemServices.GetObject('')
+            dummyClass.setClassName(className)
+            dummyClass.addNewAttribute(
+                propertyName, wmi.CIM_TYPE_ENUM.CIM_ARRAY_UINT8, expectedValue
+            )
+            iWbemServices.PutClass(dummyClass.marshalMe(), wmi.WBEM_FLAG_CREATE_ONLY)
+
+            createdClass, _ = iWbemServices.GetObject(className)
+            propertyValue = createdClass.getProperties()[propertyName]
+            self.assertEqual(propertyValue['type'], cimType)
+            self.assertEqual(propertyValue['value'], str(expectedValue))
+        finally:
+            _ = iWbemServices.DeleteClass(className)
+            if previousCimTypeName is None:
+                del wmi.CIM_TYPE_TO_NAME[cimType]
+            else:
+                wmi.CIM_TYPE_TO_NAME[cimType] = previousCimTypeName
+            dcom.disconnect()
+
 
     def test_IWbemServices_DeleteClass_missing(self):
         dcom, iWbemServices = self._connect_wmi()

--- a/tests/SMB_RPC/test_wmi.py
+++ b/tests/SMB_RPC/test_wmi.py
@@ -262,31 +262,17 @@ class WMITests(RemoteTestCase, unittest.TestCase):
 
     def test_IWbemServices_GetObject_uint8_array(self):
         dcom, iWbemServices = self._connect_wmi()
-        className = "DummyClass_%s" % uuid.uuid4().hex
-        propertyName = "Bytes"
-        expectedValue = [0, 1, 127, 255]
-        cimType = wmi.CIM_TYPE_ENUM.CIM_ARRAY_UINT8.value
-        previousCimTypeName = wmi.CIM_TYPE_TO_NAME.get(cimType)
         try:
-            # The class serializer needs this type name to construct the remote fixture.
-            wmi.CIM_TYPE_TO_NAME[cimType] = 'uint8'
-            dummyClass, _ = iWbemServices.GetObject('')
-            dummyClass.setClassName(className)
-            dummyClass.addNewAttribute(
-                propertyName, wmi.CIM_TYPE_ENUM.CIM_ARRAY_UINT8, expectedValue
-            )
-            iWbemServices.PutClass(dummyClass.marshalMe(), wmi.WBEM_FLAG_CREATE_ONLY)
-
-            createdClass, _ = iWbemServices.GetObject(className)
-            propertyValue = createdClass.getProperties()[propertyName]
-            self.assertEqual(propertyValue['type'], cimType)
-            self.assertEqual(propertyValue['value'], str(expectedValue))
+            try:
+                eventFilterClass, _ = iWbemServices.GetObject('__EventFilter')
+            except Exception as exc:
+                if 'WBEM_E_NOT_FOUND' in str(exc):
+                    self.skipTest('__EventFilter is unavailable on the remote host')
+                raise
+            creatorSID = eventFilterClass.getProperties()['CreatorSID']
+            self.assertEqual(creatorSID['type'], wmi.CIM_TYPE_ENUM.CIM_ARRAY_UINT8.value)
+            self.assertEqual(creatorSID['value'], '[1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0]')
         finally:
-            _ = iWbemServices.DeleteClass(className)
-            if previousCimTypeName is None:
-                del wmi.CIM_TYPE_TO_NAME[cimType]
-            else:
-                wmi.CIM_TYPE_TO_NAME[cimType] = previousCimTypeName
             dcom.disconnect()
 
 


### PR DESCRIPTION
Add specific support for UINT8 array in WMI GetObject. This will help us in NXC / dploot to dump files, even big ones, through WMI