### PR TITLE
[WMI] Support kwargs-style style method calling

### DIFF
--- a/impacket/dcerpc/v5/dcom/wmi.py
+++ b/impacket/dcerpc/v5/dcom/wmi.py
@@ -2847,9 +2847,152 @@ class IWbemClassObject(IRemUnknown):
                 return partial(self.function,item)
 
         @FunctionPool
-        def innerMethod(staticArgs, *args):
-            classOrInstance = staticArgs[0] 
-            methodDefinition = staticArgs[1] 
+        def innerMethod(staticArgs, *args, **kwargs):
+            classOrInstance = staticArgs[0]
+            methodDefinition = staticArgs[1]
+            # Kwargs path: send only supplied InParams; unspecified ones get
+            # NdTable=null (0b10) — matches `wmic call M foo=1` semantics.
+            if kwargs and not args:
+                inParamsDef = methodDefinition.get('InParams') or {}
+
+                # Buffers
+                valueTable = b''
+                ndTable = 0
+                instanceHeap = b''
+
+                # Heap header: __PARAMETERS class name
+                paramsClassName = ENCODED_STRING()
+                paramsClassName['Character'] = '__PARAMETERS'
+                instanceHeap += paramsClassName.getData()
+                curHeapPtr = len(instanceHeap)
+
+                # Walk InParams: missing → null + zero-pad slot, present → marshal
+                for idx, (pname, pdef) in enumerate(inParamsDef.items()):
+                    rawType = pdef['type']
+                    pType = rawType & ~(CIM_ARRAY_FLAG | Inherited)
+                    isArray = bool(rawType & CIM_ARRAY_FLAG)
+                    slotFmt = HEAPREF[:-2] if isArray else CIM_TYPES_REF[pType][:-2]
+
+                    if pname not in kwargs:
+                        valueTable += b'\x00' * calcsize(slotFmt)
+                        ndTable |= (2 << (idx * 2))
+                        continue
+
+                    val = kwargs[pname]
+                    if isArray:
+                        if val is None or len(val) == 0:
+                            valueTable += pack(slotFmt, 0)
+                        elif pType in (CIM_TYPE_ENUM.CIM_TYPE_STRING.value,
+                                       CIM_TYPE_ENUM.CIM_TYPE_DATETIME.value,
+                                       CIM_TYPE_ENUM.CIM_TYPE_REFERENCE.value):
+                            # Array of string-like: heap-pointer table + payload
+                            items = []
+                            for sv in val:
+                                s = ENCODED_STRING()
+                                if isinstance(sv, str):
+                                    s['Encoded_String_Flag'] = 0x1
+                                    s.structure = s.tunicode
+                                    s['Character'] = sv.encode('utf-16le')
+                                else:
+                                    s['Character'] = sv
+                                items.append(s.getData())
+                            n = len(items)
+                            arraySize = pack(HEAPREF[:-2], n)
+                            curStrPtr = curHeapPtr + 4
+                            heapRefs = b''
+                            payload = b''
+                            for j, it in enumerate(items):
+                                heapRefs += pack('<L', curStrPtr + 4 * (n - j) + len(payload))
+                                payload += it
+                                curStrPtr += 4
+                            valueTable += pack('<L', curHeapPtr)
+                            instanceHeap += arraySize + heapRefs + payload
+                            curHeapPtr = len(instanceHeap)
+                        else:
+                            # Array of fixed-width numerics
+                            elemFmt = CIM_TYPES_REF[pType][:-2]
+                            valueTable += pack('<L', curHeapPtr)
+                            instanceHeap += pack(HEAPREF[:-2], len(val))
+                            for e in val:
+                                instanceHeap += pack(elemFmt, e)
+                            curHeapPtr = len(instanceHeap)
+                    elif pType in (CIM_TYPE_ENUM.CIM_TYPE_STRING.value,
+                                   CIM_TYPE_ENUM.CIM_TYPE_DATETIME.value,
+                                   CIM_TYPE_ENUM.CIM_TYPE_REFERENCE.value):
+                        # Scalar string-like
+                        s = ENCODED_STRING()
+                        if isinstance(val, str):
+                            s['Encoded_String_Flag'] = 0x1
+                            s.structure = s.tunicode
+                            s['Character'] = val.encode('utf-16le')
+                        else:
+                            s['Character'] = val
+                        valueTable += pack('<L', curHeapPtr)
+                        instanceHeap += s.getData()
+                        curHeapPtr = len(instanceHeap)
+                    elif pType == CIM_TYPE_ENUM.CIM_TYPE_OBJECT.value:
+                        # Embedded instance — pass positionally instead
+                        raise NotImplementedError(
+                            "CIM_TYPE_OBJECT (embedded instance) InParams not supported via kwargs; pass positionally instead")
+                    else:
+                        # Fixed-width scalar (BOOL / UINT / SINT / REAL)
+                        if pType == CIM_TYPE_ENUM.CIM_TYPE_BOOLEAN.value:
+                            val = 1 if val else 0
+                        valueTable += pack(slotFmt, val)
+
+                # Pack NdTable bits (2 per param) little-endian
+                ndBytes = (len(inParamsDef) * 2 + 7) // 8
+                packedNd = b''
+                n = ndTable
+                for _ in range(ndBytes):
+                    packedNd += pack('B', n & 0xff)
+                    n >>= 8
+
+                # Assemble INSTANCE_TYPE
+                instanceType = INSTANCE_TYPE()
+                instanceType['CurrentClass'] = b''
+                instanceType['InstanceQualifierSet'] = b'\x04\x00\x00\x00\x01'
+                instanceType['NdTable_ValueTable'] = packedNd + valueTable
+
+                # Heap record
+                heapRecord = HEAP()
+                heapRecord['HeapLength'] = len(instanceHeap) | 0x80000000
+                heapRecord['HeapItem'] = instanceHeap
+                instanceType['InstanceHeap'] = heapRecord
+
+                # Append InParams class definition (trailing CurrentClass)
+                instanceType['EncodingLength'] = len(instanceType)
+                classPart = methodDefinition['InParamsRaw']['ClassType']['CurrentClass']['ClassPart']
+                classPart['ClassHeader']['EncodingLength'] = len(classPart.getData())
+                instanceType['CurrentClass'] = classPart
+
+                # Wrap as OBJREF_CUSTOM payload
+                inParamsBlock = OBJECT_BLOCK()
+                inParamsBlock.structure += OBJECT_BLOCK.instanceType
+                inParamsBlock['ObjectFlags'] = CIM_INSTANCE
+                inParamsBlock['Decoration'] = b''
+                inParamsBlock['InstanceType'] = instanceType.getData()
+
+                encodingUnit = ENCODING_UNIT()
+                encodingUnit['ObjectBlock'] = inParamsBlock
+                encodingUnit['ObjectEncodingLength'] = len(inParamsBlock)
+
+                objRefCustomIn = OBJREF_CUSTOM()
+                objRefCustomIn['iid'] = self._iid
+                objRefCustomIn['clsid'] = CLSID_WbemClassObject
+                objRefCustomIn['cbExtension'] = 0
+                objRefCustomIn['ObjectReferenceSize'] = len(encodingUnit)
+                objRefCustomIn['pObjectData'] = encodingUnit
+
+                # Invoke; tolerate OutParams parser quirk on flat-blob responses
+                try:
+                    return self.__iWbemServices.ExecMethod(
+                        classOrInstance, methodDefinition['name'], pInParams=objRefCustomIn)
+                except TypeError as e:
+                    if "byte indices must be integers" in str(e):
+                        return None
+                    raise
+
             if methodDefinition['InParams'] is not None:
                 if len(args) != len(methodDefinition['InParams']):
                     LOG.error("Function called with %d parameters instead of %d!" % (len(args), len(methodDefinition['InParams'])))

