### PR TITLE
drop Python2 hybridation imports

### DIFF
--- a/examples/GetADComputers.py
+++ b/examples/GetADComputers.py
@@ -26,9 +26,6 @@
 #   LDAP
 #
 
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 import argparse
 import logging
 import sys

--- a/examples/GetADUsers.py
+++ b/examples/GetADUsers.py
@@ -24,9 +24,6 @@
 #   LDAP
 #
 
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 import argparse
 import logging
 import sys

--- a/examples/GetLAPSPassword.py
+++ b/examples/GetLAPSPassword.py
@@ -21,9 +21,6 @@
 #   LDAP
 #
 
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 from datetime import datetime
 from impacket import version
 from impacket.dcerpc.v5 import transport

--- a/examples/GetNPUsers.py
+++ b/examples/GetNPUsers.py
@@ -26,8 +26,6 @@
 #   Alberto Solino (@agsolino)
 #
 
-from __future__ import division
-from __future__ import print_function
 import argparse
 import datetime
 import logging

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -30,8 +30,6 @@
 #   [X] Add the capability for requesting TGS and output them in JtR/hashcat format
 #
 
-from __future__ import division
-from __future__ import print_function
 import argparse
 import logging
 import sys

--- a/examples/atexec.py
+++ b/examples/atexec.py
@@ -22,8 +22,6 @@
 #   DCE/RPC for TSCH
 #
 
-from __future__ import division
-from __future__ import print_function
 import string
 import sys
 import argparse

--- a/examples/attrib.py
+++ b/examples/attrib.py
@@ -16,8 +16,6 @@
 #   Raz Kissos (@covertivy)
 #
 
-from __future__ import division
-from __future__ import print_function
 from __future__ import annotations
 import sys
 import argparse

--- a/examples/badsuccessor.py
+++ b/examples/badsuccessor.py
@@ -16,11 +16,6 @@
 # Author:
 #   Ilya Yatsenko (@fulc2um)
 
-
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import argparse
 import logging
 import random

