### PR TITLE
Fix HTTP SOCKS relay corrupting requests that carry a body

### DIFF
--- a/impacket/examples/ntlmrelayx/servers/socksplugins/http.py
+++ b/impacket/examples/ntlmrelayx/servers/socksplugins/http.py
@@ -160,24 +160,24 @@ class HTTPSocksRelay(SocksRelay):
         response = []
         for part in data.split(EOL):
             # This means end of headers, stop parsing here
-            if part == '':
+            if part == b'':
                 break
             # Remove the Basic authentication header
             if b'authorization' in part.lower():
                 continue
             # Don't close the connection
             if b'connection: close' in part.lower():
-                response.append('Connection: Keep-Alive')
+                response.append(b'Connection: Keep-Alive')
                 continue
             # If we are here it means we want to keep the header
             response.append(part)
         # Append the body
         response.append(b'')
-        response.append(data.split(EOL+EOL)[1])
+        headerSize = data.find(EOL+EOL)
+        response.append(data[headerSize+4:] if headerSize != -1 else b'')
         senddata = EOL.join(response)
 
         # Check if the body is larger than 1 packet
-        headerSize = data.find(EOL+EOL)
         headers = self.getHeaders(data)
         try:
             bodySize = int(headers['content-length'])

--- a/tests/SMB_RPC/test_socks_http.py
+++ b/tests/SMB_RPC/test_socks_http.py
@@ -1,0 +1,129 @@
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright Fortra, LLC and its affiliated companies
+#
+# All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+# Tests for the ntlmrelayx HTTP SOCKS plugin request rewriting
+# (HTTPSocksRelay.prepareRequest).
+#
+import unittest
+
+from impacket.examples.ntlmrelayx.servers.socksplugins.http import HTTPSocksRelay, EOL
+
+
+class FakeSocket(object):
+    """Minimal socket stand-in that yields a preloaded buffer in recv()-sized chunks."""
+
+    def __init__(self, buffer=b''):
+        self.buffer = buffer
+
+    def recv(self, size):
+        chunk = self.buffer[:size]
+        self.buffer = self.buffer[size:]
+        return chunk
+
+
+def build_relay(recv_buffer=b''):
+    # Build an HTTPSocksRelay without running __init__ (it needs live sockets and
+    # an activeRelays registry that are irrelevant to request rewriting).
+    relay = HTTPSocksRelay.__new__(HTTPSocksRelay)
+    relay.packetSize = 8192
+    relay.socksSocket = FakeSocket(recv_buffer)
+    return relay
+
+
+def make_request(method, headers, body):
+    head = method.encode() + b' / HTTP/1.1' + EOL
+    head += EOL.join(h.encode() for h in headers) + EOL
+    if body:
+        head += (b'Content-Length: %d' % len(body)) + EOL
+    head += EOL
+    return head + body
+
+
+def server_view(sent, body):
+    """Model what the upstream server does: after the header terminator it reads
+    Content-Length body bytes; anything past that is surplus left on the socket."""
+    header_end = sent.find(EOL + EOL)
+    body_start = header_end + 4
+    read_body = sent[body_start:body_start + len(body)]
+    leftover = len(sent) - (body_start + len(body))
+    return read_body, leftover
+
+
+class Test(unittest.TestCase):
+
+    def _assert_clean(self, sent, original_body):
+        read_body, leftover = server_view(sent, original_body)
+        self.assertEqual(read_body, original_body,
+                         "body the server reads must be byte-identical to the client's body")
+        self.assertEqual(leftover, 0,
+                         "no surplus bytes may remain on the keep-alive connection")
+
+    def test_get_without_body(self):
+        req = make_request('GET', ['Host: target', 'Authorization: Basic QUJD'], b'')
+        sent = build_relay().prepareRequest(req)
+        # Authorization header must be stripped
+        self.assertNotIn(b'authorization', sent.lower())
+        # A bodyless request has an empty body and no surplus
+        self._assert_clean(sent, b'')
+
+    def test_simple_post_body_preserved(self):
+        body = b'field1=value1&field2=value2'
+        req = make_request('POST', ['Host: target', 'Authorization: Basic QUJD',
+                                    'Content-Type: application/x-www-form-urlencoded'], body)
+        sent = build_relay().prepareRequest(req)
+        self.assertNotIn(b'authorization', sent.lower())
+        self._assert_clean(sent, body)
+
+    def test_multipart_body_with_internal_crlfcrlf(self):
+        # A multipart body always contains a CRLFCRLF between the part headers and
+        # the file content. This is the case that split(EOL+EOL)[1] truncated.
+        body = (b'--BOUNDARY\r\n'
+                b'Content-Disposition: form-data; name="files"; filename="a.txt"\r\n'
+                b'Content-Type: text/plain\r\n'
+                b'\r\n'
+                b'HELLO-PAYLOAD-DATA\r\n'
+                b'--BOUNDARY--\r\n')
+        req = make_request('POST', ['Host: target', 'Authorization: Basic QUJD',
+                                    'Content-Type: multipart/form-data; boundary=BOUNDARY'], body)
+        sent = build_relay().prepareRequest(req)
+        self._assert_clean(sent, body)
+
+    def test_connection_close_rewritten_to_keep_alive(self):
+        body = b'x=1'
+        req = make_request('POST', ['Host: target', 'Connection: close'], body)
+        sent = build_relay().prepareRequest(req)
+        self.assertNotIn(b'connection: close', sent.lower())
+        self.assertIn(b'Connection: Keep-Alive', sent)
+        self._assert_clean(sent, body)
+
+    def test_large_multipacket_body(self):
+        # Body larger than packetSize: the first recv() only carries the headers plus
+        # the leading slice of the body, and prepareRequest must pull the remainder
+        # off the socket across multiple recv() calls.
+        payload = b'A' * 20000
+        body = (b'--BOUNDARY\r\n'
+                b'Content-Disposition: form-data; name="files"; filename="big.bin"\r\n'
+                b'Content-Type: application/octet-stream\r\n'
+                b'\r\n' + payload + b'\r\n'
+                b'--BOUNDARY--\r\n')
+        req = make_request('POST', ['Host: target', 'Authorization: Basic QUJD',
+                                    'Content-Type: multipart/form-data; boundary=BOUNDARY'], body)
+        self.assertGreater(len(req), 8192)
+        first_chunk = req[:8192]
+        remainder = req[8192:]
+        relay = build_relay(recv_buffer=remainder)
+        sent = relay.prepareRequest(first_chunk)
+        self._assert_clean(sent, body)
+        # The whole preloaded buffer must have been consumed
+        self.assertEqual(relay.socksSocket.buffer, b'')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Fix HTTP SOCKS relay corrupting requests that carry a body