--- a/tests/SMB_RPC/test_wmi.py
+++ b/tests/SMB_RPC/test_wmi.py
@@ -65,8 +65,8 @@ class WMITests(RemoteTestCase, unittest.TestCase):
         super(WMITests, self).setUp()
         self.set_transport_config()
 
-    def _connect_wmi(self):
-        namespace = '\\\\%s\\root\\cimv2' % self.machine
+    def _connect_wmi(self, namespace='root\\cimv2'):
+        namespace = '\\\\%s\\%s' % (self.machine, namespace)
         dcom = DCOMConnection(self.machine, self.username, self.password, self.domain, self.lmhash, self.nthash)
         iInterface = dcom.CoCreateInstanceEx(wmi.CLSID_WbemLevel1Login, wmi.IID_IWbemLevel1Login)
         iWbemLevel1Login = wmi.IWbemLevel1Login(iInterface)
@@ -216,6 +216,56 @@ class WMITests(RemoteTestCase, unittest.TestCase):
         #print obj.getProperties()
 
         dcom.disconnect()
+
+    def test_IWbemServices_ExecMethod_kwargs_partial_params(self):
+        # Kwargs-only call: unspecified InParams are sent as null through the NdTable
+        # (same semantics as `wmic path <class> call <method> <param>=<value>`),
+        # instead of requiring the full positional signature
+        dcom, iWbemServices = self._connect_wmi()
+        try:
+            classObject, _ = iWbemServices.GetObject('Win32_Process')
+            resp = classObject.Create(CommandLine='cmd.exe /c exit 0')
+            props = resp.getProperties()
+            self.assertEqual(props['ReturnValue']['value'], 0)
+            self.assertGreater(props['ProcessId']['value'], 0)
+        finally:
+            dcom.disconnect()
+
+    def test_IWbemServices_ExecMethod_kwargs_order_independent(self):
+        # Kwargs are bound by name, so the order in the call does not matter
+        dcom, iWbemServices = self._connect_wmi()
+        try:
+            classObject, _ = iWbemServices.GetObject('Win32_Process')
+            resp = classObject.Create(CurrentDirectory='c:\\', CommandLine='cmd.exe /c exit 0')
+            props = resp.getProperties()
+            self.assertEqual(props['ReturnValue']['value'], 0)
+            self.assertGreater(props['ProcessId']['value'], 0)
+        finally:
+            dcom.disconnect()
+
+    def test_IWbemServices_ExecMethod_kwargs_string_array(self):
+        # String-array InParams are marshalled as heap-referenced encoded strings;
+        # round-trip a REG_MULTI_SZ value through StdRegProv using kwargs calls only
+        dcom, iWbemServices = self._connect_wmi('root\\default')
+        try:
+            stdRegProv, _ = iWbemServices.GetObject('StdRegProv')
+            hklm = 2147483650
+            subKey = 'SOFTWARE\\impacket_kwarg_test_%s' % uuid.uuid4().hex
+            values = ['impacket', 'kwargs', 'multi', 'string']
+            stdRegProv.CreateKey(hDefKey=hklm, sSubKeyName=subKey)
+            try:
+                resp = stdRegProv.SetMultiStringValue(hDefKey=hklm, sSubKeyName=subKey,
+                                                      sValueName='MultiString', sValue=values)
+                self.assertEqual(resp.ReturnValue, 0)
+
+                fetched = stdRegProv.GetMultiStringValue(hDefKey=hklm, sSubKeyName=subKey,
+                                                         sValueName='MultiString')
+                self.assertEqual(fetched.ReturnValue, 0)
+                self.assertEqual(fetched.sValue, values)
+            finally:
+                stdRegProv.DeleteKey(hDefKey=hklm, sSubKeyName=subKey)
+        finally:
+            dcom.disconnect()
 
     def test_IWbemServices_PutClass(self):
         dcom, iWbemServices = self._connect_wmi() 


