### PR TITLE
secretsdump: write trust keys to their own .ntds.trustkeys file

### DIFF
--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -3573,6 +3573,7 @@ class NTDSHashes:
         hashesOutputFile = None
         keysOutputFile = None
         clearTextOutputFile = None
+        trustOutputFile = None
         skipUsers = []
 
         if self.__skipUser:
@@ -3622,6 +3623,10 @@ class NTDSHashes:
                 if self.__justNTLM is False:
                     keysOutputFile = openFile(self.__outputFileName+'.ntds.kerberos',mode)
                     clearTextOutputFile = openFile(self.__outputFileName+'.ntds.cleartext',mode)
+                if self.__trustKeys:
+                    # Trust keys are not account secrets and do not follow the pwdump line
+                    # format, so they get their own file to keep .ntds parseable.
+                    trustOutputFile = openFile(self.__outputFileName+'.ntds.trustkeys',mode)
 
             if not self.__justTrustKeys:
                 LOG.info('Dumping Domain Credentials (domain\\uid:rid:lmhash:nthash)')
@@ -3694,7 +3699,7 @@ class NTDSHashes:
 
                     if self.__trustKeys:
                         try:
-                            self.__dumpTrustKeysOffline(outputFile=hashesOutputFile)
+                            self.__dumpTrustKeysOffline(outputFile=trustOutputFile)
                         except Exception as e:
                             LOG.debug('Exception', exc_info=True)
                             LOG.error('Trusted domain key dump failed: %s' % str(e))
@@ -3901,7 +3906,7 @@ class NTDSHashes:
             # from the .dit inside the branch above instead.
             if self.__trustKeys and not self.__useVSSMethod and not self.__remoteSSMethodWMINTDS:
                 try:
-                    self.__dumpTrustKeysOnline(outputFile=hashesOutputFile)
+                    self.__dumpTrustKeysOnline(outputFile=trustOutputFile)
                 except Exception as e:
                     LOG.debug('Exception', exc_info=True)
                     LOG.error('Trusted domain key dump failed: %s' % str(e))
@@ -3915,6 +3920,9 @@ class NTDSHashes:
 
             if clearTextOutputFile is not None:
                 clearTextOutputFile.close()
+
+            if trustOutputFile is not None:
+                trustOutputFile.close()
 
             self.__resumeSession.endTransaction()
 


### PR DESCRIPTION
Hello, 

While working on this pr https://github.com/Pennyw0rth/NetExec/pull/1321 , @NeffIsBack made a very good point about trusted keys not having their own file and be mixed with the wrong file.

`-trust-keys` currently writes the trust keys into `<output>.ntds`, mixed with the account hashes.

They don't follow the pwdump layout:

    Administrator:500:aad3b435b51404eeaad3b435b51404ee:c66d72021a2d4744409969a581a1705e:::
    north.sevenkingdoms.local (Incoming):rc4_hmac:dd3249d7bd57c4b5456461c3597e3648

The second field is a key type instead of a RID, so hashcat, john and any pwdump parser
break on those lines.

This writes them to `<output>.ntds.trustkeys` instead, the same way Kerberos keys already
go to `<output>.ntds.kerberos`.

Tested against a DC with one trust (`-just-dc -trust-keys`):

- `.ntds`: 19 account lines, 0 trust lines
- `.ntds.trustkeys`: 12 trust lines
