### PR TITLE
Fix SMB share type reporting in SRVS responses

### DIFF
--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -5409,7 +5409,7 @@ class SRVSServer(DCERPCServer):
 
             answer['InfoStruct']['tag'] = 1
             answer['InfoStruct']['ShareInfo1']['shi1_netname'] = s + '\x00'
-            answer['InfoStruct']['ShareInfo1']['shi1_type'] = share['share type']
+            answer['InfoStruct']['ShareInfo1']['shi1_type'] = int(share['share type'])
             answer['InfoStruct']['ShareInfo1']['shi1_remark'] = share['comment'] + '\x00'
             answer['ErrorCode'] = 0
         else:
@@ -5449,7 +5449,7 @@ class SRVSServer(DCERPCServer):
         for i in self._shares:
             shareInfo = SHARE_INFO_1()
             shareInfo['shi1_netname'] = i + '\x00'
-            shareInfo['shi1_type'] = self._shares[i]['share type']
+            shareInfo['shi1_type'] = int(self._shares[i]['share type'])
             shareInfo['shi1_remark'] = self._shares[i]['comment'] + '\x00'
             shareEnum['InfoStruct']['ShareInfo']['Level1']['Buffer'].append(shareInfo)
 

--- a/tests/SMB_RPC/test_smbserver.py
+++ b/tests/SMB_RPC/test_smbserver.py
@@ -87,6 +87,7 @@ from impacket.smbserver import normalize_path, isInFileJail, SimpleSMBServer, SM
 from impacket.smbconnection import SMBConnection, SessionError, compute_lmhash, compute_nthash
 from impacket.nt_errors import STATUS_NOT_SUPPORTED
 from impacket import smb3structs as smb2
+from impacket.dcerpc.v5 import transport, srvs
 from threading import Thread
 
 import select
@@ -341,6 +342,7 @@ class SimpleSMBServerFuncTests(unittest.TestCase):
         """Test listing shares.
         """
         server = self.get_smbserver()
+        server.addShare("printer", self.share_path, shareType="1")
         self.start_smbserver(server)
 
         client = self.get_smbclient()
@@ -353,7 +355,31 @@ class SimpleSMBServerFuncTests(unittest.TestCase):
         client.login(self.username, self.password)
         shares = client.listShares()
         shares_names = [share['shi1_netname'][:-1] for share in shares]
-        assertCountEqual(self, [self.share_name.upper(), "IPC$"], shares_names)
+        assertCountEqual(self, [self.share_name.upper(), "PRINTER", "IPC$"], shares_names)
+
+        shares_by_name = {share['shi1_netname'][:-1]: share for share in shares}
+        self.assertEqual(srvs.STYPE_DISKTREE, shares_by_name[self.share_name.upper()]['shi1_type'])
+        self.assertEqual(srvs.STYPE_PRINTQ, shares_by_name["PRINTER"]['shi1_type'])
+        self.assertEqual(srvs.STYPE_IPC, shares_by_name["IPC$"]['shi1_type'])
+
+        client.close()
+
+    def test_smbserver_get_share_info_type(self):
+        """Test getting a non-disk share type.
+        """
+        server = self.get_smbserver()
+        server.addShare("printer", self.share_path, shareType="1")
+        self.start_smbserver(server)
+
+        client = self.get_smbclient()
+        client.login(self.username, self.password)
+        rpc_transport = transport.SMBTransport(self.address, self.address, filename=r'\srvsvc',
+                                               smb_connection=client)
+        dce = rpc_transport.get_dce_rpc()
+        dce.connect()
+        dce.bind(srvs.MSRPC_UUID_SRVS)
+        share = srvs.hNetrShareGetInfo(dce, "PRINTER\x00", 1)
+        self.assertEqual(srvs.STYPE_PRINTQ, share['InfoStruct']['ShareInfo1']['shi1_type'])
 
         client.close()
 


### PR DESCRIPTION
Fixes #2271

Convert configured SMB share types to integers before assigning them to the SRVS `SHARE_INFO_1` response fields.

Share types are stored as strings by `ConfigParser`. Passing those strings directly to the NDR `DWORD` field caused every share to be reported as `STYPE_DISKTREE` (`0`).

Regression tests now verify disk, printer, and IPC share types.