### PR TITLE
secretsdump: respect -history for trust keys

### DIFF
--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -465,7 +465,8 @@ if __name__ == '__main__':
                        help='Shows pwdLastSet attribute for each NTDS.DIT account. Doesn\'t apply to -outputfile data')
     group.add_argument('-user-status', action='store_true', default=False,
                        help='Display whether or not the user is disabled')
-    group.add_argument('-history', action='store_true', help='Dump password history (NTDS and SAM hashes), and LSA secrets OldVal')
+    group.add_argument('-history', action='store_true',
+                       help='Dump password history (NTDS and SAM hashes), LSA secrets OldVal, and previous trust keys')
 
     group = parser.add_argument_group('authentication')
     group.add_argument('-hashes', action="store", metavar="LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -3464,7 +3464,7 @@ class NTDSHashes:
                     if outputFile is not None:
                         self.__writeOutput(outputFile, line + '\n')
                     count += 1
-                if previousSecret:
+                if previousSecret and self.__history:
                     for line in _format_trust_secrets(partner, previousSecret, self.__domainFQDN, isIncoming, previous=True, justNTLM=self.__justNTLM):
                         self.__perSecretCallback(NTDSHashes.SECRET_TYPE.NTDS, line)
                         if outputFile is not None:
@@ -3563,7 +3563,7 @@ class NTDSHashes:
                     self.__perSecretCallback(NTDSHashes.SECRET_TYPE.NTDS, line)
                     if outputFile is not None:
                         self.__writeOutput(outputFile, line + '\n')
-            if previousSecret:
+            if previousSecret and self.__history:
                 for line in _format_trust_secrets(partner, previousSecret, domain, isIncoming, previous=True, justNTLM=self.__justNTLM):
                     self.__perSecretCallback(NTDSHashes.SECRET_TYPE.NTDS, line)
                     if outputFile is not None:

--- a/tests/SMB_RPC/test_secretsdump.py
+++ b/tests/SMB_RPC/test_secretsdump.py
@@ -13,6 +13,7 @@ import logging
 import struct
 import pytest
 import unittest
+from unittest import mock
 from tests import RemoteTestCase
 
 from impacket.dcerpc.v5 import samr
@@ -262,6 +263,44 @@ class Options(object):
 
 
 class NTDSHashesUnitTests(unittest.TestCase):
+
+    def test_trust_key_history_is_controlled_by_history_option(self):
+        class FakeESEDB:
+            def openTable(self, table_name):
+                self.returned = False
+                return object()
+
+            def getNextRow(self, cursor, filter_tables=None):
+                if self.returned:
+                    return None
+                self.returned = True
+                return self.record
+
+        for history, expected_lines in ((False, 3), (True, 6)):
+            with self.subTest(history=history):
+                esedb = FakeESEDB()
+                esedb.record = {
+                    NTDSHashes.NAME_TO_INTERNAL['trustPartner']: 'partner.example',
+                    NTDSHashes.NAME_TO_INTERNAL['trustAuthIncoming']: b'encrypted',
+                    NTDSHashes.NAME_TO_INTERNAL['trustAuthOutgoing']: None,
+                }
+
+                ntds = object.__new__(NTDSHashes)
+                ntds._NTDSHashes__domainFQDN = 'local.example'
+                ntds._NTDSHashes__securityHive = None
+                ntds._NTDSHashes__ESEDB = esedb
+                ntds._NTDSHashes__history = history
+                ntds._NTDSHashes__justNTLM = False
+                output = []
+                ntds._NTDSHashes__perSecretCallback = lambda secret_type, line: output.append(line)
+                ntds._NTDSHashes__decryptTrustAuthBlob = lambda value: b'trust-auth-info'
+
+                with mock.patch('impacket.examples.secretsdump._parse_trust_auth_info',
+                                return_value=(b'current-secret', b'previous-secret')):
+                    ntds._NTDSHashes__dumpTrustKeysOffline()
+
+                self.assertEqual(expected_lines, len(output))
+                self.assertEqual(history, any(', previous)' in line for line in output))
 
     def test_header_only_supplemental_credentials_are_ignored(self):
         header_only_properties = (


### PR DESCRIPTION
## description

Follow-up to https://github.com/fortra/impacket/pull/2207 (-trust-keys/-just-trust-keys), `secretsdump -trust-keys` always displayed the previous trust password, even when `-history` was not specified.

this change makes previous trust keys follow the existing `-history` option:

- without `-history`, only the current trust key is displayed;
- with `-history`, both current and previous trust keys are displayed.
<img width="1812" height="1253" alt="image" src="https://github.com/user-attachments/assets/9790dcd7-9ba5-4c3c-b314-43dc7bbc6397" />


the behavior is fixed for both the online drsuapi path and the offline ntds.dit path.

## testing

- added a unit test covering `-history` enabled and disabled.
- targeted test passes:
  `python -m pytest -q tests/SMB_RPC/test_secretsdump.py -k trust_key_history_is_controlled_by_history_option`