### PR TITLE
secretsdump: add inter-realm trust AES key salt (NetBIOS & FQDN)

### DIFF
--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -2616,18 +2616,25 @@ TRUST_NAME_TO_ATTRTYP = {
 
 
 def _derive_trust_kerberos_keys(rawSecret, domain, partner, isIncoming):
-    # Inter-realm salt: {REALM_FQDN}krbtgt{PARTNER_NETBIOS}. The component after 'krbtgt' is the
-    # trust TGT principal name (krbtgt/<flatName>), i.e. the NetBIOS/flat name, NOT the FQDN.
+    # Two keys are derived from the same trust secret, differing only by salt:
+    #  - salt_fqdn ({REALM_FQDN}krbtgt{PARTNER_FQDN}): the inter-realm key used on the wire to
+    #    encrypt/sign cross-realm referral tickets (what mimikatz/tdo_dump emit, used for forging).
+    #  - salt_nb   ({REALM_FQDN}krbtgt{PARTNER_FLAT}): the trust account (<PARTNER>$) login key,
+    #    only meaningful when such an account exists (intra-forest/external trusts).
     if isIncoming:
-        salt = ('%skrbtgt%s' % (domain.upper(), partner.split('.')[0].upper())).encode('utf-8')
+        salt_fqdn = ('%skrbtgt%s' % (domain.upper(), partner.upper())).encode('utf-8')
+        salt_nb = ('%skrbtgt%s' % (domain.upper(), partner.split('.')[0].upper())).encode('utf-8')
     else:
-        salt = ('%skrbtgt%s' % (partner.upper(), domain.split('.')[0].upper())).encode('utf-8')
+        salt_fqdn = ('%skrbtgt%s' % (partner.upper(), domain.upper())).encode('utf-8')
+        salt_nb = ('%skrbtgt%s' % (partner.upper(), domain.split('.')[0].upper())).encode('utf-8')
     secret = rawSecret.decode('utf-16-le', 'replace').encode('utf-8', 'replace')
     out = []
     for etype in (int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value),
                   int(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value)):