## Summary

Relaying any HTTP request with a body through `ntlmrelayx.py -socks` corrupts the
request. The upstream target receives surplus bytes after a otherwise-valid request,
parses them as a pipelined request on the keep-alive connection, fails, and resets the
connection. The client (curl, a browser, Burp) sees `Recv failure: Connection reset by
peer` and never gets a response.

GET requests have no body and are unaffected in practice, which is why this stays hidden
until the first POST.

## Reproduce

Relay a session, then send a multipart POST through the SOCKS proxy:

```bash
curl -s --socks5-hostname 127.0.0.1:1080 -u 'DOMAIN/user:x' \
     -F "files=@somefile.txt" http://target.example/api/upload
```

Result before the fix: `curl: (56) Recv failure: Connection reset by peer`.

## Root cause

`HTTPSocksRelay.prepareRequest()` in
`impacket/examples/ntlmrelayx/servers/socksplugins/http.py` rewrites each relayed request.
The request data comes from `socket.recv()` and is therefore `bytes`, but three spots
treat it as `str`:

1. **End-of-headers check never matches.** `if part == '':` compares a `bytes` value to a
   `str`, which is always `False` under Python 3. The loop walks past the header block and
   re-emits the body, so the rewritten request carries the body twice and leaves surplus
   bytes on the connection after `Content-Length` is satisfied. Those surplus bytes are
   what the target parses as the next request, causing the reset.

2. **`str` appended into a `bytes` list.** `response.append('Connection: Keep-Alive')`
   pushes a `str` into a list that is later joined with a `bytes` separator, raising
   `TypeError`. This fires whenever a client sends `Connection: close`.

3. **Body truncated at the first blank line.** The body is extracted with
   `data.split(EOL+EOL)[1]`, which splits on every `CRLFCRLF`. A multipart body always
   contains one between the part headers and the file content, so `[1]` returns only the
   preamble and drops the payload.

The three interact: fixing only the first makes the truncated body (third defect) shorter
than its own `Content-Length`, so the target then blocks waiting for bytes that never
arrive. They are fixed together.

## Fix

Compare and build the request as `bytes`, and take the body as everything after the first
header terminator using `find()`, guarding the not-found case so a malformed request
yields an empty body rather than silently wrong data.

`https.py` (`HTTPSSocksRelay`) inherits `prepareRequest()` from `HTTPSocksRelay` and needs
no separate change.

## Tests

Adds `tests/SMB_RPC/test_socks_http.py`, a network-free unit test that drives
`prepareRequest()` directly and asserts the rewritten request is byte-clean (the body the
server reads is identical to the client's, with zero surplus bytes left on the socket).
It covers:

- a simple form POST,
- a multipart body containing an internal `CRLFCRLF` (the truncation case),
- `Connection: close` rewriting,
- a GET with no body,
- a large body that spans multiple packets, exercising the multi-`recv()` read loop with
  a fake socket.

All five fail on the current code and pass with the fix.
