### PR TITLE
  ntlmrelayx: migrate AD CS CSR generation to cryptography

### DIFF
--- a/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
@@ -18,10 +18,10 @@
 import re
 import base64
 import os
-from OpenSSL import crypto
 import urllib.parse
 
 from cryptography import x509
+from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import pkcs12
 from cryptography.hazmat.primitives.serialization import NoEncryption, Encoding
 from cryptography.hazmat.primitives import hashes
@@ -63,15 +63,6 @@ def _oid_encode(oid_str):
     return _tlv(0x06, c)
 
 
-def _encode_upn_san(upn):
-    """GeneralNames SEQUENCE containing OtherName[msUPN] = UTF8String(upn)"""
-    utf8 = _tlv(0x0c, upn.encode('utf-8'))
-    val  = _tlv(0xa0, utf8)
-    oid  = _oid_encode("1.3.6.1.4.1.311.20.2.3")
-    on   = _tlv(0xa0, oid + val)
-    return _tlv(0x30, on)
-
-
 def _encode_sid_ext(sid):
     """szOID_NTDS_CA_SECURITY_EXT value: GeneralNames containing OtherName[NTDS_OBJECTSID]"""
     oct_s = _tlv(0x04, sid.encode('utf-8'))
@@ -86,10 +77,10 @@ ELEVATED = []
 
 class ADCSAttack:
     UPN_OID = ObjectIdentifier("1.3.6.1.4.1.311.20.2.3")
+    NTDS_CA_SECURITY_EXT_OID = ObjectIdentifier("1.3.6.1.4.1.311.25.2")
 
     def _run(self):
-        key = crypto.PKey()
-        key.generate_key(crypto.TYPE_RSA, 4096)
+        key = rsa.generate_private_key(public_exponent=65537, key_size=4096)
 
         if self.username in ELEVATED:
             LOG.info('Skipping user %s since attack was already performed' % self.username)
@@ -176,7 +167,7 @@ class ADCSAttack:
 
         cert_obj = load_pem_x509_certificate(certificate.encode(), backend=default_backend())
         pfx_filename = self._sanitize_filename(self.username or self._extract_certificate_identity(cert_obj) or "certificate_{0}".format(certificate_id))
-        certificate_store = self.generate_pfx(key.to_cryptography_key(), cert_obj)
+        certificate_store = self.generate_pfx(key, cert_obj)
         output_path = os.path.join(self.config.lootdir, "{}.pfx".format(pfx_filename))
         LOG.info("Writing PKCS#12 certificate to %s" % output_path)
         try:
@@ -194,45 +185,45 @@ class ADCSAttack:
             LOG.info("This certificate can also be used for user : {}".format(self.config.altName))
 
     @staticmethod
-    def generate_csr(key, CN, altName, csr_type=crypto.FILETYPE_PEM, altSid=None):
+    def generate_csr(key, CN, altName, csr_type=Encoding.PEM, altSid=None):
         LOG.info("Generating CSR...")
 
-        if altSid is None:
-            req = crypto.X509Req()
-            if CN:
-                req.get_subject().CN = CN
-            if altName:
-                req.add_extensions([crypto.X509Extension(b"subjectAltName", False,
-                    b"otherName:1.3.6.1.4.1.311.20.2.3;UTF8:%b" % altName.encode())])
-            req.set_pubkey(key)
-            req.sign(key, "sha256")
-            return crypto.dump_certificate_request(csr_type, req)
+        if hasattr(key, 'to_cryptography_key'):
+            key = key.to_cryptography_key()
 