-        key = string_to_key(etype, secret, salt, None)
-        out.append((_TRUST_KERBEROS_TYPE[etype], hexlify(key.contents).decode('utf-8')))
+        keyFqdn = string_to_key(etype, secret, salt_fqdn, None)
+        keyNb = string_to_key(etype, secret, salt_nb, None)
+        out.append((_TRUST_KERBEROS_TYPE[etype], hexlify(keyFqdn.contents).decode('utf-8')))
+        out.append((_TRUST_KERBEROS_TYPE[etype] + ' (trust account)', hexlify(keyNb.contents).decode('utf-8')))
     return out
 
 

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -2616,11 +2616,12 @@ TRUST_NAME_TO_ATTRTYP = {
 
 
 def _derive_trust_kerberos_keys(rawSecret, domain, partner, isIncoming):
-    # Inter-realm salt: {FROM}krbtgt{DEST} with the partner FQDN, upper-cased.
+    # Inter-realm salt: {REALM_FQDN}krbtgt{PARTNER_NETBIOS}. The component after 'krbtgt' is the
+    # trust TGT principal name (krbtgt/<flatName>), i.e. the NetBIOS/flat name, NOT the FQDN.
     if isIncoming:
-        salt = ('%skrbtgt%s' % (domain.upper(), partner.upper())).encode('utf-8')
+        salt = ('%skrbtgt%s' % (domain.upper(), partner.split('.')[0].upper())).encode('utf-8')
     else:
-        salt = ('%skrbtgt%s' % (partner.upper(), domain.upper())).encode('utf-8')
+        salt = ('%skrbtgt%s' % (partner.upper(), domain.split('.')[0].upper())).encode('utf-8')
     secret = rawSecret.decode('utf-16-le', 'replace').encode('utf-8', 'replace')
     out = []
     for etype in (int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value),

--- a/tests/SMB_RPC/test_secretsdump.py
+++ b/tests/SMB_RPC/test_secretsdump.py
@@ -276,7 +276,8 @@ class NTDSHashesUnitTests(unittest.TestCase):
                 self.returned = True
                 return self.record
 
-        for history, expected_lines in ((False, 3), (True, 6)):
+        # per trust value: rc4 + aes256 + aes256(trust account) + aes128 + aes128(trust account)
+        for history, expected_lines in ((False, 5), (True, 10)):
             with self.subTest(history=history):
                 esedb = FakeESEDB()
                 esedb.record = {


### PR DESCRIPTION
Hello @alexisbalbachan while playing with the TDO option I found a bug on the keberos key generation :)

## Problem
`_derive_trust_kerberos_keys` (`-trust-keys` / `-just-trust-keys`) salts trust AES keys with `{REALM_FQDN}krbtgt{PARTNER_FQDN}`. The KDC salts the inter-realm principal `krbtgt/<flatName>`, so the part after `krbtgt` must be the `NetBIOS/<flatName>`, not the FQDN.

**Impact:** the emitted AES128/256 are unusable `getTGT -aesKey` on the trust account fails with `KDC_ERR_PREAUTH_FAILED`. RC4 is unaffected (no salt).

## Evidence
Salt advertised by the KDC in `PA-ETYPE-INFO2` (trust where `RESEARCH.LOCAL` trusts `CORP.LOCAL`):

| account | KDC salt | current code |
|---|---|---|
| `CORP$` (trust) | `RESEARCH.LOCALkrbtgtCORP` | `RESEARCH.LOCALkrbtgtCORP.LOCAL` ❌ |
| `WS01$` (machine) | `RESEARCH.LOCALhostws01.research.local` | correct (`getMachineKerberosSalt`) ✅ |

## Fix
Use the first DNS label after `krbtgt`:
```python
salt = ('%skrbtgt%s' % (domain.upper(),  partner.split('.')[0].upper()))   # isIncoming
salt = ('%skrbtgt%s' % (partner.upper(), domain.split('.')[0].upper()))    # else
```
After the fix, the derived AES256 matches the DC's key and `getTGT` succeeds. This aligns the trust salt with `getMachineKerberosSalt` (salt = `REALM_FQDN` + the account's principal name).

## Before / After

```
$ secretsdump.py -k -no-pass -just-trust-keys -dc-ip <dc-ip> 'corp.local/<dcsync-user>@DC01.corp.local'
research.local (Outgoing):rc4_hmac:7b00c6071465456e4d31df876044a0d2
research.local (Outgoing):aes256-cts-hmac-sha1-96:45d7599053c8f71a788f4e6beb3051bab8d3f30401f5b269a3722acef7b8ea76
research.local (Outgoing):aes128-cts-hmac-sha1-96:cd2e64261b3cc517267d33276c4e74ee

$ getTGT.py 'research.local/CORP$' -aesKey 45d7599053c8f71a788f4e6beb3051bab8d3f30401f5b269a3722acef7b8ea76 -dc-ip <dc-ip>
[-] Kerberos SessionError: KDC_ERR_PREAUTH_FAILED(Pre-authentication information was invalid)
```

```
$ secretsdump.py -k -no-pass -just-trust-keys -dc-ip <dc-ip> 'corp.local/<dcsync-user>@DC01.corp.local'
research.local (Outgoing):rc4_hmac:7b00c6071465456e4d31df876044a0d2
research.local (Outgoing):aes256-cts-hmac-sha1-96:60ee348addbaa131d9354e5098689576277f634c1e36869a4968513f7ce6a72e
research.local (Outgoing):aes128-cts-hmac-sha1-96:4811709762300e5af16f92d94467f118

$ getTGT.py 'research.local/CORP$' -aesKey 60ee348addbaa131d9354e5098689576277f634c1e36869a4968513f7ce6a72e -dc-ip <dc-ip>
[*] Saving ticket in CORP$.ccache
```

Related PR:
- https://github.com/fortra/impacket/pull/2207
- https://github.com/fortra/impacket/pull/2278