### PR TITLE
feat(epm): add optional connection timeout to hept_map

### DIFF
--- a/impacket/dcerpc/v5/epm.py
+++ b/impacket/dcerpc/v5/epm.py
@@ -1250,11 +1250,13 @@ def hept_lookup(destHost, inquiry_type = RPC_C_EP_ALL_ELTS, objectUUID = NULL, i
 
     return entries
 
-def hept_map(destHost, remoteIf, dataRepresentation = uuidtup_to_bin(('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')), protocol = 'ncacn_np', dce=None):
+def hept_map(destHost, remoteIf, dataRepresentation = uuidtup_to_bin(('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')), protocol = 'ncacn_np', dce=None, timeout=None):
 
     if dce is None:
         stringBinding = r'ncacn_ip_tcp:%s[135]' % destHost
         rpctransport = transport.DCERPCTransportFactory(stringBinding)
+        if timeout is not None:
+            rpctransport.set_connect_timeout(timeout)
         dce = rpctransport.get_dce_rpc()
         dce.connect()
         disconnect = True


### PR DESCRIPTION
`hept_map()` has no way to bound how long it waits on the initial endpoint mapper lookup (TCP/135). It builds its own transport internally when no `dce` is passed in, and that transport falls back to the hardcoded 30 second default in `TCPTransport`, with no way for a caller to shorten or lengthen it.

This follows the same pattern as #2217 (LDAP) and #2253 (Kerberos/kpasswd): a timeout parameter that defaults to `None` (unchanged blocking behaviour) and gets applied to the underlying transport only when set.

Tested against an unreachable host: without `timeout`, the endpoint mapper lookup blocks for the default 30 seconds before raising. With `timeout=3`, it raises after roughly 3 seconds.

Regards