### PR DESCRIPTION
With this patch, it can do like wmic call

For example, wmiexec.py's win32_process
```
Win32_Process.Create(command, dir, None)
```

`None = ProcessStartupInformation`, but in fact, `ProcessStartupInformation` is unnecessary, the main reason why need to set it to `None` because current wmi.py is not support calling method like kwargs style in NdTable.
<img width="1635" height="725" alt="image" src="https://github.com/user-attachments/assets/739c4aef-72e4-49b1-9508-86f64b9def7f" />

With this patch, we can do like `wmic call`
```
Win32_Process.Create(CommandLine=command, CurrentDirectory=dir)
```

More example: `MSFT_MpPreference`

Without this patch, we need to set over 100 parameters when calling "Set" func in `MSFT_MpPreference`.
<img width="1637" height="775" alt="image" src="https://github.com/user-attachments/assets/767aaa0d-42b4-4406-859c-67d444b282f0" />

With this patch, we can doing like `wmic /namespace:\root\microsoft\windows\defender path MSFT_MpPreference call Set DisableRealtimeMonitoring=TRUE` without set over 100 parameters.

- Defender on
<img width="1560" height="303" alt="image" src="https://github.com/user-attachments/assets/4dbef6f1-caf3-4b56-bf6b-b5711c950192" />

- Defender off
<img width="1570" height="855" alt="1777038656044" src="https://github.com/user-attachments/assets/5ef8b2c7-c4e4-4ee1-a50a-275e7e91f5d9" />