-        private_key = key.to_cryptography_key()
-        builder = x509.CertificateSigningRequestBuilder()
-        builder = builder.subject_name(x509.Name([
-            x509.NameAttribute(NameOID.COMMON_NAME, CN or "")
-        ]))
+        if csr_type in (Encoding.PEM, 1):  # OpenSSL.crypto.FILETYPE_PEM == 1
+            encoding = Encoding.PEM
+        elif csr_type in (Encoding.DER, 2):  # OpenSSL.crypto.FILETYPE_ASN1 == 2
+            encoding = Encoding.DER
+        else:
+            raise ValueError("Unsupported CSR encoding")
+
+        subject = []
+        if CN:
+            subject.append(x509.NameAttribute(NameOID.COMMON_NAME, CN))
+
+        builder = x509.CertificateSigningRequestBuilder().subject_name(x509.Name(subject))
         if altName:
             builder = builder.add_extension(
+                x509.SubjectAlternativeName([
+                    x509.OtherName(
+                        ADCSAttack.UPN_OID,
+                        _tlv(0x0c, altName.encode('utf-8'))
+                    )
+                ]),
+                critical=False
+            )
+        if altSid is not None:
+            builder = builder.add_extension(
                 x509.UnrecognizedExtension(
-                    oid=ObjectIdentifier("2.5.29.17"),
-                    value=_encode_upn_san(altName)
+                    oid=ADCSAttack.NTDS_CA_SECURITY_EXT_OID,
+                    value=_encode_sid_ext(altSid)
                 ),
                 critical=False
             )
-        builder = builder.add_extension(
-            x509.UnrecognizedExtension(
-                oid=ObjectIdentifier("1.3.6.1.4.1.311.25.2"),
-                value=_encode_sid_ext(altSid)
-            ),
-            critical=False
-        )
-        csr = builder.sign(private_key, hashes.SHA256(), default_backend())
-        if csr_type == crypto.FILETYPE_PEM:
-            return csr.public_bytes(Encoding.PEM)
-        else:
-            return csr.public_bytes(Encoding.DER)
+
+        csr = builder.sign(key, hashes.SHA256(), default_backend())
+        return csr.public_bytes(encoding)
 
     @staticmethod
     def generate_pfx(key, certificate):

--- a/impacket/examples/ntlmrelayx/attacks/rpcattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/rpcattack.py
@@ -19,9 +19,10 @@ import time
 import string
 import random
 
-from OpenSSL import crypto
 from cryptography.x509 import load_der_x509_certificate
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import Encoding
 
 from impacket import LOG
 from impacket.dcerpc.v5 import tsch, icpr
@@ -123,8 +124,7 @@ class TSCHRPCAttack:
 
 class ICPRRPCAttack:
     def _run(self):
-        key = crypto.PKey()
-        key.generate_key(crypto.TYPE_RSA, 4096)
+        key = rsa.generate_private_key(public_exponent=65537, key_size=4096)
 
         if self.username in ELEVATED:
             LOG.info('Skipping user %s since attack was already performed' % self.username)
@@ -138,7 +138,7 @@ class ICPRRPCAttack:
 
         altSid = getattr(self.config, 'altSid', None)
         csr = ADCSAttack.generate_csr(key, self.username, self.config.altName,
-                                      crypto.FILETYPE_ASN1, altSid=altSid)
+                                      csr_type=Encoding.DER, altSid=altSid)
         if altSid:
             LOG.info("CSR generated with SID extension: %s" % altSid)
         else:
@@ -165,7 +165,7 @@ class ICPRRPCAttack:
 
         cert_obj = load_der_x509_certificate(certificate, backend=default_backend())
         pfx_filename = ADCSAttack._sanitize_filename(self.username or ADCSAttack._extract_certificate_identity(cert_obj) or "certificate")
-        certificate_store = ADCSAttack.generate_pfx(key.to_cryptography_key(), cert_obj)
+        certificate_store = ADCSAttack.generate_pfx(key, cert_obj)
         output_path = os.path.join(self.config.lootdir, "{}.pfx".format(pfx_filename))
         LOG.info("Writing PKCS#12 certificate to %s" % output_path)
         try:

--- a/tests/misc/test_ntlmrelayx_adcs.py
+++ b/tests/misc/test_ntlmrelayx_adcs.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright Fortra, LLC and its affiliated companies
+#
+# All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+import unittest
+
+from OpenSSL import crypto
+from cryptography import x509
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import Encoding
+from cryptography.x509.oid import ExtensionOID, NameOID
+
+from impacket.examples.ntlmrelayx.attacks.httpattacks.adcsattack import ADCSAttack
+
+
+class ADCSCertificateSigningRequestTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    def test_generate_pem_csr_without_subject_or_extensions(self):
+        data = ADCSAttack.generate_csr(self.key, None, None)
+        request = x509.load_pem_x509_csr(data)
+
+        self.assertTrue(data.startswith(b"-----BEGIN CERTIFICATE REQUEST-----"))
+        self.assertEqual(request.subject, x509.Name([]))
+        self.assertEqual(len(request.extensions), 0)
+        self.assertEqual(request.signature_hash_algorithm.name, "sha256")
+        self.assertTrue(request.is_signature_valid)
+
+    def test_generate_pem_csr_with_common_name_and_upn_san(self):
+        upn = "alice@example.test"
+        data = ADCSAttack.generate_csr(self.key, "alice", upn)
+        request = x509.load_pem_x509_csr(data)
+
+        common_names = request.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+        self.assertEqual([attribute.value for attribute in common_names], ["alice"])
+
+        extension = request.extensions.get_extension_for_oid(
+            ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+        )
+        other_names = extension.value.get_values_for_type(x509.OtherName)
+        self.assertFalse(extension.critical)
+        self.assertEqual(len(other_names), 1)
+        self.assertEqual(other_names[0].type_id, ADCSAttack.UPN_OID)
+        self.assertEqual(other_names[0].value, b"\x0c\x12alice@example.test")
+        self.assertEqual(
+            extension.value.public_bytes(),
+            bytes.fromhex(
+                "3024a022060a2b060104018237140203a0140c12"
+                "616c696365406578616d706c652e74657374"
+            )
+        )
+        self.assertTrue(request.is_signature_valid)
+
+    def test_generate_der_csr_with_upn_and_sid_extensions(self):
+        data = ADCSAttack.generate_csr(
+            self.key,
+            "alice",
+            "alice@example.test",
+            csr_type=Encoding.DER,
+            altSid="S-1-5-21-1"
+        )
+        request = x509.load_der_x509_csr(data)
+
+        self.assertFalse(data.startswith(b"-----BEGIN"))
+        sid_extension = request.extensions.get_extension_for_oid(
+            ADCSAttack.NTDS_CA_SECURITY_EXT_OID
+        )
+        self.assertFalse(sid_extension.critical)
+        self.assertIsInstance(sid_extension.value, x509.UnrecognizedExtension)
+        self.assertEqual(
+            sid_extension.value.value,
+            bytes.fromhex(
+                "301ca01a060a2b060104018237190201a00c040a"
+                "532d312d352d32312d31"
+            )
+        )
+        self.assertIsNotNone(
+            request.extensions.get_extension_for_oid(
+                ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+            )
+        )
+        self.assertTrue(request.is_signature_valid)
+
+    def test_generate_csr_accepts_legacy_pyopenssl_arguments(self):
+        key = crypto.PKey.from_cryptography_key(self.key)
+        cases = (
+            (crypto.FILETYPE_PEM, x509.load_pem_x509_csr),
+            (crypto.FILETYPE_ASN1, x509.load_der_x509_csr),
+        )
+
+        for csr_type, loader in cases:
+            with self.subTest(csr_type=csr_type):
+                data = ADCSAttack.generate_csr(
+                    key,
+                    "alice",
+                    None,
+                    csr_type=csr_type
+                )
+                request = loader(data)
+
+                self.assertTrue(request.is_signature_valid)
+                self.assertEqual(
+                    request.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value,
+                    "alice"
+                )
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=1)


### PR DESCRIPTION
This PR replaces the deprecated `OpenSSL.crypto.X509Req` usage in
ntlmrelayx's AD CS relay implementation with `cryptography.x509`.

pyOpenSSL 26.3.0 removed the affected CSR APIs, causing AD CS web
enrollment relays using `--adcs` to fail. This change updates both the
HTTP Web Enrollment and RPC/ICPR certificate-request paths.

## Compatibility

The production HTTP and ICPR paths no longer construct
`OpenSSL.crypto.X509Req` objects and work with pyOpenSSL 26.3.0.

The compatibility conversion in `generate_csr` is retained for callers
that still provide a pyOpenSSL key. Existing numeric pyOpenSSL encoding
constants also remain accepted.


Fixes #2248.