--- a/examples/checkMSSQLStatus.py
+++ b/examples/checkMSSQLStatus.py
@@ -9,7 +9,6 @@ Usage:
 
 Writen by @Defte_
 """
-from __future__ import print_function
 
 import sys
 import logging

--- a/examples/dcomexec.py
+++ b/examples/dcomexec.py
@@ -36,8 +36,6 @@
 #       getInterface() method
 #
 
-from __future__ import division
-from __future__ import print_function
 import argparse
 import cmd
 import logging

--- a/examples/dpapi.py
+++ b/examples/dpapi.py
@@ -34,9 +34,6 @@
 #   - https://www.passcape.com/windows_password_recovery_dpapi_master_key
 #
 
-from __future__ import division
-from __future__ import print_function
-
 import struct
 import argparse
 import logging

--- a/examples/dpapidump.py
+++ b/examples/dpapidump.py
@@ -16,8 +16,6 @@
 #   Julien Egloff (@laxaa)
 #
 
-from __future__ import division
-from __future__ import print_function
 import argparse
 import codecs
 import logging

--- a/examples/esentutl.py
+++ b/examples/esentutl.py
@@ -19,8 +19,6 @@
 #   Extensive Storage Engine (ese)
 #
 
-from __future__ import division
-from __future__ import print_function
 import sys
 import logging
 import argparse

--- a/examples/exchanger.py
+++ b/examples/exchanger.py
@@ -25,7 +25,6 @@
 #   - https://swarm.ptsecurity.com/attacking-ms-exchange-web-interfaces/
 #
 
-from __future__ import print_function
 import base64
 import codecs
 import logging

--- a/examples/filetime.py
+++ b/examples/filetime.py
@@ -18,8 +18,6 @@
 #   Raz Kissos (@covertivy)
 #
 
-from __future__ import division
-from __future__ import print_function
 from __future__ import annotations
 import sys
 import argparse

--- a/examples/findDelegation.py
+++ b/examples/findDelegation.py
@@ -21,9 +21,6 @@
 #   Based on GetUserSPNs.py by Alberto Solino (@agsolino)
 #
 
-from __future__ import division
-from __future__ import print_function
-
 import argparse
 import logging
 import sys

--- a/examples/getArch.py
+++ b/examples/getArch.py
@@ -25,8 +25,6 @@
 #   RPCRT, NDR
 #
 
-from __future__ import division
-from __future__ import print_function
 import argparse
 import logging
 import sys

--- a/examples/getPac.py
+++ b/examples/getPac.py
@@ -22,8 +22,6 @@
 #   - [MS-SFU]: https://msdn.microsoft.com/en-us/library/cc246071.aspx
 #
 
-from __future__ import division
-from __future__ import print_function
 import argparse
 import datetime
 import logging

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -49,8 +49,6 @@
 #   Leandro (@0xdeaddood)
 #   Jake Karnes (@jakekarnes42)
 
-from __future__ import division
-from __future__ import print_function
 import argparse
 import datetime
 import logging

--- a/examples/getTGT.py
+++ b/examples/getTGT.py
@@ -19,8 +19,6 @@
 #   Alberto Solino (@agsolino)
 #
 
-from __future__ import division
-from __future__ import print_function
 import argparse
 import logging
 import sys

--- a/examples/goldenPac.py
+++ b/examples/goldenPac.py
@@ -34,8 +34,6 @@
 #   Alberto Solino (@agsolino)
 #
 
-from __future__ import division
-from __future__ import print_function
 import cmd
 import logging
 import os

--- a/examples/karmaSMB.py
+++ b/examples/karmaSMB.py
@@ -53,8 +53,6 @@
 #       hosting. *CAREFUL!!!*
 #
 
-from __future__ import division
-from __future__ import print_function
 import sys
 import os
 import argparse

--- a/examples/lookupsid.py
+++ b/examples/lookupsid.py
@@ -19,8 +19,6 @@
 #   DCE/RPC [MS-LSAT]
 #
 
-from __future__ import division
-from __future__ import print_function
 import sys
 import logging
 import argparse

--- a/examples/mimikatz.py
+++ b/examples/mimikatz.py
@@ -19,8 +19,6 @@
 #   SMB DCE/RPC
 #
 
-from __future__ import division
-from __future__ import print_function
 import argparse
 import cmd
 import logging

--- a/examples/mqtt_check.py
+++ b/examples/mqtt_check.py
@@ -20,8 +20,6 @@
 #   MQTT and Structure
 #
 
-from __future__ import print_function
-
 import argparse
 import logging
 import sys

--- a/examples/mssqlinstance.py
+++ b/examples/mssqlinstance.py
@@ -19,8 +19,6 @@
 #   Structure
 #
 
-from __future__ import division
-from __future__ import print_function
 import argparse
 import sys
 import logging

--- a/examples/netview.py
+++ b/examples/netview.py
@@ -50,8 +50,6 @@
 #   beto (@agsolino)
 #
 
-from __future__ import division
-from __future__ import print_function
 import sys
 import argparse
 import logging

--- a/examples/ntfs-read.py
+++ b/examples/ntfs-read.py
@@ -24,8 +24,6 @@
 #   [] Support compressed, encrypted files
 #
 
-from __future__ import division
-from __future__ import print_function
 import os
 import sys
 import logging

--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -58,8 +58,6 @@
 #   Alberto Solino (@agsolino)
 #
 
-from __future__ import division
-from __future__ import print_function
 import argparse
 import datetime
 import logging

--- a/examples/reg.py
+++ b/examples/reg.py
@@ -28,8 +28,6 @@
 #   [MS-RRP]
 #
 
-from __future__ import division
-from __future__ import print_function
 import argparse
 import codecs
 import logging

--- a/examples/registry-read.py
+++ b/examples/registry-read.py
@@ -19,8 +19,6 @@
 #   winregistry.py
 #
 
-from __future__ import division
-from __future__ import print_function
 import sys
 import argparse
 import ntpath

--- a/examples/rpcdump.py
+++ b/examples/rpcdump.py
@@ -20,8 +20,6 @@
 #   DCE/RPC.
 #
 
-from __future__ import division
-from __future__ import print_function
 import sys
 import logging
 import argparse

--- a/examples/rpcmap.py
+++ b/examples/rpcmap.py
@@ -30,8 +30,6 @@
 #      This will require changing SMB and RPC libraries.
 #
 
-from __future__ import division
-from __future__ import print_function
 import re
 import sys
 import logging

--- a/examples/samrdump.py
+++ b/examples/samrdump.py
@@ -20,8 +20,6 @@
 #   DCE/RPC for SAMR
 #
 
-from __future__ import division
-from __future__ import print_function
 import sys
 import logging
 import argparse

--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -50,8 +50,6 @@
 #   - https://www.passcape.com/index.php?section=blog&cmd=details&id=15
 #
 
-from __future__ import division
-from __future__ import print_function
 import argparse
 import codecs
 import logging

--- a/examples/services.py
+++ b/examples/services.py
@@ -22,8 +22,6 @@
 #   [ ] Check errors
 #
 
-from __future__ import division
-from __future__ import print_function
 import sys
 import argparse
 import logging

--- a/examples/smbclient.py
+++ b/examples/smbclient.py
@@ -19,8 +19,6 @@
 #   SMB DCE/RPC
 #
 
-from __future__ import division
-from __future__ import print_function
 import sys
 import logging
 import argparse

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -34,8 +34,6 @@
 #   DCE/RPC and SMB.
 #
 
-from __future__ import division
-from __future__ import print_function
 import sys
 import os
 import random

--- a/examples/split.py
+++ b/examples/split.py
@@ -24,8 +24,6 @@
 #   ImpactDecoder
 #
 
-from __future__ import division
-from __future__ import print_function
 import sys
 import pcapy
 from pcapy import open_offline

--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -45,8 +45,6 @@
 #   [ ] When -request is specified, we could ask for a user2user ticket and also populate the received PAC
 #
 
-from __future__ import division
-from __future__ import print_function
 import argparse
 import datetime
 import logging

--- a/examples/wmiexec.py
+++ b/examples/wmiexec.py
@@ -24,8 +24,6 @@
 #   DCOM
 #
 
-from __future__ import division
-from __future__ import print_function
 import sys
 import os
 import cmd

--- a/examples/wmipersist.py
+++ b/examples/wmipersist.py
@@ -49,8 +49,6 @@
 #  DCOM/WMI
 #
 
-from __future__ import division
-from __future__ import print_function
 import sys
 import argparse
 import logging

--- a/examples/wmiquery.py
+++ b/examples/wmiquery.py
@@ -23,8 +23,6 @@
 #  DCOM
 #
 
-from __future__ import division
-from __future__ import print_function
 import argparse
 import sys
 import os

--- a/impacket/ImpactPacket.py
+++ b/impacket/ImpactPacket.py
@@ -18,8 +18,6 @@
 #   Javier Kohen (jkohen)
 #
 
-from __future__ import division
-from __future__ import print_function
 import array
 import struct
 import socket

--- a/impacket/crypto.py
+++ b/impacket/crypto.py
@@ -22,8 +22,6 @@
 #   Alberto Solino (@agsolino)
 #
 
-from __future__ import division
-from __future__ import print_function
 from impacket import LOG
 try:
     from Cryptodome.Cipher import DES, AES

--- a/impacket/dcerpc/v5/bkrp.py
+++ b/impacket/dcerpc/v5/bkrp.py
@@ -27,8 +27,6 @@
 #   [ ] 2.2.2 Client-Side-Wrapped Secret
 #
 
-from __future__ import division
-from __future__ import print_function
 from impacket.dcerpc.v5.ndr import NDRCALL, NDRPOINTER, NDRUniConformantArray
 from impacket.dcerpc.v5.dtypes import DWORD, NTSTATUS, GUID, RPC_SID, NULL
 from impacket.dcerpc.v5.rpcrt import DCERPCException

--- a/impacket/dcerpc/v5/dcom/comev.py
+++ b/impacket/dcerpc/v5/dcom/comev.py
@@ -24,8 +24,6 @@
 # Author:
 #   Alberto Solino (@agsolino)
 #
-from __future__ import division
-from __future__ import print_function
 from impacket.dcerpc.v5.ndr import NDRSTRUCT, NDRENUM, NDRUniConformantVaryingArray
 from impacket.dcerpc.v5.dcomrt import DCOMCALL, DCOMANSWER, INTERFACE, PMInterfacePointer, IRemUnknown
 from impacket.dcerpc.v5.dcom.oaut import IDispatch, BSTR, VARIANT

--- a/impacket/dcerpc/v5/dcom/oaut.py
+++ b/impacket/dcerpc/v5/dcom/oaut.py
@@ -24,8 +24,6 @@
 # Author:
 #   Alberto Solino (@agsolino)
 #
-from __future__ import division
-from __future__ import print_function
 import random
 from struct import pack, unpack
 

--- a/impacket/dcerpc/v5/dcom/scmp.py
+++ b/impacket/dcerpc/v5/dcom/scmp.py
@@ -24,8 +24,6 @@
 # Author:
 #   Alberto Solino (@agsolino)
 #
-from __future__ import division
-from __future__ import print_function
 from impacket.dcerpc.v5.ndr import NDRENUM, NDRSTRUCT, NDRUNION
 from impacket.dcerpc.v5.dcomrt import PMInterfacePointer, INTERFACE, DCOMCALL, DCOMANSWER, IRemUnknown2
 from impacket.dcerpc.v5.dtypes import LONG, LONGLONG, ULONG, WSTR

--- a/impacket/dcerpc/v5/dcom/vds.py
+++ b/impacket/dcerpc/v5/dcom/vds.py
@@ -24,8 +24,6 @@
 # Author:
 #   Alberto Solino (@agsolino)
 #
-from __future__ import division
-from __future__ import print_function
 from impacket.dcerpc.v5.ndr import NDRSTRUCT, NDRUniConformantVaryingArray, NDRENUM
 from impacket.dcerpc.v5.dcomrt import DCOMCALL, DCOMANSWER, IRemUnknown2, PMInterfacePointer, INTERFACE
 from impacket.dcerpc.v5.dtypes import LPWSTR, ULONG, DWORD, SHORT, GUID

--- a/impacket/dcerpc/v5/dcom/wmi.py
+++ b/impacket/dcerpc/v5/dcom/wmi.py
@@ -22,8 +22,6 @@
 # Author:
 #   Alberto Solino (@agsolino)
 #
-from __future__ import division
-from __future__ import print_function
 from struct import unpack, calcsize, pack
 from functools import partial
 import collections

--- a/impacket/dcerpc/v5/dcomrt.py
+++ b/impacket/dcerpc/v5/dcomrt.py
@@ -30,8 +30,6 @@
 #       not used, returning RPC_E_DISCONNECTED
 #
 
-from __future__ import division
-from __future__ import print_function
 import ipaddress
 import socket
 from struct import pack

--- a/impacket/dcerpc/v5/dhcpm.py
+++ b/impacket/dcerpc/v5/dhcpm.py
@@ -24,8 +24,6 @@
 #   Alberto Solino (@agsolino)
 #
 
-from __future__ import division
-from __future__ import print_function
 from impacket import system_errors
 from impacket.dcerpc.v5.dtypes import LPWSTR, ULONG, NULL, DWORD, BOOL, BYTE, LPDWORD, WORD
 from impacket.dcerpc.v5.ndr import NDRCALL, NDRUniConformantArray, NDRPOINTER, NDRSTRUCT, NDRENUM, NDRUNION

--- a/impacket/dcerpc/v5/drsuapi.py
+++ b/impacket/dcerpc/v5/drsuapi.py
@@ -24,8 +24,6 @@
 #   Alberto Solino (@agsolino)
 #
 
-from __future__ import division
-from __future__ import print_function
 from builtins import bytes
 import hashlib
 from struct import pack

--- a/impacket/dcerpc/v5/dtypes.py
+++ b/impacket/dcerpc/v5/dtypes.py
@@ -15,8 +15,6 @@
 #   Alberto Solino (@agsolino)
 #
 
-from __future__ import division
-from __future__ import print_function
 from struct import pack, unpack
 from six import binary_type
 

--- a/impacket/dcerpc/v5/even.py
+++ b/impacket/dcerpc/v5/even.py
@@ -24,8 +24,6 @@
 #   Alberto Solino (@agsolino)
 #   Itamar Mizrahi (@MrAnde7son)
 #
-from __future__ import division
-from __future__ import print_function
 from impacket.dcerpc.v5.ndr import NDRCALL, NDRSTRUCT, NDR, NDRPOINTERNULL, NDRUniConformantArray
 from impacket.dcerpc.v5.dtypes import ULONG, LPWSTR, RPC_UNICODE_STRING, LPSTR, NTSTATUS, NULL, PRPC_UNICODE_STRING, PULONG, USHORT, PRPC_SID, LPBYTE
 from impacket.dcerpc.v5.lsad import PRPC_UNICODE_STRING_ARRAY

--- a/impacket/dcerpc/v5/lsad.py
+++ b/impacket/dcerpc/v5/lsad.py
@@ -23,8 +23,6 @@
 # Author:
 #   Alberto Solino (@agsolino)
 #
-from __future__ import division
-from __future__ import print_function
 from impacket.dcerpc.v5.ndr import NDRCALL, NDRENUM, NDRUNION, NDRUniConformantVaryingArray, NDRPOINTER, NDR, NDRSTRUCT, \
     NDRUniConformantArray
 from impacket.dcerpc.v5.dtypes import DWORD, LPWSTR, STR, LUID, LONG, ULONG, RPC_UNICODE_STRING, PRPC_SID, LPBYTE, \

--- a/impacket/dcerpc/v5/mimilib.py
+++ b/impacket/dcerpc/v5/mimilib.py
@@ -23,8 +23,6 @@
 # Author:
 #   Alberto Solino (@agsolino)
 #
-from __future__ import division
-from __future__ import print_function
 import binascii
 import random
 

--- a/impacket/dcerpc/v5/ndr.py
+++ b/impacket/dcerpc/v5/ndr.py
@@ -18,8 +18,6 @@
 #   [X] Unions and rest of the structured types
 #   [ ] Documentation for this library, especially the support for Arrays
 #
-from __future__ import division
-from __future__ import print_function
 import random
 import inspect
 from struct import pack, unpack_from, calcsize

--- a/impacket/dcerpc/v5/nspi.py
+++ b/impacket/dcerpc/v5/nspi.py
@@ -22,8 +22,6 @@
 #   [ ] Test restriction structures
 #
 
-from __future__ import division
-from __future__ import print_function
 from struct import unpack
 from datetime import datetime
 from six import PY2

--- a/impacket/dcerpc/v5/samr.py
+++ b/impacket/dcerpc/v5/samr.py
@@ -23,8 +23,6 @@
 # Author:
 #   Alberto Solino (@agsolino)
 #
-from __future__ import division
-from __future__ import print_function
 from binascii import unhexlify
 
 from impacket.dcerpc.v5.ndr import NDRCALL, NDR, NDRSTRUCT, NDRUNION, NDRPOINTER, NDRUniConformantArray, \

--- a/impacket/dcerpc/v5/srvs.py
+++ b/impacket/dcerpc/v5/srvs.py
@@ -23,8 +23,6 @@
 # Author:
 #   Alberto Solino (@agsolino)
 #
-from __future__ import division
-from __future__ import print_function
 from impacket.dcerpc.v5.rpcrt import DCERPCException
 from impacket.dcerpc.v5.ndr import NDRCALL, NDR, NDRSTRUCT, NDRUNION, NDRPOINTER, NDRUniConformantArray, \
     NDRUniFixedArray, NDRBOOLEAN, NDRUniConformantVaryingArray, PNDRUniConformantArray

--- a/impacket/dcerpc/v5/transport.py
+++ b/impacket/dcerpc/v5/transport.py
@@ -14,8 +14,6 @@
 # Author:
 #   Alberto Solino (@agsolino)
 #
-from __future__ import division
-from __future__ import print_function
 
 import binascii
 import os

--- a/impacket/dpapi.py
+++ b/impacket/dpapi.py
@@ -24,8 +24,6 @@
 #   -  https://www.passcape.com/windows_password_recovery_dpapi_master_key
 #
 
-from __future__ import division
-from __future__ import print_function
 import sys
 
 from struct import unpack

--- a/impacket/ese.py
+++ b/impacket/ese.py
@@ -26,8 +26,6 @@
 #   [ ] Support long values properly
 #
 
-from __future__ import division
-from __future__ import print_function
 from impacket import LOG
 from collections import OrderedDict
 from impacket.structure import Structure, hexdump

--- a/impacket/examples/ntlmrelayx/servers/rdprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/rdprelayserver.py
@@ -16,9 +16,6 @@
 # Author:
 #  Giovanni A. (@azoxlpf)
 
-from __future__ import division
-from __future__ import print_function
-
 import select
 import socket
 import socketserver

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -18,8 +18,6 @@
 #   Alberto Solino (@agsolino)
 #   Dirk-jan Mollema / Fox-IT (https://www.fox-it.com)
 #
-from __future__ import division
-from __future__ import print_function
 from threading import Thread
 try:
     import ConfigParser

--- a/impacket/examples/ntlmrelayx/servers/socksserver.py
+++ b/impacket/examples/ntlmrelayx/servers/socksserver.py
@@ -22,8 +22,6 @@
 #   [ ] Port handlers should be dynamically subscribed, and coded in another place. This will help coding
 #       proxies for different protocols (e.g. MSSQL)
 #
-from __future__ import division
-from __future__ import print_function
 import socketserver
 import socket
 import time

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -47,8 +47,6 @@
 #   - https://www.exploit-db.com/docs/english/18244-active-domain-offline-hash-dump-&-forensic-analysis.pdf
 #   - https://www.passcape.com/index.php?section=blog&cmd=details&id=15
 #
-from __future__ import division
-from __future__ import print_function
 import codecs
 import json
 import hashlib

--- a/impacket/examples/smbclient.py
+++ b/impacket/examples/smbclient.py
@@ -17,8 +17,6 @@
 # Reference for:
 #   SMB DCE/RPC
 #
-from __future__ import division
-from __future__ import print_function
 from io import BytesIO
 import sys
 import time

--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -18,8 +18,6 @@
 # Author:
 #   Alberto Solino (@agsolino)
 #
-from __future__ import division
-from __future__ import print_function
 from datetime import datetime, timezone
 import os
 from struct import pack, unpack, calcsize

--- a/impacket/mqtt.py
+++ b/impacket/mqtt.py
@@ -24,7 +24,6 @@
 #   [ ] Implement QoS = QOS_ASSURED_DELIVERY when publishing messages
 #
 
-from __future__ import print_function
 import logging
 import struct
 import socket

--- a/impacket/nmb.py
+++ b/impacket/nmb.py
@@ -34,9 +34,6 @@
 #
 # 3. This notice cannot be removed or altered from any source distribution.
 #
-from __future__ import division
-from __future__ import print_function
-from __future__ import absolute_import
 import errno
 import re
 import select

--- a/impacket/ntlm.py
+++ b/impacket/ntlm.py
@@ -9,8 +9,6 @@
 # for more information.
 #
 
-from __future__ import division
-from __future__ import print_function
 import base64
 import struct
 import calendar

--- a/impacket/smb.py
+++ b/impacket/smb.py
@@ -49,8 +49,6 @@
 #   [ ] Transform the rest of the calls to structure
 #   [X] Implement TRANS/TRANS2 reassembly for list_path
 #
-from __future__ import division
-from __future__ import print_function
 
 import os
 import socket

--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -30,9 +30,6 @@
 #   [ ] Fix up all the 'ToDo' comments inside the code
 #
 
-from __future__ import division
-from __future__ import print_function
-
 import socket
 import ntpath
 import random

--- a/impacket/smb3structs.py
+++ b/impacket/smb3structs.py
@@ -15,9 +15,6 @@
 #   Alberto Solino (@agsolino)
 #
 
-from __future__ import division
-from __future__ import print_function
-
 import struct as _struct
 from impacket.structure import Structure
 from impacket import LOG

--- a/impacket/spnego.py
+++ b/impacket/spnego.py
@@ -15,8 +15,6 @@
 #   Alberto Solino (@agsolino)
 #
 
-from __future__ import division
-from __future__ import print_function
 from struct import pack, unpack, calcsize
 
 from impacket import ntlm

--- a/impacket/structure.py
+++ b/impacket/structure.py
@@ -9,9 +9,6 @@
 # for more information.
 #
 
-from __future__ import division
-from __future__ import print_function
-
 import re
 from struct import pack, unpack, calcsize
 

--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -28,10 +28,6 @@
 #   [ ] printRows is crappy, just an easy way to print the rows. It should be
 #       rewritten to output like a normal SQL client
 
-
-from __future__ import division
-from __future__ import print_function
-
 # Native SSL support for in memory handshake
 import ssl
 

--- a/impacket/uuid.py
+++ b/impacket/uuid.py
@@ -16,8 +16,6 @@
 #   Javier Kohen (jkohen)
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 import re
 import binascii
 

--- a/impacket/winregistry.py
+++ b/impacket/winregistry.py
@@ -22,8 +22,6 @@
 #   [ ] Parse li records, probable the same as the ri but couldn't find any to probe
 #
 
-from __future__ import division
-from __future__ import print_function
 import sys
 import re
 from binascii import unhexlify

--- a/tests/ImpactPacket/test_IP6_Extension_Headers.py
+++ b/tests/ImpactPacket/test_IP6_Extension_Headers.py
@@ -9,8 +9,6 @@
 # of the Apache Software License. See the accompanying LICENSE file
 # for more information.
 #
-from __future__ import division
-from __future__ import print_function
 import unittest
 from six import PY2
 

--- a/tests/SMB_RPC/test_acl.py
+++ b/tests/SMB_RPC/test_acl.py
@@ -14,7 +14,6 @@
 # Author:
 #   Gefen Altshuler (@gaffner)
 #
-from __future__ import print_function
 import unittest
 from unittest import mock
 from unittest.mock import MagicMock, patch

--- a/tests/SMB_RPC/test_ldap.py
+++ b/tests/SMB_RPC/test_ldap.py
@@ -8,8 +8,6 @@
 # of the Apache Software License. See the accompanying LICENSE file
 # for more information.
 #
-from __future__ import division
-from __future__ import print_function
 import pytest
 import unittest
 from tests import RemoteTestCase

--- a/tests/SMB_RPC/test_ndr.py
+++ b/tests/SMB_RPC/test_ndr.py
@@ -8,8 +8,6 @@
 # of the Apache Software License. See the accompanying LICENSE file
 # for more information.
 #
-from __future__ import division
-from __future__ import print_function
 
 import unittest
 

--- a/tests/SMB_RPC/test_ntlm.py
+++ b/tests/SMB_RPC/test_ntlm.py
@@ -8,7 +8,6 @@
 # of the Apache Software License. See the accompanying LICENSE file
 # for more information.
 #
-from __future__ import print_function
 import unittest
 import struct
 

--- a/tests/SMB_RPC/test_rpch.py
+++ b/tests/SMB_RPC/test_rpch.py
@@ -8,8 +8,6 @@
 # of the Apache Software License. See the accompanying LICENSE file
 # for more information.
 #
-from __future__ import division
-from __future__ import print_function
 from struct import unpack
 
 import pytest

--- a/tests/SMB_RPC/test_rpcrt.py
+++ b/tests/SMB_RPC/test_rpcrt.py
@@ -8,8 +8,6 @@
 # of the Apache Software License. See the accompanying LICENSE file
 # for more information.
 #
-from __future__ import division
-from __future__ import print_function
 
 import pytest
 import unittest

--- a/tests/SMB_RPC/test_wmi.py
+++ b/tests/SMB_RPC/test_wmi.py
@@ -43,8 +43,6 @@
 # 
 # Shouldn't dump errors against a win7
 #
-from __future__ import division
-from __future__ import print_function
 
 import zlib
 import base64

--- a/tests/dcerpc/test_bkrp.py
+++ b/tests/dcerpc/test_bkrp.py
@@ -11,8 +11,6 @@
 # Tested so far:
 #   (h)BackuprKey
 #
-from __future__ import division
-from __future__ import print_function
 
 import pytest
 import unittest

--- a/tests/dcerpc/test_dcomrt.py
+++ b/tests/dcerpc/test_dcomrt.py
@@ -21,8 +21,6 @@
 #   RemRelease
 #   RemoteGetClassObject
 #
-from __future__ import division
-from __future__ import print_function
 
 import pytest
 import unittest

--- a/tests/dcerpc/test_dhcpm.py
+++ b/tests/dcerpc/test_dhcpm.py
@@ -25,8 +25,6 @@
 #   DhcpEnumSubnetElementsV5
 #   DhcpEnumSubnetClientsVQ
 #
-from __future__ import division
-from __future__ import print_function
 
 import socket
 import struct

--- a/tests/dcerpc/test_drsuapi.py
+++ b/tests/dcerpc/test_drsuapi.py
@@ -18,8 +18,6 @@
 # Not yet:
 #   DRSUnBind
 #
-from __future__ import division
-from __future__ import print_function
 import pytest
 import unittest
 from tests.dcerpc import DCERPCTests

--- a/tests/dcerpc/test_epm.py
+++ b/tests/dcerpc/test_epm.py
@@ -12,8 +12,6 @@
 #   (h)ept_lookup
 #   (h)ept_map
 #
-from __future__ import division
-from __future__ import print_function
 import ast
 import socket
 import pytest

--- a/tests/dcerpc/test_even.py
+++ b/tests/dcerpc/test_even.py
@@ -21,8 +21,6 @@
 # Not yet:
 #   ElfrCloseEL
 #
-from __future__ import division
-from __future__ import print_function
 import pytest
 import unittest
 from six import assertRaisesRegex

--- a/tests/dcerpc/test_even6.py
+++ b/tests/dcerpc/test_even6.py
@@ -19,8 +19,6 @@
 #   EvtRpcOpenLogHandle
 #   EvtRpcGetChannelList
 #
-from __future__ import division
-from __future__ import print_function
 import pytest
 import unittest
 from six.moves import xrange

--- a/tests/dcerpc/test_lsad.py
+++ b/tests/dcerpc/test_lsad.py
@@ -62,8 +62,6 @@
 #   LsarCreateTrustedDomainEx2
 #   LsarSetForestTrustInformation
 #
-from __future__ import division
-from __future__ import print_function
 import pytest
 import unittest
 

--- a/tests/dcerpc/test_lsat.py
+++ b/tests/dcerpc/test_lsat.py
@@ -18,8 +18,6 @@
 #   (h)LsarLookupSids2
 #   LsarLookupSids3
 #
-from __future__ import division
-from __future__ import print_function
 import pytest
 import unittest
 from six import assertRaisesRegex

--- a/tests/dcerpc/test_mgmt.py
+++ b/tests/dcerpc/test_mgmt.py
@@ -15,8 +15,6 @@
 #   (h)stop_server_listening
 #   (h)inq_princ_name
 #
-from __future__ import division
-from __future__ import print_function
 import pytest
 import unittest
 from six import assertRaisesRegex

--- a/tests/dcerpc/test_raa.py
+++ b/tests/dcerpc/test_raa.py
@@ -17,8 +17,6 @@
 #   (h)AuthzrModifyClaims
 #   (h)AuthzrModifySids
 #
-from __future__ import division
-from __future__ import print_function
 import pytest
 import unittest
 

--- a/tests/dcerpc/test_rprn.py
+++ b/tests/dcerpc/test_rprn.py
@@ -18,8 +18,6 @@
 #   RpcEnumPrinterDrivers
 #   RpcAddPrinterDriverEx
 #
-from __future__ import division
-from __future__ import print_function
 
 import pytest
 import unittest

--- a/tests/dcerpc/test_rrp.py
+++ b/tests/dcerpc/test_rrp.py
@@ -42,8 +42,6 @@
 # Not yet:
 #   BaseRegSetKeySecurity
 #
-from __future__ import division
-from __future__ import print_function
 import pytest
 import unittest
 from tests.dcerpc import DCERPCTests

--- a/tests/dcerpc/test_srvs.py
+++ b/tests/dcerpc/test_srvs.py
@@ -59,8 +59,6 @@
 # Not yet:
 #   NetrServerSetInfo
 #
-from __future__ import division
-from __future__ import print_function
 
 import pytest
 import unittest

--- a/tests/dcerpc/test_tsch.py
+++ b/tests/dcerpc/test_tsch.py
@@ -40,8 +40,6 @@
 #   SchRpcSetSecurity
 #   SchRpcGetSecurity
 #
-from __future__ import division
-from __future__ import print_function
 
 import pytest
 import unittest

--- a/tests/dcerpc/test_wkst.py
+++ b/tests/dcerpc/test_wkst.py
@@ -33,8 +33,6 @@
 # Not yet:
 #   NetrWkstaTransportDel
 #
-from __future__ import division
-from __future__ import print_function
 
 import pytest
 import unittest

--- a/tests/misc/test_crypto.py
+++ b/tests/misc/test_crypto.py
@@ -9,7 +9,6 @@
 # of the Apache Software License. See the accompanying LICENSE file
 # for more information.
 #
-from __future__ import print_function, division
 import unittest
 from binascii import hexlify, unhexlify
 

--- a/tests/misc/test_dcerpc_v5_ndr.py
+++ b/tests/misc/test_dcerpc_v5_ndr.py
@@ -9,7 +9,6 @@
 # of the Apache Software License. See the accompanying LICENSE file
 # for more information.
 #
-from __future__ import print_function
 import unittest
 from binascii import hexlify
 

--- a/tests/misc/test_krb5_crypto.py
+++ b/tests/misc/test_krb5_crypto.py
@@ -9,7 +9,6 @@
 # of the Apache Software License. See the accompanying LICENSE file
 # for more information.
 #
-from __future__ import print_function
 import unittest
 from binascii import unhexlify
 

--- a/tests/misc/test_structure.py
+++ b/tests/misc/test_structure.py
@@ -9,7 +9,6 @@
 # of the Apache Software License. See the accompanying LICENSE file
 # for more information.
 #
-from __future__ import print_function
 import six
 import unittest
 from binascii import hexlify


### PR DESCRIPTION
Hi,

I saw recent activity on the Debian package; so I'm giving a new try to finish this cleanup.

I'd like to drop `six`, but this is an even lower hanging fruit.

---

The "from __future__ import annotations" are the only from __future__ still usefull with Python3, they stay.

impacket$ git diff | grep annota
 from __future__ import annotations
 from __future__ import annotations
impacket$