### PR TITLE
Add LDAP paged search to findDelegation.py and GetNPUsers.py

### DIFF
--- a/examples/GetNPUsers.py
+++ b/examples/GetNPUsers.py
@@ -236,15 +236,17 @@ class GetUserNoPreAuth:
 
         try:
             logging.debug('Search Filter=%s' % searchFilter)
+            # Microsoft Active Directory set an hard limit of 1000 entries returned by any search
+            paged_search_control = ldapasn1.SimplePagedResultsControl(criticality=True, size=1000)
+
             resp = ldapConnection.search(searchFilter=searchFilter,
                                          attributes=['sAMAccountName',
                                                      'pwdLastSet', 'MemberOf', 'userAccountControl', 'lastLogon'],
-                                         sizeLimit=999)
+                                         searchControls=[paged_search_control])
         except ldap.LDAPSearchError as e:
             if e.getErrorString().find('sizeLimitExceeded') >= 0:
+                # We should never reach this code as we use paged search now
                 logging.debug('sizeLimitExceeded exception caught, giving up and processing the data received')
-                # We reached the sizeLimit, process the answers we have already and that's it. Until we implement
-                # paged queries
                 resp = e.getAnswers()
                 pass
             else:

--- a/examples/findDelegation.py
+++ b/examples/findDelegation.py
@@ -126,16 +126,18 @@ class FindDelegation:
             searchFilter += ')'
 
         try:
+            # Microsoft Active Directory set an hard limit of 1000 entries returned by any search
+            paged_search_control = ldapasn1.SimplePagedResultsControl(criticality=True, size=1000)
+
             resp = ldapConnection.search(searchFilter=searchFilter,
                                          attributes=['sAMAccountName',
                                                      'pwdLastSet', 'userAccountControl', 'objectCategory',
                                                      'msDS-AllowedToActOnBehalfOfOtherIdentity', 'msDS-AllowedToDelegateTo'],
-                                         sizeLimit=999)
+                                         searchControls=[paged_search_control])
         except ldap.LDAPSearchError as e:
             if e.getErrorString().find('sizeLimitExceeded') >= 0:
+                # We should never reach this code as we use paged search now
                 logging.debug('sizeLimitExceeded exception caught, giving up and processing the data received')
-                # We reached the sizeLimit, process the answers we have already and that's it. Until we implement
-                # paged queries
                 resp = e.getAnswers()
                 pass
             else:


### PR DESCRIPTION
### Summary

Adds `SimplePagedResultsControl` to `findDelegation.py` and `GetNPUsers.py`, matching PR #1498's fix for `GetUserSPNs.py`.

Both scripts use `sizeLimit=999` with no paging control. When a domain has more than 999 matching objects, both scripts drop the excess and log it at `DEBUG` level only. Replacing `sizeLimit` with paged search returns complete results at any domain size.

Closes #2284

### Changes

In both `findDelegation.py` and `GetNPUsers.py`:
- Replaced `sizeLimit=999` with `SimplePagedResultsControl(size=1000)` + `searchControls=`
- Updated `sizeLimitExceeded` comment to match `GetUserSPNs.py`: "We should never reach this code as we use paged search now"

`findDelegation.py`'s RBCD sub-query (`sizeLimit=999`) left unchanged: it queries specific SIDs from one object's ACL and won't approach the limit. `GetNPUsers.py`'s `-usersfile` code path also unchanged, as it bypasses LDAP.

### Testing

Tested against a 100K-user Active Directory lab (Windows Server 2022). All counts verified against LDAP ground truth (identity-set diff, not just count).

- **findDelegation.py**: Set `TrustedForDelegation` on 1,099 accounts (+ DC01$ = 1,100 matching objects). Before patch: 999 returned. After patch: 1,100 returned.
- **GetNPUsers.py**: Set `DONT_REQUIRE_PREAUTH` on 1,099 accounts. Before patch: 999 returned. After patch: 1,099 returned.
- **Regression**: 51 delegation and 50 preauth objects (<999). Both scripts returned correct counts, no errors.